### PR TITLE
Fix clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,15 @@ add_subdirectory(usrsctp EXCLUDE_FROM_ALL)
 
 # Set include directory and custom options to make usrsctp compile with recent g++
 target_include_directories(usrsctp-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/usrsctp/usrsctplib)
-target_compile_options(usrsctp-static PRIVATE -Wno-error=address-of-packed-member -Wno-error=format-truncation)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # using regular Clang or AppleClang: Needed since they don't have -Wno-error=format-truncation
+  target_compile_options(usrsctp-static PRIVATE -Wno-error=address-of-packed-member)
+else()
+  # all other compilers
+  target_compile_options(usrsctp-static PRIVATE -Wno-error=address-of-packed-member -Wno-error=format-truncation)
+endif()
+
 
 find_package(GnuTLS REQUIRED)
 find_package(LibNice REQUIRED)

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -22,6 +22,7 @@
 #include <cstddef>
 #include <memory>
 #include <optional>
+#include <string>
 #include <vector>
 
 namespace rtc {


### PR DESCRIPTION
- Fix the build for the clang compiler since it doesn't support `-Wno-error=format-truncation`.
- Added missing `#include <string>` that caused `implicit instantiation of undefined
      template`