### PR TITLE
Back-pressure

### DIFF
--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -54,25 +54,6 @@ protected:
 	virtual void triggerSent();
 
 private:
-	template <typename... P> class synchronized_callback {
-	public:
-		synchronized_callback &operator=(std::function<void(P...)> func) {
-			std::lock_guard<std::recursive_mutex> lock(mutex);
-			callback = func;
-			return *this;
-		}
-
-		void operator()(P... args) {
-			std::lock_guard<std::recursive_mutex> lock(mutex);
-			if (callback)
-				callback(args...);
-		}
-
-	private:
-		std::function<void(P...)> callback;
-		std::recursive_mutex mutex;
-	};
-
 	synchronized_callback<> mOpenCallback;
 	synchronized_callback<> mClosedCallback;
 	synchronized_callback<const string &> mErrorCallback;

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -22,6 +22,7 @@
 #include "include.hpp"
 
 #include <functional>
+#include <mutex>
 #include <variant>
 
 namespace rtc {
@@ -30,30 +31,36 @@ class Channel {
 public:
 	virtual void close(void) = 0;
 	virtual void send(const std::variant<binary, string> &data) = 0;
-
+	virtual std::optional<std::variant<binary, string>> receive() = 0;
 	virtual bool isOpen(void) const = 0;
 	virtual bool isClosed(void) const = 0;
 
 	void onOpen(std::function<void()> callback);
 	void onClosed(std::function<void()> callback);
 	void onError(std::function<void(const string &error)> callback);
+
 	void onMessage(std::function<void(const std::variant<binary, string> &data)> callback);
 	void onMessage(std::function<void(const binary &data)> binaryCallback,
 	               std::function<void(const string &data)> stringCallback);
+
+	void onAvailable(std::function<void()> callback);
 
 protected:
 	virtual void triggerOpen(void);
 	virtual void triggerClosed(void);
 	virtual void triggerError(const string &error);
-	virtual void triggerMessage(const std::variant<binary, string> &data);
+	virtual void triggerAvailable(size_t available);
 
 private:
 	std::function<void()> mOpenCallback;
 	std::function<void()> mClosedCallback;
 	std::function<void(const string &)> mErrorCallback;
 	std::function<void(const std::variant<binary, string> &)> mMessageCallback;
+	std::function<void()> mAvailableCallback;
+	std::recursive_mutex mCallbackMutex;
 };
 
 } // namespace rtc
 
 #endif // RTC_CHANNEL_H
+

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -44,12 +44,14 @@ public:
 	               std::function<void(const string &data)> stringCallback);
 
 	void onAvailable(std::function<void()> callback);
+	void onSent(std::function<void()> callback);
 
 protected:
 	virtual void triggerOpen(void);
 	virtual void triggerClosed(void);
 	virtual void triggerError(const string &error);
 	virtual void triggerAvailable(size_t available);
+	virtual void triggerSent();
 
 private:
 	std::function<void()> mOpenCallback;
@@ -57,7 +59,13 @@ private:
 	std::function<void(const string &)> mErrorCallback;
 	std::function<void(const std::variant<binary, string> &)> mMessageCallback;
 	std::function<void()> mAvailableCallback;
-	std::recursive_mutex mCallbackMutex;
+	std::function<void()> mSentCallback;
+	std::mutex mCallbackMutex;
+
+	template <typename T> T getCallback(const T &callback) {
+		std::lock_guard<std::mutex> lock(mCallbackMutex);
+		return callback;
+	}
 };
 
 } // namespace rtc

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -22,8 +22,10 @@
 #include "channel.hpp"
 #include "include.hpp"
 #include "message.hpp"
+#include "queue.hpp"
 #include "reliability.hpp"
 
+#include <atomic>
 #include <chrono>
 #include <functional>
 #include <variant>
@@ -42,6 +44,7 @@ public:
 	void close(void);
 	void send(const std::variant<binary, string> &data);
 	void send(const byte *data, size_t size);
+	std::optional<std::variant<binary, string>> receive();
 
 	unsigned int stream() const;
 	string label() const;
@@ -62,8 +65,10 @@ private:
 	string mProtocol;
 	std::shared_ptr<Reliability> mReliability;
 
-	bool mIsOpen = false;
-	bool mIsClosed = false;
+	std::atomic<bool> mIsOpen = false;
+	std::atomic<bool> mIsClosed = false;
+
+	Queue<message_ptr> mRecvQueue;
 
 	friend class PeerConnection;
 };

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -37,8 +37,10 @@ class PeerConnection;
 
 class DataChannel : public Channel {
 public:
-	DataChannel(unsigned int stream_, string label_, string protocol_, Reliability reliability_);
-	DataChannel(unsigned int stream, std::shared_ptr<SctpTransport> sctpTransport);
+	DataChannel(std::shared_ptr<PeerConnection> pc, unsigned int stream, string label,
+	            string protocol, Reliability reliability);
+	DataChannel(std::shared_ptr<PeerConnection> pc, std::shared_ptr<SctpTransport> transport,
+	            unsigned int stream);
 	~DataChannel();
 
 	void close(void);
@@ -62,8 +64,10 @@ private:
 	void incoming(message_ptr message);
 	void processOpenMessage(message_ptr message);
 
-	unsigned int mStream;
+	const std::shared_ptr<PeerConnection> mPeerConnection; // keeps the PeerConnection alive
 	std::shared_ptr<SctpTransport> mSctpTransport;
+
+	unsigned int mStream;
 	string mLabel;
 	string mProtocol;
 	std::shared_ptr<Reliability> mReliability;

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -46,6 +46,9 @@ public:
 	void send(const byte *data, size_t size);
 	std::optional<std::variant<binary, string>> receive();
 
+	size_t available() const;
+	size_t availableSize() const;
+
 	unsigned int stream() const;
 	string label() const;
 	string protocol() const;
@@ -69,6 +72,7 @@ private:
 	std::atomic<bool> mIsClosed = false;
 
 	Queue<message_ptr> mRecvQueue;
+	std::atomic<size_t> mRecvSize = 0;
 
 	friend class PeerConnection;
 };

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -54,6 +54,9 @@ template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;
 
 template <typename... P> class synchronized_callback {
 public:
+	synchronized_callback() = default;
+	~synchronized_callback() { *this = nullptr; }
+
 	synchronized_callback &operator=(std::function<void(P...)> func) {
 		std::lock_guard<std::recursive_mutex> lock(mutex);
 		callback = func;

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -60,15 +60,17 @@ public:
 		return *this;
 	}
 
-	void operator()(P... args) {
+	void operator()(P... args) const {
 		std::lock_guard<std::recursive_mutex> lock(mutex);
 		if (callback)
 			callback(args...);
 	}
 
+	operator bool() const { return callback ? true : false; }
+
 private:
 	std::function<void(P...)> callback;
-	std::recursive_mutex mutex;
+	mutable std::recursive_mutex mutex;
 };
 }
 

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -33,6 +33,7 @@ using binary = std::vector<byte>;
 
 using std::nullopt;
 
+using std::size_t;
 using std::uint16_t;
 using std::uint32_t;
 using std::uint64_t;
@@ -40,6 +41,9 @@ using std::uint8_t;
 
 const size_t MAX_NUMERICNODE_LEN = 48; // Max IPv6 string representation length
 const size_t MAX_NUMERICSERV_LEN = 6;  // Max port string representation length
+
+const size_t RECV_QUEUE_SIZE = 256; // DataChannel receive queue size in messages
+                                    // (0 means unlimited)
 
 const uint16_t DEFAULT_SCTP_PORT = 5000; // SCTP port to use by default
 

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -115,11 +115,11 @@ private:
 	std::atomic<State> mState;
 	std::atomic<GatheringState> mGatheringState;
 
-	std::function<void(std::shared_ptr<DataChannel> dataChannel)> mDataChannelCallback;
-	std::function<void(const Description &description)> mLocalDescriptionCallback;
-	std::function<void(const Candidate &candidate)> mLocalCandidateCallback;
-	std::function<void(State state)> mStateChangeCallback;
-	std::function<void(GatheringState state)> mGatheringStateChangeCallback;
+	synchronized_callback<std::shared_ptr<DataChannel>> mDataChannelCallback;
+	synchronized_callback<const Description &> mLocalDescriptionCallback;
+	synchronized_callback<const Candidate &> mLocalCandidateCallback;
+	synchronized_callback<State> mStateChangeCallback;
+	synchronized_callback<GatheringState> mGatheringStateChangeCallback;
 };
 
 } // namespace rtc

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -114,8 +114,6 @@ private:
 	std::atomic<State> mState;
 	std::atomic<GatheringState> mGatheringState;
 
-	std::list<std::thread> mResolveThreads;
-
 	std::function<void(std::shared_ptr<DataChannel> dataChannel)> mDataChannelCallback;
 	std::function<void(const Description &description)> mLocalDescriptionCallback;
 	std::function<void(const Candidate &candidate)> mLocalCandidateCallback;

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -89,6 +89,7 @@ private:
 
 	bool checkFingerprint(std::weak_ptr<PeerConnection> weak_this, const std::string &fingerprint) const;
 	void forwardMessage(std::weak_ptr<PeerConnection> weak_this, message_ptr message);
+	void forwardSent(std::weak_ptr<PeerConnection> weak_this, uint16_t stream);
 	void iterateDataChannels(std::function<void(std::shared_ptr<DataChannel> channel)> func);
 	void openDataChannels();
 	void closeDataChannels();

--- a/include/rtc/queue.hpp
+++ b/include/rtc/queue.hpp
@@ -32,32 +32,36 @@ namespace rtc {
 
 template <typename T> class Queue {
 public:
-	Queue();
+	Queue(std::size_t limit = 0);
 	~Queue();
 
 	void stop();
 	bool empty() const;
+	size_t size() const;
 	void push(const T &element);
 	std::optional<T> pop();
+	std::optional<T> tryPop();
 	void wait();
 	void wait(const std::chrono::milliseconds &duration);
 
 private:
+	const size_t mLimit;
 	std::queue<T> mQueue;
-	std::condition_variable mCondition;
-	std::atomic<bool> mStopping;
+	std::condition_variable mPopCondition, mPushCondition;
+	bool mStopping = false;
 
 	mutable std::mutex mMutex;
 };
 
-template <typename T> Queue<T>::Queue() : mStopping(false) {}
+template <typename T> Queue<T>::Queue(size_t limit) : mLimit(limit) {}
 
 template <typename T> Queue<T>::~Queue() { stop(); }
 
 template <typename T> void Queue<T>::stop() {
 	std::lock_guard<std::mutex> lock(mMutex);
 	mStopping = true;
-	mCondition.notify_all();
+	mPopCondition.notify_all();
+	mPushCondition.notify_all();
 }
 
 template <typename T> bool Queue<T>::empty() const {
@@ -65,37 +69,51 @@ template <typename T> bool Queue<T>::empty() const {
 	return mQueue.empty();
 }
 
-template <typename T> void Queue<T>::push(const T &element) {
+template <typename T> size_t Queue<T>::size() const {
 	std::lock_guard<std::mutex> lock(mMutex);
-	if (mStopping)
-		return;
-	mQueue.push(element);
-	mCondition.notify_one();
+	return mQueue.size();
+}
+
+template <typename T> void Queue<T>::push(const T &element) {
+	std::unique_lock<std::mutex> lock(mMutex);
+	mPushCondition.wait(lock, [this]() { return !mLimit || mQueue.size() < mLimit || mStopping; });
+	if (!mStopping) {
+		mQueue.push(element);
+		mPopCondition.notify_one();
+	}
 }
 
 template <typename T> std::optional<T> Queue<T>::pop() {
 	std::unique_lock<std::mutex> lock(mMutex);
-	while (mQueue.empty()) {
-		if (mStopping)
-			return nullopt;
-		mCondition.wait(lock);
+	mPopCondition.wait(lock, [this]() { return !mQueue.empty() || mStopping; });
+	if (!mQueue.empty()) {
+		std::optional<T> element(std::move(mQueue.front()));
+		mQueue.pop();
+		return element;
+	} else {
+		return nullopt;
 	}
+}
 
-	std::optional<T> element = mQueue.front();
-	mQueue.pop();
-	return element;
+template <typename T> std::optional<T> Queue<T>::tryPop() {
+	std::unique_lock<std::mutex> lock(mMutex);
+	if (!mQueue.empty()) {
+		std::optional<T> element(std::move(mQueue.front()));
+		mQueue.pop();
+		return element;
+	} else {
+		return nullopt;
+	}
 }
 
 template <typename T> void Queue<T>::wait() {
 	std::unique_lock<std::mutex> lock(mMutex);
-	if (mQueue.empty() && !mStopping)
-		mCondition.wait(lock);
+	mPopCondition.wait(lock, [this]() { return !mQueue.empty() || mStopping; });
 }
 
 template <typename T> void Queue<T>::wait(const std::chrono::milliseconds &duration) {
 	std::unique_lock<std::mutex> lock(mMutex);
-	if (mQueue.empty() && !mStopping)
-		mCondition.wait_for(lock, duration);
+	mPopCondition.wait_for(lock, duration, [this]() { return !mQueue.empty() || mStopping; });
 }
 
 } // namespace rtc

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -18,30 +18,34 @@
 
 #include "channel.hpp"
 
+namespace {}
+
 namespace rtc {
 
 void Channel::onOpen(std::function<void()> callback) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
 	mOpenCallback = callback;
 }
 
 void Channel::onClosed(std::function<void()> callback) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
 	mClosedCallback = callback;
 }
 
 void Channel::onError(std::function<void(const string &error)> callback) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
 	mErrorCallback = callback;
 }
 
 void Channel::onMessage(std::function<void(const std::variant<binary, string> &data)> callback) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
 	mMessageCallback = callback;
 
 	// Pass pending messages
 	while (auto message = receive()) {
-		mMessageCallback(*message);
+		// The callback might be changed from itself
+		if (auto callback = getCallback(mMessageCallback))
+			callback(*message);
 	}
 }
 
@@ -53,40 +57,48 @@ void Channel::onMessage(std::function<void(const binary &data)> binaryCallback,
 }
 
 void Channel::onAvailable(std::function<void()> callback) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
 	mAvailableCallback = callback;
 }
 
-void Channel::triggerOpen(void) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
-	if (mOpenCallback)
-		mOpenCallback();
+void Channel::onSent(std::function<void()> callback) {
+	std::lock_guard<std::mutex> lock(mCallbackMutex);
+	mSentCallback = callback;
 }
 
-void Channel::triggerClosed(void) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
-	if (mClosedCallback)
-		mClosedCallback();
+void Channel::triggerOpen() {
+	if (auto callback = getCallback(mOpenCallback))
+		callback();
+}
+
+void Channel::triggerClosed() {
+	if (auto callback = getCallback(mClosedCallback))
+		callback();
 }
 
 void Channel::triggerError(const string &error) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
-	if (mErrorCallback)
-		mErrorCallback(error);
+	if (auto callback = getCallback(mErrorCallback))
+		callback(error);
 }
 
 void Channel::triggerAvailable(size_t available) {
-	std::lock_guard<std::recursive_mutex> lock(mCallbackMutex);
-	if (mAvailableCallback && available == 1) {
-		mAvailableCallback();
+	if (available == 1) {
+		if (auto callback = getCallback(mAvailableCallback))
+			callback();
 	}
-	// The callback might be changed from itself
-	while (mMessageCallback && available--) {
+	while (available--) {
 		auto message = receive();
 		if (!message)
 			break;
-		mMessageCallback(*message);
+		// The callback might be changed from itself
+		if (auto callback = getCallback(mMessageCallback))
+			callback(*message);
 	}
+}
+
+void Channel::triggerSent() {
+	if (auto callback = getCallback(mSentCallback))
+		callback();
 }
 
 } // namespace rtc

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -67,7 +67,7 @@ void Channel::triggerAvailable(size_t available) {
 	if (available == 1)
 		mAvailableCallback();
 
-	while (available--) {
+	while (mMessageCallback && available--) {
 		auto message = receive();
 		if (!message)
 			break;

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -118,15 +118,21 @@ std::optional<std::variant<binary, string>> DataChannel::receive() {
 			break;
 		}
 		case Message::String:
+			mRecvSize -= message->size();
 			return std::make_optional(
 			    string(reinterpret_cast<const char *>(message->data()), message->size()));
 		case Message::Binary:
+			mRecvSize -= message->size();
 			return std::make_optional(std::move(*message));
 		}
 	}
 
 	return nullopt;
 }
+
+size_t DataChannel::available() const { return mRecvQueue.size(); }
+
+size_t DataChannel::availableSize() const { return mRecvSize; }
 
 unsigned int DataChannel::stream() const { return mStream; }
 
@@ -197,6 +203,7 @@ void DataChannel::incoming(message_ptr message) {
 	}
 	case Message::String:
 	case Message::Binary:
+		mRecvSize += message->size();
 		mRecvQueue.push(message);
 		triggerAvailable(mRecvQueue.size());
 		break;

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -57,14 +57,16 @@ struct CloseMessage {
 };
 #pragma pack(pop)
 
-DataChannel::DataChannel(unsigned int stream, string label, string protocol,
-                         Reliability reliability)
-    : mStream(stream), mLabel(std::move(label)), mProtocol(std::move(protocol)),
+DataChannel::DataChannel(shared_ptr<PeerConnection> pc, unsigned int stream, string label,
+                         string protocol, Reliability reliability)
+    : mPeerConnection(std::move(pc)), mStream(stream), mLabel(std::move(label)),
+      mProtocol(std::move(protocol)),
       mReliability(std::make_shared<Reliability>(std::move(reliability))),
       mRecvQueue(RECV_QUEUE_SIZE) {}
 
-DataChannel::DataChannel(unsigned int stream, shared_ptr<SctpTransport> sctpTransport)
-    : mStream(stream), mSctpTransport(sctpTransport),
+DataChannel::DataChannel(shared_ptr<PeerConnection> pc, shared_ptr<SctpTransport> transport,
+                         unsigned int stream)
+    : mPeerConnection(std::move(pc)), mSctpTransport(transport), mStream(stream),
       mReliability(std::make_shared<Reliability>()) {}
 
 DataChannel::~DataChannel() { close(); }

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -83,11 +83,13 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, shared_ptr<Certific
 }
 
 DtlsTransport::~DtlsTransport() {
-  onRecv(nullptr);
+	onRecv(nullptr); // unset recv callback
+
 	mIncomingQueue.stop();
-  mRecvThread.join();
-  gnutls_bye(mSession, GNUTLS_SHUT_RDWR);
-  gnutls_deinit(mSession);
+	mRecvThread.join();
+
+	gnutls_bye(mSession, GNUTLS_SHUT_RDWR);
+	gnutls_deinit(mSession);
 }
 
 DtlsTransport::State DtlsTransport::state() const { return mState; }

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -154,6 +154,10 @@ void DtlsTransport::runRecvLoop() {
 				ret = gnutls_record_recv(mSession, buffer, bufferSize);
 			} while (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN);
 
+			// Consider premature termination as remote closing
+			if (ret == GNUTLS_E_PREMATURE_TERMINATION)
+				break;
+
 			if (check_gnutls(ret)) {
 				if (ret == 0) {
 					// Closed

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -112,8 +112,8 @@ bool DtlsTransport::send(message_ptr message) {
 void DtlsTransport::incoming(message_ptr message) { mIncomingQueue.push(message); }
 
 void DtlsTransport::changeState(State state) {
-	mState = state;
-	mStateChangeCallback(state);
+	if (mState.exchange(state) != state)
+		mStateChangeCallback(state);
 }
 
 void DtlsTransport::runRecvLoop() {

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -226,8 +226,8 @@ void IceTransport::outgoing(message_ptr message) {
 }
 
 void IceTransport::changeState(State state) {
-	mState = state;
-	mStateChangeCallback(mState);
+	if (mState.exchange(state) != state)
+		mStateChangeCallback(mState);
 }
 
 void IceTransport::changeGatheringState(GatheringState state) {

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -132,8 +132,7 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 
 IceTransport::~IceTransport() {
 	g_main_loop_quit(mMainLoop.get());
-	if (mMainLoopThread.joinable())
-		mMainLoopThread.join();
+	mMainLoopThread.join();
 }
 
 Description::Role IceTransport::role() const { return mRole; }

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -28,7 +28,6 @@ namespace rtc {
 
 using namespace std::placeholders;
 
-using std::function;
 using std::shared_ptr;
 using std::weak_ptr;
 
@@ -358,41 +357,41 @@ void PeerConnection::processLocalDescription(Description description) {
 	mLocalDescription->setFingerprint(mCertificate->fingerprint());
 	mLocalDescription->setSctpPort(remoteSctpPort.value_or(DEFAULT_SCTP_PORT));
 
-	if (mLocalDescriptionCallback)
-		mLocalDescriptionCallback(*mLocalDescription);
+	mLocalDescriptionCallback(*mLocalDescription);
 }
 
 void PeerConnection::processLocalCandidate(weak_ptr<PeerConnection> weak_this, Candidate candidate) {
-  auto strong_this = weak_this.lock();
-  if (!strong_this) return;
+	auto strong_this = weak_this.lock();
+	if (!strong_this)
+		return;
 
 	if (!mLocalDescription)
 		throw std::logic_error("Got a local candidate without local description");
 
 	mLocalDescription->addCandidate(candidate);
 
-	if (mLocalCandidateCallback)
-		mLocalCandidateCallback(candidate);
+	mLocalCandidateCallback(candidate);
 }
 
 void PeerConnection::triggerDataChannel(weak_ptr<PeerConnection> weak_this, weak_ptr<DataChannel> weakDataChannel) {
-  auto strong_this = weak_this.lock();
-  if (!strong_this) return;
+	auto strong_this = weak_this.lock();
+	if (!strong_this)
+		return;
 
-  auto dataChannel = weakDataChannel.lock();
-  if (!dataChannel) return;
+	auto dataChannel = weakDataChannel.lock();
+	if (!dataChannel)
+		return;
 
-	if (mDataChannelCallback)
-		mDataChannelCallback(dataChannel);
+	mDataChannelCallback(dataChannel);
 }
 
 void PeerConnection::changeState(State state) {
-	if (mState.exchange(state) != state && mStateChangeCallback)
+	if (mState.exchange(state) != state)
 		mStateChangeCallback(state);
 }
 
 void PeerConnection::changeGatheringState(GatheringState state) {
-	if (mGatheringState.exchange(state) != state && mGatheringStateChangeCallback)
+	if (mGatheringState.exchange(state) != state)
 		mGatheringStateChangeCallback(state);
 }
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -363,14 +363,12 @@ void PeerConnection::triggerDataChannel(weak_ptr<PeerConnection> weak_this, weak
 }
 
 void PeerConnection::changeState(State state) {
-	mState = state;
-	if (mStateChangeCallback)
+	if (mState.exchange(state) != state && mStateChangeCallback)
 		mStateChangeCallback(state);
 }
 
 void PeerConnection::changeGatheringState(GatheringState state) {
-	mGatheringState = state;
-	if (mGatheringStateChangeCallback)
+	if (mGatheringState.exchange(state) != state && mGatheringStateChangeCallback)
 		mGatheringStateChangeCallback(state);
 }
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -127,7 +127,8 @@ shared_ptr<DataChannel> PeerConnection::createDataChannel(const string &label,
 			throw std::runtime_error("Too many DataChannels");
 	}
 
-	auto channel = std::make_shared<DataChannel>(stream, label, protocol, reliability);
+	auto channel =
+	    std::make_shared<DataChannel>(shared_from_this(), stream, label, protocol, reliability);
 	mDataChannels.insert(std::make_pair(stream, channel));
 
 	if (!mIceTransport) {
@@ -297,7 +298,8 @@ void PeerConnection::forwardMessage(weak_ptr<PeerConnection> weak_this, message_
 		unsigned int remoteParity = (mIceTransport->role() == Description::Role::Active) ? 1 : 0;
 		if (message->type == Message::Control && *message->data() == dataChannelOpenMessage &&
 		    message->stream % 2 == remoteParity) {
-			channel = std::make_shared<DataChannel>(message->stream, mSctpTransport);
+			channel =
+			    std::make_shared<DataChannel>(shared_from_this(), mSctpTransport, message->stream);
 			channel->onOpen(std::bind(&PeerConnection::triggerDataChannel, this, weak_this, weak_ptr<DataChannel>{channel}));
 			mDataChannels.insert(std::make_pair(message->stream, channel));
 		} else {

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -178,8 +178,8 @@ void SctpTransport::incoming(message_ptr message) {
 }
 
 void SctpTransport::changeState(State state) {
-	mState = state;
-	mStateChangeCallback(state);
+	if (mState.exchange(state) != state)
+		mStateChangeCallback(state);
 }
 
 void SctpTransport::runConnectAndSendLoop() {

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -312,8 +312,10 @@ int SctpTransport::handleWrite(void *data, size_t len, uint8_t tos, uint8_t set_
 
 int SctpTransport::process(struct socket *sock, union sctp_sockstore addr, void *data, size_t len,
                            struct sctp_rcvinfo info, int flags) {
-	if (!data)
+	if (!data) {
 		recv(nullptr);
+		return 0;
+	}
 	if (flags & MSG_NOTIFICATION) {
 		processNotification((union sctp_notification *)data, len);
 	} else {

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -116,7 +116,7 @@ SctpTransport::SctpTransport(std::shared_ptr<Transport> lower, uint16_t port, me
 	if (usrsctp_bind(mSock, reinterpret_cast<struct sockaddr *>(&sconn), sizeof(sconn)))
 		throw std::runtime_error("Could not bind usrsctp socket, errno=" + std::to_string(errno));
 
-	mConnectThread = std::thread(&SctpTransport::runConnect, this);
+	mConnectThread = std::thread(&SctpTransport::runConnectAndSendLoop, this);
 }
 
 SctpTransport::~SctpTransport() {
@@ -183,7 +183,7 @@ void SctpTransport::changeState(State state) {
 	mStateChangeCallback(state);
 }
 
-void SctpTransport::runConnect() {
+void SctpTransport::runConnectAndSendLoop() {
 	try {
 		changeState(State::Connecting);
 

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -218,9 +218,11 @@ void SctpTransport::runConnectAndSendLoop() {
 		}
 	} catch (const std::exception &e) {
 		std::cerr << "SCTP send: " << e.what() << std::endl;
-		mStopping = true;
-		return;
 	}
+
+	changeState(State::Disconnected);
+	mStopping = true;
+	mConnectCondition.notify_all();
 }
 
 bool SctpTransport::doSend(message_ptr message) {

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -62,7 +62,7 @@ private:
 
 	void incoming(message_ptr message);
 	void changeState(State state);
-	void runConnect();
+	void runConnectAndSendLoop();
 	bool doSend(message_ptr message);
 
 	int handleWrite(void *data, size_t len, uint8_t tos, uint8_t set_df);

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -73,8 +73,8 @@ private:
 	void processData(const byte *data, size_t len, uint16_t streamId, PayloadId ppid);
 	void processNotification(const union sctp_notification *notify, size_t len);
 
+	const uint16_t mPort;
 	struct socket *mSock;
-	uint16_t mPort;
 
 	Queue<message_ptr> mSendQueue;
 	std::thread mSendThread;

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -77,14 +77,13 @@ private:
 	uint16_t mPort;
 
 	Queue<message_ptr> mSendQueue;
-	std::thread mConnectThread;
+	std::thread mSendThread;
 	std::mutex mConnectMutex;
 	std::condition_variable mConnectCondition;
 	std::atomic<bool> mConnectDataSent = false;
 	std::atomic<bool> mStopping = false;
 
 	std::atomic<State> mState;
-
 	state_callback mStateChangeCallback;
 
 	static int WriteCallback(void *sctp_ptr, void *data, size_t len, uint8_t tos, uint8_t set_df);


### PR DESCRIPTION
This PR implements back-pressure on `DataChannel` via two new callbacks `onAvailable` and `onSent`. It also solves thread synchronization issues with `Channel` callbacks and a potential issue with `PeerConnection` blocking for a few seconds on destruction.

Back-pressure for reading does not exist on the web API, and back-pressure for writing is implemented in a rather counter-intuitive (not to say broken) way with `onbufferedamountlow`, therefore this PR introduces new optional callbacks rather than trying to imitate the web API.