### PR TITLE
Large messages support

### DIFF
--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -30,13 +30,14 @@ namespace rtc {
 class Channel {
 public:
 	virtual void close() = 0;
-	virtual bool send(const std::variant<binary, string> &data) = 0;
-	virtual std::optional<std::variant<binary, string>> receive() = 0;
+	virtual bool send(const std::variant<binary, string> &data) = 0; // returns false if buffered
+	virtual std::optional<std::variant<binary, string>> receive() = 0; // only if onMessage unset
+
 	virtual bool isOpen() const = 0;
 	virtual bool isClosed() const = 0;
-	virtual size_t availableAmount() const { return 0; }
 
-	size_t bufferedAmount() const;
+	virtual size_t availableAmount() const; // total size available to receive
+	virtual size_t bufferedAmount() const; // total size buffered to send
 
 	void onOpen(std::function<void()> callback);
 	void onClosed(std::function<void()> callback);

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -21,8 +21,8 @@
 
 #include "include.hpp"
 
+#include <atomic>
 #include <functional>
-#include <mutex>
 #include <variant>
 
 namespace rtc {
@@ -30,7 +30,7 @@ namespace rtc {
 class Channel {
 public:
 	virtual void close() = 0;
-	virtual void send(const std::variant<binary, string> &data) = 0;
+	virtual bool send(const std::variant<binary, string> &data) = 0;
 	virtual std::optional<std::variant<binary, string>> receive() = 0;
 	virtual bool isOpen() const = 0;
 	virtual bool isClosed() const = 0;
@@ -66,8 +66,8 @@ private:
 	synchronized_callback<> mAvailableCallback;
 	synchronized_callback<> mBufferedAmountLowCallback;
 
-	size_t mBufferedAmount = 0;
-	size_t mBufferedAmountLowThreshold = 0;
+	std::atomic<size_t> mBufferedAmount = 0;
+	std::atomic<size_t> mBufferedAmountLowThreshold = 0;
 };
 
 } // namespace rtc

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -44,19 +44,21 @@ public:
 	            unsigned int stream);
 	~DataChannel();
 
-	void close(void);
-	bool send(const std::variant<binary, string> &data);
-	bool send(const byte *data, size_t size);
-	std::optional<std::variant<binary, string>> receive();
+	void close(void) override;
 
-	// Directly send a buffer to avoid a copy
+	bool send(const std::variant<binary, string> &data) override;
+	bool send(const byte *data, size_t size);
+
 	template <typename Buffer> bool sendBuffer(const Buffer &buf);
 	template <typename Iterator> bool sendBuffer(Iterator first, Iterator last);
 
-	bool isOpen(void) const;
-	bool isClosed(void) const;
-	size_t availableAmount() const;
-	size_t maxMessageSize() const;
+	std::optional<std::variant<binary, string>> receive() override;
+
+	bool isOpen(void) const override;
+	bool isClosed(void) const override;
+	size_t availableAmount() const override;
+
+	size_t maxMessageSize() const;  // maximum message size in a call to send or sendBuffer
 
 	unsigned int stream() const;
 	string label() const;

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -56,6 +56,7 @@ public:
 	bool isOpen(void) const;
 	bool isClosed(void) const;
 	size_t availableAmount() const;
+	size_t maxMessageSize() const;
 
 	unsigned int stream() const;
 	string label() const;
@@ -68,7 +69,7 @@ private:
 	void incoming(message_ptr message);
 	void processOpenMessage(message_ptr message);
 
-	const std::shared_ptr<PeerConnection> mPeerConnection; // keeps the PeerConnection alive
+	const std::shared_ptr<PeerConnection> mPeerConnection;
 	std::shared_ptr<SctpTransport> mSctpTransport;
 
 	unsigned int mStream;

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -44,9 +44,11 @@ public:
 	string mid() const;
 	std::optional<string> fingerprint() const;
 	std::optional<uint16_t> sctpPort() const;
+	std::optional<size_t> maxMessageSize() const;
 
 	void setFingerprint(string fingerprint);
 	void setSctpPort(uint16_t port);
+	void setMaxMessageSize(size_t size);
 
 	void addCandidate(Candidate candidate);
 	void endCandidates();
@@ -62,6 +64,7 @@ private:
 	string mIceUfrag, mIcePwd;
 	std::optional<string> mFingerprint;
 	std::optional<uint16_t> mSctpPort;
+	std::optional<size_t> mMaxMessageSize;
 	std::vector<Candidate> mCandidates;
 	bool mTrickle;
 

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -43,7 +43,10 @@ using std::uint8_t;
 
 const size_t MAX_NUMERICNODE_LEN = 48; // Max IPv6 string representation length
 const size_t MAX_NUMERICSERV_LEN = 6;  // Max port string representation length
+
 const uint16_t DEFAULT_SCTP_PORT = 5000; // SCTP port to use by default
+const size_t DEFAULT_MAX_MESSAGE_SIZE = 65536;    // Remote max message size if not specified in SDP
+const size_t LOCAL_MAX_MESSAGE_SIZE = 256 * 1024; // Local max message size
 
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;

--- a/include/rtc/message.hpp
+++ b/include/rtc/message.hpp
@@ -44,6 +44,7 @@ struct Message : binary {
 using message_ptr = std::shared_ptr<const Message>;
 using mutable_message_ptr = std::shared_ptr<Message>;
 using message_callback = std::function<void(message_ptr message)>;
+
 constexpr auto message_size_func = [](const message_ptr &m) -> size_t {
 	return m->type != Message::Control ? m->size() : 0;
 };

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -57,6 +57,8 @@ void Channel::onBufferedAmountLow(std::function<void()> callback) {
 	mBufferedAmountLowCallback = callback;
 }
 
+size_t Channel::availableAmount() const { return 0; }
+
 size_t Channel::bufferedAmount() const { return mBufferedAmount; }
 
 void Channel::setBufferedAmountLowThreshold(size_t amount) { mBufferedAmountLowThreshold = amount; }

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -80,10 +80,9 @@ void Channel::triggerAvailable(size_t count) {
 }
 
 void Channel::triggerBufferedAmount(size_t amount) {
-	bool lowThresholdCrossed =
-	    mBufferedAmount > mBufferedAmountLowThreshold && amount <= mBufferedAmountLowThreshold;
-	mBufferedAmount = amount;
-	if (lowThresholdCrossed)
+	size_t previous = mBufferedAmount.exchange(amount);
+	size_t threshold = mBufferedAmountLowThreshold.load();
+	if (previous > threshold && amount <= threshold)
 		mBufferedAmountLowCallback();
 }
 

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -98,8 +98,8 @@ void DataChannel::send(const byte *data, size_t size) {
 }
 
 std::optional<std::variant<binary, string>> DataChannel::receive() {
-	while (auto opt = mRecvQueue.tryPop()) {
-		auto message = *opt;
+	while (!mRecvQueue.empty()) {
+		auto message = *mRecvQueue.pop();
 		switch (message->type) {
 		case Message::Control: {
 			auto raw = reinterpret_cast<const uint8_t *>(message->data());

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -81,6 +81,8 @@ Description::Description(const string &sdp, Type type, Role role)
 			mIcePwd = line.substr(line.find(':') + 1);
 		} else if (hasprefix(line, "a=sctp-port")) {
 			mSctpPort = uint16_t(std::stoul(line.substr(line.find(':') + 1)));
+		} else if (hasprefix(line, "a=max-message-size")) {
+			mMaxMessageSize = size_t(std::stoul(line.substr(line.find(':') + 1)));
 		} else if (hasprefix(line, "a=candidate")) {
 			addCandidate(Candidate(line.substr(2), mMid));
 		} else if (hasprefix(line, "a=end-of-candidates")) {
@@ -103,11 +105,15 @@ std::optional<string> Description::fingerprint() const { return mFingerprint; }
 
 std::optional<uint16_t> Description::sctpPort() const { return mSctpPort; }
 
+std::optional<size_t> Description::maxMessageSize() const { return mMaxMessageSize; }
+
 void Description::setFingerprint(string fingerprint) {
 	mFingerprint.emplace(std::move(fingerprint));
 }
 
 void Description::setSctpPort(uint16_t port) { mSctpPort.emplace(port); }
+
+void Description::setMaxMessageSize(size_t size) { mMaxMessageSize.emplace(size); }
 
 void Description::addCandidate(Candidate candidate) {
 	mCandidates.emplace_back(std::move(candidate));
@@ -145,7 +151,8 @@ Description::operator string() const {
 		sdp << "a=fingerprint:sha-256 " << *mFingerprint << "\n";
 	if (mSctpPort)
 		sdp << "a=sctp-port:" << *mSctpPort << "\n";
-
+	if (mMaxMessageSize)
+		sdp << "a=max-message-size:" << *mMaxMessageSize << "\n";
 	for (const auto &candidate : mCandidates) {
 		sdp << string(candidate) << "\n";
 	}

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -85,10 +85,10 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, shared_ptr<Certific
 }
 
 DtlsTransport::~DtlsTransport() {
-	onRecv(nullptr); // unset recv callback
-
 	mIncomingQueue.stop();
-	mRecvThread.join();
+
+	if (mRecvThread.joinable())
+		mRecvThread.join();
 
 	gnutls_bye(mSession, GNUTLS_SHUT_RDWR);
 	gnutls_deinit(mSession);

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -356,8 +356,6 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, shared_ptr<Certific
 }
 
 DtlsTransport::~DtlsTransport() {
-	onRecv(nullptr); // unset recv callback
-
 	mIncomingQueue.stop();
 
 	if (mRecvThread.joinable())

--- a/src/dtlstransport.hpp
+++ b/src/dtlstransport.hpp
@@ -54,7 +54,7 @@ public:
 
 	State state() const;
 
-	bool send(message_ptr message);
+	bool send(message_ptr message); // false if dropped
 
 private:
 	void incoming(message_ptr message);

--- a/src/icetransport.hpp
+++ b/src/icetransport.hpp
@@ -67,7 +67,7 @@ public:
 	std::optional<string> getLocalAddress() const;
 	std::optional<string> getRemoteAddress() const;
 
-	bool send(message_ptr message);
+	bool send(message_ptr message); // false if dropped
 
 private:
 	void incoming(message_ptr message);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -359,6 +359,7 @@ void PeerConnection::processLocalDescription(Description description) {
 	mLocalDescription.emplace(std::move(description));
 	mLocalDescription->setFingerprint(mCertificate->fingerprint());
 	mLocalDescription->setSctpPort(remoteSctpPort.value_or(DEFAULT_SCTP_PORT));
+	mLocalDescription->setMaxMessageSize(LOCAL_MAX_MESSAGE_SIZE);
 
 	mLocalDescriptionCallback(*mLocalDescription);
 }

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -54,10 +54,14 @@ public:
 	void reset(unsigned int stream);
 
 private:
+	// Order seems wrong but these are the actual values
+	// See https://tools.ietf.org/html/draft-ietf-rtcweb-data-channel-13#section-8
 	enum PayloadId : uint32_t {
 		PPID_CONTROL = 50,
 		PPID_STRING = 51,
+		PPID_BINARY_PARTIAL = 52,
 		PPID_BINARY = 53,
+		PPID_STRING_PARTIAL = 54,
 		PPID_STRING_EMPTY = 56,
 		PPID_BINARY_EMPTY = 57
 	};
@@ -94,6 +98,8 @@ private:
 
 	state_callback mStateChangeCallback;
 	std::atomic<State> mState;
+
+	binary mPartialStringData, mPartialBinaryData;
 
 	static int RecvCallback(struct socket *sock, union sctp_sockstore addr, void *data, size_t len,
 	                        struct sctp_rcvinfo recv_info, int flags, void *user_data);

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -73,10 +73,10 @@ private:
 	bool trySend(message_ptr message);
 	void updateBufferedAmount(uint16_t streamId, long delta);
 
-	int handleRecv(struct socket *sock, union sctp_sockstore addr, void *data, size_t len,
+	int handleRecv(struct socket *sock, union sctp_sockstore addr, const byte *data, size_t len,
 	               struct sctp_rcvinfo recv_info, int flags);
 	int handleSend(size_t free);
-	int handleWrite(void *data, size_t len, uint8_t tos, uint8_t set_df);
+	int handleWrite(byte *data, size_t len, uint8_t tos, uint8_t set_df);
 
 	void processData(const byte *data, size_t len, uint16_t streamId, PayloadId ppid);
 	void processNotification(const union sctp_notification *notify, size_t len);
@@ -99,7 +99,7 @@ private:
 	state_callback mStateChangeCallback;
 	std::atomic<State> mState;
 
-	binary mPartialStringData, mPartialBinaryData;
+	binary mPartialRecv, mPartialStringData, mPartialBinaryData;
 
 	static int RecvCallback(struct socket *sock, union sctp_sockstore addr, void *data, size_t len,
 	                        struct sctp_rcvinfo recv_info, int flags, void *user_data);

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -69,8 +69,9 @@ private:
 	void connect();
 	void incoming(message_ptr message);
 	void changeState(State state);
-	bool trySendAll();
-	bool trySend(message_ptr message);
+
+	bool trySendQueue();
+	bool trySendMessage(message_ptr message);
 	void updateBufferedAmount(uint16_t streamId, long delta);
 
 	int handleRecv(struct socket *sock, union sctp_sockstore addr, const byte *data, size_t len,
@@ -86,8 +87,6 @@ private:
 
 	std::mutex mSendMutex;
 	Queue<message_ptr> mSendQueue;
-
-	std::mutex mBufferedAmountMutex;
 	std::map<uint16_t, size_t> mBufferedAmount;
 	amount_callback mBufferedAmountCallback;
 

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -50,7 +50,7 @@ public:
 
 	State state() const;
 
-	bool send(message_ptr message);
+	bool send(message_ptr message); // false if buffered
 	void reset(unsigned int stream);
 
 private:


### PR DESCRIPTION
- Implemented max message size negociation and `maxMessageSize` getter on `DataChannel`
- Added proper handling of SCTP EOR flag at reception if the sender uses chunked messages
- Added support of deprecated String Partial and Binary Partial PPIDs
- SCTP socket is now non-blocking, removing the need for the sender thread, and working around the issue with `usrsctp_close()` waiting for `usrsctp_connect()`, see https://github.com/sctplab/usrsctp/issues/24.
