### PR TITLE
Fix late candidates triggering DTLS init twice

### DIFF
--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -91,6 +91,7 @@ private:
 	std::shared_ptr<DtlsTransport> initDtlsTransport();
 	std::shared_ptr<SctpTransport> initSctpTransport();
 
+	void endLocalCandidates();
 	bool checkFingerprint(const std::string &fingerprint) const;
 	void forwardMessage(message_ptr message);
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
@@ -114,6 +115,7 @@ private:
 	std::shared_ptr<IceTransport> mIceTransport;
 	std::shared_ptr<DtlsTransport> mDtlsTransport;
 	std::shared_ptr<SctpTransport> mSctpTransport;
+	std::recursive_mutex mInitMutex;
 
 	std::unordered_map<unsigned int, std::weak_ptr<DataChannel>> mDataChannels;
 

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -87,7 +87,6 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, shared_ptr<Certific
 DtlsTransport::~DtlsTransport() {
 	stop();
 
-	gnutls_bye(mSession, GNUTLS_SHUT_RDWR);
 	gnutls_deinit(mSession);
 }
 
@@ -98,6 +97,7 @@ void DtlsTransport::stop() {
 
 	if (mRecvThread.joinable()) {
 		mIncomingQueue.stop();
+		gnutls_bye(mSession, GNUTLS_SHUT_RDWR);
 		mRecvThread.join();
 	}
 }

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -95,6 +95,8 @@ private:
 	std::condition_variable mConnectCondition;
 	bool mConnectDataSent = false;
 
+	std::atomic<bool> mShutdown = false;
+
 	state_callback mStateChangeCallback;
 	std::atomic<State> mState;
 


### PR DESCRIPTION
If the ICE connection happens too fast, late candidates could reset the ICE transport state, triggering the DTLS transport initialization a second time, in which case the first would be destroyed and incorrectly report a failure of the peer connection.