### PR TITLE
Libjuice as alternative to Libnice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "deps/plog"]
 	path = deps/plog
 	url = https://github.com/SergiusTheBest/plog
+[submodule "deps/libjuice"]
+	path = deps/libjuice
+	url = https://github.com/paullouisageneau/libjuice

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required (VERSION 3.7)
 project (libdatachannel
 	DESCRIPTION "WebRTC Data Channels Library"
-	VERSION 0.2.1
+	VERSION 0.3.2
 	LANGUAGES CXX)
+
+option(USE_GNUTLS "Use GnuTLS instead of OpenSSL" OFF)
+option(USE_JUICE "Use libjuice instead of libnice" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
@@ -33,6 +36,7 @@ set(TESTS_ANSWERER_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/p2p/answerer.cpp
 )
 
+
 # Hack because usrsctp uses CMAKE_SOURCE_DIR instead of CMAKE_CURRENT_SOURCE_DIR
 set(CMAKE_REQUIRED_FLAGS "-I${CMAKE_CURRENT_SOURCE_DIR}/deps/usrsctp/usrsctplib")
 
@@ -58,9 +62,8 @@ else()
   endif()
 endif()
 
-option(USE_GNUTLS "Use GnuTLS instead of OpenSSL" OFF)
-
-find_package(LibNice REQUIRED)
+add_library(Usrsctp::Usrsctp ALIAS usrsctp)
+add_library(Usrsctp::UsrsctpStatic ALIAS usrsctp-static)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
@@ -74,10 +77,9 @@ target_include_directories(datachannel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/includ
 target_include_directories(datachannel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/rtc)
 target_include_directories(datachannel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(datachannel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/deps/plog/include)
-target_link_libraries(datachannel 
+target_link_libraries(datachannel
 						Threads::Threads
-						usrsctp-static 
-						LibNice::LibNice						
+						usrsctp-static
 						)
 
 add_library(datachannel-static STATIC EXCLUDE_FROM_ALL ${LIBDATACHANNEL_SOURCES})
@@ -91,8 +93,7 @@ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR
 target_include_directories(datachannel-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/deps/plog/include)
 target_link_libraries(datachannel-static
 						Threads::Threads
-						usrsctp-static 
-						LibNice::LibNice						
+						usrsctp-static
 						)
 
 if (USE_GNUTLS)
@@ -117,29 +118,44 @@ else()
 	target_link_libraries(datachannel-static OpenSSL::SSL)
 endif()
 
+if (USE_JUICE)
+	add_subdirectory(deps/libjuice EXCLUDE_FROM_ALL)
+	target_compile_definitions(datachannel PRIVATE USE_JUICE=1)
+	target_link_libraries(datachannel LibJuice::LibJuiceStatic)
+	target_compile_definitions(datachannel-static PRIVATE USE_JUICE=1)
+	target_link_libraries(datachannel-static LibJuice::LibJuiceStatic)
+else()
+	find_package(LibNice REQUIRED)
+	target_compile_definitions(datachannel PRIVATE USE_JUICE=0)
+	target_link_libraries(datachannel LibNice::LibNice)
+	target_compile_definitions(datachannel-static PRIVATE USE_JUICE=0)
+	target_link_libraries(datachannel-static LibNice::LibNice)
+endif()
+
 add_library(LibDataChannel::LibDataChannel ALIAS datachannel)
 add_library(LibDataChannel::LibDataChannelStatic ALIAS datachannel-static)
 
 # Main Test
-add_executable(tests ${TESTS_SOURCES})
-set_target_properties(tests PROPERTIES
+add_executable(libdatachannel-tests ${TESTS_SOURCES})
+set_target_properties(libdatachannel-tests PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-
-target_link_libraries(tests datachannel)
+set_target_properties(libdatachannel-tests PROPERTIES OUTPUT_NAME tests)
+target_link_libraries(libdatachannel-tests datachannel)
 
 # P2P Test: offerer
-add_executable(offerer ${TESTS_OFFERER_SOURCES})
-set_target_properties(offerer PROPERTIES
+add_executable(libdatachannel-offerer ${TESTS_OFFERER_SOURCES})
+set_target_properties(libdatachannel-offerer PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-
-target_link_libraries(offerer datachannel)
+set_target_properties(libdatachannel-offerer PROPERTIES OUTPUT_NAME offerer)
+target_link_libraries(libdatachannel-offerer datachannel)
 
 # P2P Test: answerer
-add_executable(answerer ${TESTS_ANSWERER_SOURCES})
-set_target_properties(answerer PROPERTIES
+add_executable(libdatachannel-answerer ${TESTS_ANSWERER_SOURCES})
+set_target_properties(libdatachannel-answerer PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
+set_target_properties(libdatachannel-answerer PROPERTIES OUTPUT_NAME datachannel)
+target_link_libraries(libdatachannel-answerer datachannel)
 
-target_link_libraries(answerer datachannel)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,7 @@ target_include_directories(datachannel PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_include_directories(datachannel PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/deps/plog/include)
 target_link_libraries(datachannel
 						Threads::Threads
-						usrsctp-static
+						Usrsctp::UsrsctpStatic
 						)
 
 add_library(datachannel-static STATIC EXCLUDE_FROM_ALL ${LIBDATACHANNEL_SOURCES})
@@ -93,7 +93,7 @@ target_include_directories(datachannel-static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR
 target_include_directories(datachannel-static PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/deps/plog/include)
 target_link_libraries(datachannel-static
 						Threads::Threads
-						usrsctp-static
+						Usrsctp::UsrsctpStatic
 						)
 
 if (USE_GNUTLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,26 +136,27 @@ add_library(LibDataChannel::LibDataChannel ALIAS datachannel)
 add_library(LibDataChannel::LibDataChannelStatic ALIAS datachannel-static)
 
 # Main Test
-add_executable(libdatachannel-tests ${TESTS_SOURCES})
-set_target_properties(libdatachannel-tests PROPERTIES
+add_executable(datachannel-tests ${TESTS_SOURCES})
+set_target_properties(datachannel-tests PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-set_target_properties(libdatachannel-tests PROPERTIES OUTPUT_NAME tests)
-target_link_libraries(libdatachannel-tests datachannel)
+set_target_properties(datachannel-tests PROPERTIES OUTPUT_NAME tests)
+target_include_directories(datachannel-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_link_libraries(datachannel-tests datachannel)
 
 # P2P Test: offerer
-add_executable(libdatachannel-offerer ${TESTS_OFFERER_SOURCES})
-set_target_properties(libdatachannel-offerer PROPERTIES
+add_executable(datachannel-offerer ${TESTS_OFFERER_SOURCES})
+set_target_properties(datachannel-offerer PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-set_target_properties(libdatachannel-offerer PROPERTIES OUTPUT_NAME offerer)
-target_link_libraries(libdatachannel-offerer datachannel)
+set_target_properties(datachannel-offerer PROPERTIES OUTPUT_NAME offerer)
+target_link_libraries(datachannel-offerer datachannel)
 
 # P2P Test: answerer
-add_executable(libdatachannel-answerer ${TESTS_ANSWERER_SOURCES})
-set_target_properties(libdatachannel-answerer PROPERTIES
+add_executable(datachannel-answerer ${TESTS_ANSWERER_SOURCES})
+set_target_properties(datachannel-answerer PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-set_target_properties(libdatachannel-answerer PROPERTIES OUTPUT_NAME datachannel)
-target_link_libraries(libdatachannel-answerer datachannel)
+set_target_properties(datachannel-answerer PROPERTIES OUTPUT_NAME datachannel)
+target_link_libraries(datachannel-answerer datachannel)
 

--- a/Jamfile
+++ b/Jamfile
@@ -7,15 +7,17 @@ lib libdatachannel
 	: # requirements
 	<include>./include/rtc
 	<define>USE_GNUTLS=0
-	<cxxflags>"`pkg-config --cflags openssl glib-2.0 gobject-2.0 nice`"
+	<define>USE_JUICE=1
+	<cxxflags>"`pkg-config --cflags openssl`"
 	<library>/libdatachannel//usrsctp
+	<library>/libdatachannel//juice
 	: # default build
 	<link>static
 	: # usage requirements
 	<include>./include
 	<library>/libdatachannel//plog
 	<cxxflags>-pthread
-	<linkflags>"`pkg-config --libs openssl glib-2.0 gobject-2.0 nice`"
+	<linkflags>"`pkg-config --libs openssl`"
 	;
 
 alias plog
@@ -35,6 +37,15 @@ alias usrsctp
 	<library>libusrsctp.a
     ;
 
+alias juice
+    : # no sources
+    : # no build requirements
+    : # no default build
+    : # usage requirements
+    <include>./deps/libjuice/include
+	<library>libjuice.a
+    ;
+
 make libusrsctp.a : : @make_libusrsctp ;
 actions make_libusrsctp
 {
@@ -43,5 +54,12 @@ actions make_libusrsctp
 		./configure --enable-static --disable-debug CFLAGS="-fPIC -Wno-address-of-packed-member" && \
 		make)
     cp $(CWD)/deps/usrsctp/usrsctplib/.libs/libusrsctp.a $(<)
+}
+
+make libjuice.a : : @make_libjuice ;
+actions make_libjuice
+{
+	(cd $(CWD)/deps/libjuice && make)
+    cp $(CWD)/deps/libjuice/libjuice.a $(<)
 }
 

--- a/Makefile
+++ b/Makefile
@@ -7,21 +7,37 @@ RM=rm -f
 CPPFLAGS=-O2 -pthread -fPIC -Wall -Wno-address-of-packed-member
 CXXFLAGS=-std=c++17
 LDFLAGS=-pthread
-LIBS=glib-2.0 gobject-2.0 nice
+LIBS=
+LOCALLIBS=libusrsctp.a
 USRSCTP_DIR=deps/usrsctp
+JUICE_DIR=deps/libjuice
 PLOG_DIR=deps/plog
+
+INCLUDES=-Iinclude/rtc -I$(PLOG_DIR)/include -I$(USRSCTP_DIR)/usrsctplib
+LDLIBS=
 
 USE_GNUTLS ?= 0
 ifneq ($(USE_GNUTLS), 0)
-        CPPFLAGS+= -DUSE_GNUTLS=1
-        LIBS+= gnutls
+        CPPFLAGS+=-DUSE_GNUTLS=1
+        LIBS+=gnutls
 else
-        CPPFLAGS+= -DUSE_GNUTLS=0
-        LIBS+= openssl
+        CPPFLAGS+=-DUSE_GNUTLS=0
+        LIBS+=openssl
 endif
 
-LDLIBS= $(shell pkg-config --libs $(LIBS))
-INCLUDES=-Iinclude/rtc -I$(PLOG_DIR)/include -I$(USRSCTP_DIR)/usrsctplib $(shell pkg-config --cflags $(LIBS))
+USE_JUICE ?= 0
+ifneq ($(USE_JUICE), 0)
+        CPPFLAGS+=-DUSE_JUICE=1
+        INCLUDES+=-I$(JUICE_DIR)/include
+        LOCALLIBS+=libjuice.a
+        LIBS+=nettle
+else
+        CPPFLAGS+=-DUSE_JUICE=0
+        LIBS+=glib-2.0 gobject-2.0 nice
+endif
+
+INCLUDES+=$(shell pkg-config --cflags $(LIBS))
+LDLIBS+=$(LOCALLIBS) $(shell pkg-config --libs $(LIBS))
 
 SRCS=$(shell printf "%s " src/*.cpp)
 OBJS=$(subst .cpp,.o,$(SRCS))
@@ -39,11 +55,11 @@ test/%.o: test/%.cpp
 $(NAME).a: $(OBJS)
 	$(AR) crf $@ $(OBJS)
 
-$(NAME).so: libusrsctp.a $(OBJS)
-	$(CXX) $(LDFLAGS) -shared -o $@ $(OBJS) $(LDLIBS) libusrsctp.a
+$(NAME).so: $(LOCALLIBS) $(OBJS)
+	$(CXX) $(LDFLAGS) -shared -o $@ $(OBJS) $(LDLIBS)
 
 tests: $(NAME).a test/main.o
-	$(CXX) $(LDFLAGS) -o $@ test/main.o $(LDLIBS) $(NAME).a libusrsctp.a
+	$(CXX) $(LDFLAGS) -o $@ test/main.o $(NAME).a $(LDLIBS)
 
 clean:
 	-$(RM) include/rtc/*.d *.d
@@ -66,4 +82,8 @@ libusrsctp.a:
 		./configure --enable-static --disable-debug CFLAGS="$(CPPFLAGS)" && \
 		make
 	cp $(USRSCTP_DIR)/usrsctplib/.libs/libusrsctp.a .
+
+libjuice.a:
+	cd $(JUICE_DIR) && make
+	cp $(JUICE_DIR)/libjuice.a .
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ src/%.o: src/%.cpp
 	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) -MMD -MP -o $@ -c $<
 
 test/%.o: test/%.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) -Iinclude -I$(PLOG_DIR)/include -MMD -MP -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) -MMD -MP -o $@ -c $<
 
 -include $(subst .cpp,.d,$(SRCS))
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ The library aims at fully implementing WebRTC SCTP DataChannels ([draft-ietf-rtc
 
 ## Dependencies
 
-- libnice: https://github.com/libnice/libnice
 - GnuTLS: https://www.gnutls.org/ or OpenSSL: https://www.openssl.org/
+
+Optional:
+- libnice: https://github.com/libnice/libnice (substituable with libjuice)
 
 Submodules:
 - usrsctp: https://github.com/sctplab/usrsctp
+- libjuice: https://github.com/paullouisageneau/libjuice
 
 ## Building
 
@@ -24,7 +27,7 @@ Submodules:
 $ git submodule update --init --recursive
 $ mkdir build
 $ cd build
-$ cmake -DUSE_GNUTLS=1 ..
+$ cmake -DUSE_JUICE=1 -DUSE_GNUTLS=1 ..
 $ make
 ```
 

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -57,6 +57,8 @@ public:
 
 	operator string() const;
 
+	string generateSdp(const string &eol) const;
+
 private:
 	Type mType;
 	Role mRole;

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -44,6 +44,8 @@ using std::uint32_t;
 using std::uint64_t;
 using std::uint8_t;
 
+// Constants
+
 const size_t MAX_NUMERICNODE_LEN = 48; // Max IPv6 string representation length
 const size_t MAX_NUMERICSERV_LEN = 6;  // Max port string representation length
 
@@ -51,16 +53,9 @@ const uint16_t DEFAULT_SCTP_PORT = 5000; // SCTP port to use by default
 const size_t DEFAULT_MAX_MESSAGE_SIZE = 65536;    // Remote max message size if not specified in SDP
 const size_t LOCAL_MAX_MESSAGE_SIZE = 256 * 1024; // Local max message size
 
-inline void InitLogger(plog::Severity severity, plog::IAppender *appender = nullptr) {
-	static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
-	if (!appender)
-		appender = &consoleAppender;
-	plog::init(severity, appender);
-	PLOG_DEBUG << "Logger initialized";
-}
+// Log
 
-// Don't change, it must match plog severity
-enum class LogLevel {
+enum class LogLevel { // Don't change, it must match plog severity
 	None = 0,
 	Fatal = 1,
 	Error = 2,
@@ -70,7 +65,17 @@ enum class LogLevel {
 	Verbose = 6
 };
 
+inline void InitLogger(plog::Severity severity, plog::IAppender *appender = nullptr) {
+	static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
+	if (!appender)
+		appender = &consoleAppender;
+	plog::init(severity, appender);
+	PLOG_DEBUG << "Logger initialized";
+}
+
 inline void InitLogger(LogLevel level) { InitLogger(static_cast<plog::Severity>(level)); }
+
+// Utils
 
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...)->overloaded<Ts...>;

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -130,37 +130,39 @@ std::vector<Candidate> Description::extractCandidates() {
 	return result;
 }
 
-Description::operator string() const {
+Description::operator string() const { return generateSdp("\r\n"); }
+
+string Description::generateSdp(const string &eol) const {
 	if (!mFingerprint)
-		throw std::logic_error("Fingerprint must be set to generate a SDP");
+		throw std::logic_error("Fingerprint must be set to generate an SDP string");
 
 	std::ostringstream sdp;
-	sdp << "v=0\n";
-	sdp << "o=- " << mSessionId << " 0 IN IP4 127.0.0.1\n";
-	sdp << "s=-\n";
-	sdp << "t=0 0\n";
-	sdp << "a=group:BUNDLE 0\n";
-	sdp << "m=application 9 UDP/DTLS/SCTP webrtc-datachannel\n";
-	sdp << "c=IN IP4 0.0.0.0\n";
-	sdp << "a=ice-ufrag:" << mIceUfrag << "\n";
-	sdp << "a=ice-pwd:" << mIcePwd << "\n";
+	sdp << "v=0" << eol;
+	sdp << "o=- " << mSessionId << " 0 IN IP4 127.0.0.1" << eol;
+	sdp << "s=-" << eol;
+	sdp << "t=0 0" << eol;
+	sdp << "a=group:BUNDLE 0" << eol;
+	sdp << "m=application 9 UDP/DTLS/SCTP webrtc-datachannel" << eol;
+	sdp << "c=IN IP4 0.0.0.0" << eol;
+	sdp << "a=ice-ufrag:" << mIceUfrag << eol;
+	sdp << "a=ice-pwd:" << mIcePwd << eol;
 	if (mTrickle)
-		sdp << "a=ice-options:trickle\n";
-	sdp << "a=mid:" << mMid << "\n";
-	sdp << "a=setup:" << roleToString(mRole) << "\n";
-	sdp << "a=dtls-id:1\n";
+		sdp << "a=ice-options:trickle" << eol;
+	sdp << "a=mid:" << mMid << eol;
+	sdp << "a=setup:" << roleToString(mRole) << eol;
+	sdp << "a=dtls-id:1" << eol;
 	if (mFingerprint)
-		sdp << "a=fingerprint:sha-256 " << *mFingerprint << "\n";
+		sdp << "a=fingerprint:sha-256 " << *mFingerprint << eol;
 	if (mSctpPort)
-		sdp << "a=sctp-port:" << *mSctpPort << "\n";
+		sdp << "a=sctp-port:" << *mSctpPort << eol;
 	if (mMaxMessageSize)
-		sdp << "a=max-message-size:" << *mMaxMessageSize << "\n";
+		sdp << "a=max-message-size:" << *mMaxMessageSize << eol;
 	for (const auto &candidate : mCandidates) {
-		sdp << string(candidate) << "\n";
+		sdp << string(candidate) << eol;
 	}
 
 	if (!mTrickle)
-		sdp << "a=end-of-candidates\n";
+		sdp << "a=end-of-candidates" << eol;
 
 	return sdp.str();
 }

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -270,7 +270,7 @@ int DtlsTransport::TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms) 
 
 } // namespace rtc
 
-#else
+#else // USE_GNUTLS==0
 
 #include <openssl/bio.h>
 #include <openssl/ec.h>

--- a/src/dtlstransport.hpp
+++ b/src/dtlstransport.hpp
@@ -79,18 +79,22 @@ private:
 	static ssize_t ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_t maxlen);
 	static int TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms);
 #else
-	void writePending();
-
 	SSL_CTX *mCtx;
 	SSL *mSsl;
 	BIO *mInBio, *mOutBio;
 
+	static BIO_METHOD *BioMethods;
 	static int TransportExIndex;
 	static std::mutex GlobalMutex;
 
 	static void GlobalInit();
 	static int CertificateCallback(int preverify_ok, X509_STORE_CTX *ctx);
 	static void InfoCallback(const SSL *ssl, int where, int ret);
+
+	static int BioMethodNew(BIO *bio);
+	static int BioMethodFree(BIO *bio);
+	static int BioMethodWrite(BIO *bio, const char *in, int inl);
+	static long BioMethodCtrl(BIO *bio, int cmd, long num, void *ptr);
 #endif
 };
 

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -51,6 +51,7 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 		PLOG_WARNING << "ICE-TCP is not supported with libjuice";
 	}
 	juice_set_log_handler(IceTransport::LogCallback);
+	juice_set_log_level(JUICE_LOG_LEVEL_VERBOSE);
 
 	juice_config_t jconfig = {};
 	jconfig.cb_state_changed = IceTransport::StateChangeCallback;

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -446,7 +446,8 @@ void IceTransport::setRemoteDescription(const Description &description) {
 	mMid = description.mid();
 	mTrickleTimeout = description.trickleEnabled() ? 30s : 0s;
 
-	if (nice_agent_parse_remote_sdp(mNiceAgent.get(), string(description).c_str()) < 0)
+	// Warning: libnice expects "\n" as end of line
+	if (nice_agent_parse_remote_sdp(mNiceAgent.get(), description.generateSdp("\n").c_str()) < 0)
 		throw std::runtime_error("Failed to parse remote SDP");
 }
 

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -135,14 +135,16 @@ void IceTransport::gatherLocalCandidates() {
 
 std::optional<string> IceTransport::getLocalAddress() const {
 	char str[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (juice_get_selected_addresses(mAgent.get(), str, JUICE_MAX_ADDRESS_STRING_LEN, NULL, 0)) {
+	if (juice_get_selected_addresses(mAgent.get(), str, JUICE_MAX_ADDRESS_STRING_LEN, NULL, 0) ==
+	    0) {
 		return std::make_optional(string(str));
 	}
 	return nullopt;
 }
 std::optional<string> IceTransport::getRemoteAddress() const {
 	char str[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (juice_get_selected_addresses(mAgent.get(), NULL, 0, str, JUICE_MAX_ADDRESS_STRING_LEN)) {
+	if (juice_get_selected_addresses(mAgent.get(), NULL, 0, str, JUICE_MAX_ADDRESS_STRING_LEN) ==
+	    0) {
 		return std::make_optional(string(str));
 	}
 	return nullopt;
@@ -495,6 +497,7 @@ std::optional<string> IceTransport::getLocalAddress() const {
 	}
 	return nullopt;
 }
+
 std::optional<string> IceTransport::getRemoteAddress() const {
 	NiceCandidate *local = nullptr;
 	NiceCandidate *remote = nullptr;

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -72,8 +72,10 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 				server.service = "3478"; // STUN UDP port
 			PLOG_DEBUG << "Using STUN server \"" << server.hostname << ":" << server.service
 			           << "\"";
-			jconfig.stun_server_host = server.hostname.c_str();
-			jconfig.stun_server_port = std::stoul(server.service);
+			mStunHostname = server.hostname;
+			mStunService = server.service;
+			jconfig.stun_server_host = mStunHostname.c_str();
+			jconfig.stun_server_port = std::stoul(mStunService);
 		}
 	}
 

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -70,6 +70,8 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 		if (!server.hostname.empty() && server.type == IceServer::Type::Stun) {
 			if (server.service.empty())
 				server.service = "3478"; // STUN UDP port
+			PLOG_DEBUG << "Using STUN server \"" << server.hostname << ":" << server.service
+			           << "\"";
 			jconfig.stun_server_host = server.hostname.c_str();
 			jconfig.stun_server_port = std::stoul(server.service);
 		}
@@ -333,6 +335,8 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 				if (getnameinfo(p->ai_addr, p->ai_addrlen, nodebuffer, MAX_NUMERICNODE_LEN,
 				                servbuffer, MAX_NUMERICNODE_LEN,
 				                NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
+					PLOG_DEBUG << "Using STUN server \"" << server.hostname << ":" << server.service
+					           << "\"";
 					g_object_set(G_OBJECT(mNiceAgent.get()), "stun-server", nodebuffer, nullptr);
 					g_object_set(G_OBJECT(mNiceAgent.get()), "stun-server-port",
 					             std::stoul(servbuffer), nullptr);

--- a/src/icetransport.hpp
+++ b/src/icetransport.hpp
@@ -26,13 +26,11 @@
 #include "peerconnection.hpp"
 #include "transport.hpp"
 
-extern "C" {
 #if USE_JUICE
 #include <juice/juice.h>
 #else
 #include <nice/agent.h>
 #endif
-}
 
 #include <atomic>
 #include <chrono>

--- a/src/icetransport.hpp
+++ b/src/icetransport.hpp
@@ -107,6 +107,8 @@ private:
 
 #if USE_JUICE
 	std::unique_ptr<juice_agent_t, void (*)(juice_agent_t *)> mAgent;
+	string mStunHostname;
+	string mStunService;
 
 	static void StateChangeCallback(juice_agent_t *agent, juice_state_t state, void *user_ptr);
 	static void CandidateCallback(juice_agent_t *agent, const char *sdp, void *user_ptr);

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -29,7 +29,7 @@ using namespace std;
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
 int main(int argc, char **argv) {
-	// InitLogger(LogLevel::Debug);
+	InitLogger(LogLevel::Warning);
 
 	Configuration config;
 	// config.iceServers.emplace_back("stun:stun.l.google.com:19302");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -113,6 +113,15 @@ int main(int argc, char **argv) {
 
 	this_thread::sleep_for(3s);
 
+	if (auto addr = pc1->localAddress())
+		cout << "Local address 1:  " << *addr << endl;
+	if (auto addr = pc1->remoteAddress())
+		cout << "Remote address 1: " << *addr << endl;
+	if (auto addr = pc2->localAddress())
+		cout << "Local address 2:  " << *addr << endl;
+	if (auto addr = pc2->remoteAddress())
+		cout << "Remote address 2: " << *addr << endl;
+
 	if (dc1->isOpen() && dc2->isOpen()) {
 		pc1->close();
 		pc2->close();

--- a/test/p2p/answerer.cpp
+++ b/test/p2p/answerer.cpp
@@ -28,7 +28,7 @@ using namespace std;
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
 int main(int argc, char **argv) {
-	// InitLogger(LogLevel::Debug);
+	InitLogger(LogLevel::Warning);
 
 	Configuration config;
 	// config.iceServers.emplace_back("stun.l.google.com:19302");

--- a/test/p2p/offerer.cpp
+++ b/test/p2p/offerer.cpp
@@ -28,7 +28,7 @@ using namespace std;
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
 int main(int argc, char **argv) {
-	// InitLogger(LogLevel::Debug);
+	InitLogger(LogLevel::Warning);
 
 	Configuration config;
 	// config.iceServers.emplace_back("stun.l.google.com:19302");


### PR DESCRIPTION
This PR allows to use the custom [libjuice](https://github.com/paullouisageneau/libjuice) as alternative to libnice for ICE, in order to alleviate the complexity of integrating Libnice and GLib. It should also work better, thanks to the proper support of IPv6 candidates gathering and the addition of the Don't Fragment flag in libjuice.