### PR TITLE
Do not free candidate memory

### DIFF
--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -676,8 +676,6 @@ bool IceTransport::getSelectedCandidatePair(CandidateInfo *localInfo, CandidateI
 	remoteInfo->type = IceTransport::NiceTypeToCandidateType(remote->type);
 	remoteInfo->transportType = IceTransport::NiceTransportTypeToCandidateTransportType(remote->transport);
 
-	nice_candidate_free(local);
-	nice_candidate_free(remote);
 	return true;
 }
 


### PR DESCRIPTION
If we free retrieved candidate memories app crashs in tests.