### PR TITLE
define WIN32_LEAN_AND_MEAN in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/Modules)
 
 if(WIN32)
+	add_definitions(-DWIN32_LEAN_AND_MEAN)
 	if (MSYS OR MINGW)
 		add_definitions(-DSCTP_STDINT_INCLUDE=<stdint.h>)
 	endif()

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -20,7 +20,6 @@
 #define RTC_INCLUDE_H
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0602
 #endif


### PR DESCRIPTION
Defining in header file generates so many warnings while compiling 