### PR TITLE
Manually handle OpenSSL handshake timeout

### DIFF
--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -89,8 +89,10 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, shared_ptr<Certific
 	    gnutls_credentials_set(mSession, GNUTLS_CRD_CERTIFICATE, mCertificate->credentials()));
 
 	gnutls_dtls_set_mtu(mSession, 1280 - 40 - 8); // min MTU over UDP/IPv6 (only for handshake)
-	gnutls_dtls_set_timeouts(mSession, 400, 60000);
-	gnutls_handshake_set_timeout(mSession, 60000);
+	gnutls_dtls_set_timeouts(mSession,
+	                         1000,   // 1s retransmission timeout recommended by RFC 6347
+	                         30000); // 30s total timeout
+	gnutls_handshake_set_timeout(mSession, 30000);
 
 	gnutls_session_set_ptr(mSession, this);
 	gnutls_transport_set_ptr(mSession, this);

--- a/test/capi.cpp
+++ b/test/capi.cpp
@@ -168,7 +168,7 @@ int test_capi_main() {
 	rtcSetMessageCallback(peer1->dc, messageCallback);
 
 	attempts = 10;
-	while (!peer2->connected && attempts--)
+	while (!peer2->connected && !peer1->connected && attempts--)
 		sleep(1);
 
 	if (peer1->state != RTC_CONNECTED || peer2->state != RTC_CONNECTED) {

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -115,7 +115,7 @@ void test_connectivity() {
 	});
 
 	int attempts = 10;
-	while ((!dc2 || !dc2->isOpen()) && attempts--)
+	while ((!dc2 || !dc2->isOpen() || !dc1->isOpen()) && attempts--)
 		this_thread::sleep_for(1s);
 
 	if (pc1->state() != PeerConnection::State::Connected &&


### PR DESCRIPTION
- Refactor the OpenSSL handshake loop
- Handle the handshake timeout manually since OpenSSL does not allow to set it up.

Partially fixes https://github.com/paullouisageneau/libdatachannel/issues/58