### PR TITLE
Fix SCTP interleaved notifications

### DIFF
--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -455,6 +455,8 @@ int SctpTransport::handleRecv(struct socket *sock, union sctp_sockstore addr, co
 		if (!len)
 			return 0; // Ignore
 
+		// SCTP_FRAGMENT_INTERLEAVE does not seem to work as expected for messages > 64KB,
+		// therefore partial notifications and messages need to be handled separately.
 		if (flags & MSG_NOTIFICATION) {
 			// SCTP event notification
 			if (flags & MSG_EOR) {

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -473,16 +473,16 @@ int SctpTransport::handleRecv(struct socket *sock, union sctp_sockstore addr, co
 		} else {
 			// SCTP message
 			if (flags & MSG_EOR) {
-				if (!mPartialData.empty()) {
-					mPartialData.insert(mPartialData.end(), data, data + len);
-					data = mPartialData.data();
-					len = mPartialData.size();
+				if (!mPartialMessage.empty()) {
+					mPartialMessage.insert(mPartialMessage.end(), data, data + len);
+					data = mPartialMessage.data();
+					len = mPartialMessage.size();
 				}
 				// Message is complete, process it
 				processData(data, len, info.rcv_sid, PayloadId(htonl(info.rcv_ppid)));
-				mPartialData.clear();
+				mPartialMessage.clear();
 			} else {
-				mPartialData.insert(mPartialData.end(), data, data + len);
+				mPartialMessage.insert(mPartialMessage.end(), data, data + len);
 			}
 		}
 

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -99,7 +99,7 @@ private:
 	std::atomic<bool> mWritten = false; // written outside lock
 	std::atomic<bool> mWrittenOnce = false; // same
 
-	binary mPartialData, mPartialNotification;
+	binary mPartialMessage, mPartialNotification;
 	binary mPartialStringData, mPartialBinaryData;
 
 	// Stats

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -99,7 +99,8 @@ private:
 	std::atomic<bool> mWritten = false; // written outside lock
 	std::atomic<bool> mWrittenOnce = false; // same
 
-	binary mPartialRecv, mPartialStringData, mPartialBinaryData;
+	binary mPartialData, mPartialNotification;
+	binary mPartialStringData, mPartialBinaryData;
 
 	// Stats
 	std::atomic<size_t> mBytesSent = 0, mBytesReceived = 0;


### PR DESCRIPTION
Fixes https://github.com/paullouisageneau/libdatachannel/issues/96

`SCTP_FRAGMENT_INTERLEAVE` does not seem to work as expected for messages > 64KB, therefore partial notifications and messages need to be handled separately.