### PR TITLE
Fix use-after-free in SctpTransport::incoming()

### DIFF
--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -194,6 +194,11 @@ SctpTransport::~SctpTransport() {
 }
 
 bool SctpTransport::stop() {
+	// Transport::stop() will unregister incoming() from the lower layer, therefore we need to make
+	// sure the thread from lower layers is not blocked in incoming() by the WrittenOnce condition.
+	mWrittenOnce = true;
+	mWrittenCondition.notify_all();
+
 	if (!Transport::stop())
 		return false;
 

--- a/src/transport.hpp
+++ b/src/transport.hpp
@@ -41,12 +41,17 @@ public:
 
 	virtual ~Transport() {
 		stop();
-		if (mLower)
-			mLower->onRecv(nullptr); // doing it on stop could cause a deadlock
 	}
 
 	virtual bool stop() {
-		return !mShutdown.exchange(true);
+		if (mShutdown.exchange(true))
+			return false;
+
+		// We don't want incoming() to be called by the lower layer anymore
+		if (mLower)
+			mLower->onRecv(nullptr);
+
+		return true;
 	}
 
 	void registerIncoming() {


### PR DESCRIPTION
Fixes https://github.com/paullouisageneau/libdatachannel/issues/104

`SctpTransport::incoming()` must be unregistered by `Transport::stop()` before `SctpTransport::shutdown()` to prevent `usrsctp_close()` from being called while calling `usrsctp_conninput()` from lower layer.
