### PR TITLE
Add the right header for IPPROTO_* on platforms such as Termux

### DIFF
--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -28,6 +28,7 @@
 #else
 #include <netdb.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #endif
 
 #include <sys/types.h>


### PR DESCRIPTION
When building libdatachannel using Termux on Android, with Juice and OpenSSL, the IPPROTO_TCP and IPPROTO_UDP constants cannot be found. Adding the `<netinet/in.h>` header fixes the problem.