### PR TITLE
Fix ThreadPool static destruction issues

### DIFF
--- a/src/threadpool.cpp
+++ b/src/threadpool.cpp
@@ -21,8 +21,9 @@
 namespace rtc {
 
 ThreadPool &ThreadPool::Instance() {
-	static ThreadPool instance;
-	return instance;
+	// Init handles joining on cleanup
+	static ThreadPool *instance = new ThreadPool;
+	return *instance;
 }
 
 ThreadPool::~ThreadPool() { join(); }


### PR DESCRIPTION
This PR fixes the lifecycle of `ThreadPool` to prevent it from being called by other static objects after its destruction.