### PR TITLE
Add Data Channel reliability to C API

### DIFF
--- a/include/rtc/reliability.hpp
+++ b/include/rtc/reliability.hpp
@@ -27,13 +27,9 @@
 namespace rtc {
 
 struct Reliability {
-	enum Type : uint8_t {
-		TYPE_RELIABLE = 0x00,
-		TYPE_PARTIAL_RELIABLE_REXMIT = 0x01,
-		TYPE_PARTIAL_RELIABLE_TIMED = 0x02,
-	};
+	enum class Type { Reliable = 0, Rexmit, Timed };
 
-	Type type = TYPE_RELIABLE;
+	Type type = Type::Reliable;
 	bool unordered = false;
 	std::variant<int, std::chrono::milliseconds> rexmit = 0;
 };

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -78,6 +78,13 @@ typedef struct {
 	uint16_t portRangeEnd;
 } rtcConfiguration;
 
+typedef struct {
+	bool unordered;
+	bool unreliable;
+	unsigned int maxPacketLifeTime; // ignored if reliable
+	unsigned int maxRetransmits;    // ignored if reliable
+} rtcReliability;
+
 typedef void (*rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
 typedef void (*rtcDataChannelCallbackFunc)(int dc, void *ptr);
 typedef void (*rtcDescriptionCallbackFunc)(const char *sdp, const char *type, void *ptr);
@@ -115,9 +122,13 @@ RTC_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
 
 // DataChannel
 RTC_EXPORT int rtcCreateDataChannel(int pc, const char *label); // returns dc id
+RTC_EXPORT int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
+                                       const rtcReliability *reliability); // returns dc id
 RTC_EXPORT int rtcDeleteDataChannel(int dc);
 
 RTC_EXPORT int rtcGetDataChannelLabel(int dc, char *buffer, int size);
+RTC_EXPORT int rtcGetDataChannelProtocol(int dc, char *buffer, int size);
+RTC_EXPORT int rtcGetDataChannelReliability(int dc, rtcReliability *reliability);
 
 // WebSocket
 #if RTC_ENABLE_WEBSOCKET

--- a/src/rtc.cpp
+++ b/src/rtc.cpp
@@ -256,7 +256,7 @@ int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
 				if (reliability->maxPacketLifeTime > 0) {
 					r.type = Reliability::TYPE_PARTIAL_RELIABLE_TIMED;
 					r.rexmit = milliseconds(reliability->maxPacketLifeTime);
-				} else if (reliability->maxRetransmits > 0) {
+				} else {
 					r.type = Reliability::TYPE_PARTIAL_RELIABLE_REXMIT;
 					r.rexmit = int(reliability->maxRetransmits);
 				}

--- a/src/rtc.cpp
+++ b/src/rtc.cpp
@@ -254,14 +254,14 @@ int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
 			r.unordered = reliability->unordered;
 			if (reliability->unreliable) {
 				if (reliability->maxPacketLifeTime > 0) {
-					r.type = Reliability::TYPE_PARTIAL_RELIABLE_TIMED;
+					r.type = Reliability::Type::Timed;
 					r.rexmit = milliseconds(reliability->maxPacketLifeTime);
 				} else {
-					r.type = Reliability::TYPE_PARTIAL_RELIABLE_REXMIT;
+					r.type = Reliability::Type::Rexmit;
 					r.rexmit = int(reliability->maxRetransmits);
 				}
 			} else {
-				r.type = Reliability::TYPE_RELIABLE;
+				r.type = Reliability::Type::Reliable;
 			}
 		}
 		auto peerConnection = getPeerConnection(pc);
@@ -499,10 +499,10 @@ int rtcGetDataChannelReliability(int dc, rtcReliability *reliability) {
 		Reliability r = dataChannel->reliability();
 		std::memset(reliability, sizeof(*reliability), 0);
 		reliability->unordered = r.unordered;
-		if (r.type == Reliability::TYPE_PARTIAL_RELIABLE_TIMED) {
+		if (r.type == Reliability::Type::Timed) {
 			reliability->unreliable = true;
 			reliability->maxPacketLifeTime = std::get<milliseconds>(r.rexmit).count();
-		} else if (r.type == Reliability::TYPE_PARTIAL_RELIABLE_REXMIT) {
+		} else if (r.type == Reliability::Type::Rexmit) {
 			reliability->unreliable = true;
 			reliability->maxRetransmits = unsigned(std::get<int>(r.rexmit));
 		} else {

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -372,12 +372,12 @@ bool SctpTransport::trySendMessage(message_ptr message) {
 		spa.sendv_sndinfo.snd_flags |= SCTP_UNORDERED;
 
 	switch (reliability.type) {
-	case Reliability::TYPE_PARTIAL_RELIABLE_REXMIT:
+	case Reliability::Type::Rexmit:
 		spa.sendv_flags |= SCTP_SEND_PRINFO_VALID;
 		spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_RTX;
 		spa.sendv_prinfo.pr_value = uint32_t(std::get<int>(reliability.rexmit));
 		break;
-	case Reliability::TYPE_PARTIAL_RELIABLE_TIMED:
+	case Reliability::Type::Timed:
 		spa.sendv_flags |= SCTP_SEND_PRINFO_VALID;
 		spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_TTL;
 		spa.sendv_prinfo.pr_value = uint32_t(std::get<milliseconds>(reliability.rexmit).count());


### PR DESCRIPTION
Add functions `rtcCreateDataChannelExt`, `rtcGetDataChannelProtocol`, and `rtcGetDataChannelReliability`.