### PR TITLE
Move comon lines before m= lines

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -229,7 +229,7 @@ string Description::generateSdp(const string &eol) const {
 
     sdp << "a=ice-ufrag:" << mIceUfrag << eol;
     sdp << "a=ice-pwd:" << mIcePwd << eol;
-    sdp << "a=setup:" << roleToString(mRole) << eol;g
+    sdp << "a=setup:" << roleToString(mRole) << eol;
     sdp << "a=tls-id:1" << eol;
 
     if (mFingerprint)
@@ -268,10 +268,6 @@ string Description::generateSdp(const string &eol) const {
 				sdp << "a=sctp-port:" << *mData.sctpPort << eol;
 			if (mData.maxMessageSize)
 				sdp << "a=max-message-size:" << *mData.maxMessageSize << eol;
-		}
-
-		if (i == 0) {
-
 		}
 	}
 

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -223,6 +223,18 @@ string Description::generateSdp(const string &eol) const {
 
 	sdp << "a=msid-semantic: WMS" << eol;
 
+    // Common
+    if (!mEnded)
+        sdp << "a=ice-options:trickle" << eol;
+
+    sdp << "a=ice-ufrag:" << mIceUfrag << eol;
+    sdp << "a=ice-pwd:" << mIcePwd << eol;
+    sdp << "a=setup:" << roleToString(mRole) << eol;g
+    sdp << "a=tls-id:1" << eol;
+
+    if (mFingerprint)
+        sdp << "a=fingerprint:sha-256 " << *mFingerprint << eol;
+
 	// Non-data media
 	if (!mMedia.empty()) {
 		// Lip-sync
@@ -259,17 +271,7 @@ string Description::generateSdp(const string &eol) const {
 		}
 
 		if (i == 0) {
-			// Common
-			if (!mEnded)
-				sdp << "a=ice-options:trickle" << eol;
 
-			sdp << "a=ice-ufrag:" << mIceUfrag << eol;
-			sdp << "a=ice-pwd:" << mIcePwd << eol;
-			sdp << "a=setup:" << roleToString(mRole) << eol;
-			sdp << "a=tls-id:1" << eol;
-
-			if (mFingerprint)
-				sdp << "a=fingerprint:sha-256 " << *mFingerprint << eol;
 		}
 	}
 


### PR DESCRIPTION
This references #141 but moves common lines before the m= lines which is necessary to allow for the ice-ufrag and such to be applied globally.
