### PR TITLE
simple CLI for C++ datachannel client

### DIFF
--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -3,7 +3,7 @@ if(POLICY CMP0079)
 	cmake_policy(SET CMP0079 NEW)
 endif()
 
-add_executable(datachannel-client main.cpp)
+add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h)
 set_target_properties(datachannel-client PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME client)

--- a/examples/client/parse_cl.cpp
+++ b/examples/client/parse_cl.cpp
@@ -1,0 +1,160 @@
+/******************************************************************************
+**
+** parse_cl.cpp
+**
+** Thu Aug  6 19:42:25 2020
+** Linux 5.4.0-42-generic (#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020) x86_64
+** cerik@Erik-VBox-Ubuntu (Erik Cota-Robles)
+**
+** Copyright (c) 2020 Erik Cota-Robles
+**
+** Definition of command line parser class
+**
+** Automatically created by genparse v0.9.3
+**
+** See http://genparse.sourceforge.net for details and updates
+**
+**
+******************************************************************************/
+
+#include <getopt.h>
+#include <stdlib.h>
+#include "parse_cl.h"
+
+/*----------------------------------------------------------------------------
+**
+** Cmdline::Cmdline ()
+**
+** Constructor method.
+**
+**--------------------------------------------------------------------------*/
+
+Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::string )
+{
+  extern char *optarg;
+  extern int optind;
+  int c;
+
+  static struct option long_options[] =
+  {
+    {"stunServer", required_argument, NULL, 's'},
+    {"stunPort", required_argument, NULL, 't'},
+    {"webSocketServer", required_argument, NULL, 'w'},
+    {"webSocketPort", required_argument, NULL, 'x'},
+    {"help", no_argument, NULL, 'h'},
+    {"version", no_argument, NULL, 'v'},
+    {NULL, 0, NULL, 0}
+  };
+
+  _program_name += argv[0];
+
+  /* default values */
+  _s = "stun.l.google.com";
+  _t = 19302;
+  _w = "localhost";
+  _x = 8000;
+  _h = false;
+  _v = false;
+
+  optind = 0;
+  while ((c = getopt_long (argc, argv, "s:t:w:x:hv", long_options, &optind)) != - 1)
+    {
+      switch (c)
+        {
+        case 's': 
+          _s = optarg;
+          break;
+
+        case 't': 
+          _t = atoi (optarg);
+          if (_t < 0)
+            {
+              std::string err;
+              err += "parameter range error: t must be >= 0";
+              throw (std::range_error(err));
+            }
+          if (_t > 65535)
+            {
+              std::string err;
+              err += "parameter range error: t must be <= 65535";
+              throw (std::range_error(err));
+            }
+          break;
+
+        case 'w': 
+          _w = optarg;
+          break;
+
+        case 'x': 
+          _x = atoi (optarg);
+          if (_x < 0)
+            {
+              std::string err;
+              err += "parameter range error: x must be >= 0";
+              throw (std::range_error(err));
+            }
+          if (_x > 65535)
+            {
+              std::string err;
+              err += "parameter range error: x must be <= 65535";
+              throw (std::range_error(err));
+            }
+          break;
+
+        case 'h': 
+          _h = true;
+          this->usage (EXIT_SUCCESS);
+          break;
+
+        case 'v': 
+          _v = true;
+          this->version (EXIT_SUCCESS);
+          break;
+
+        default:
+          this->usage (EXIT_FAILURE);
+
+        }
+    } /* while */
+
+  _optind = optind;
+}
+
+/*----------------------------------------------------------------------------
+**
+** Cmdline::usage () and version()
+**
+** Print out usage (or version) information, then exit.
+**
+**--------------------------------------------------------------------------*/
+
+void Cmdline::usage (int status)
+{
+  if (status != EXIT_SUCCESS)
+    std::cerr << "Try `" << _program_name << " --help' for more information.\n";
+  else
+    {
+      std::cout << "\
+usage: " << _program_name << " [ -stwxhv ] \n\
+libdatachannel client implementing WebRTC Data Channels with WebSocket signaling\n\
+   [ -s ] [ --stunServer ] (type=STRING, default=stun.l.google.com)\n\
+          Stun server URL or IP address.\n\
+   [ -t ] [ --stunPort ] (type=INTEGER, range=0...65535, default=19302)\n\
+          Stun server port.\n\
+   [ -w ] [ --webSocketServer ] (type=STRING, default=localhost)\n\
+          Web socket server URL or IP address.\n\
+   [ -x ] [ --webSocketPort ] (type=INTEGER, range=0...65535, default=8000)\n\
+          Web socket server port.\n\
+   [ -h ] [ --help ] (type=FLAG)\n\
+          Display this help and exit.\n\
+   [ -v ] [ --version ] (type=FLAG)\n\
+          Output version information and exit.\n";
+    }
+  exit (status);
+}
+
+void Cmdline::version (int status)
+{
+  std::cout << _program_name << " v0.5\n";
+  exit (status);
+}

--- a/examples/client/parse_cl.h
+++ b/examples/client/parse_cl.h
@@ -1,0 +1,70 @@
+/******************************************************************************
+**
+** parse_cl.h
+**
+** Thu Aug  6 19:42:25 2020
+** Linux 5.4.0-42-generic (#46-Ubuntu SMP Fri Jul 10 00:24:02 UTC 2020) x86_64
+** cerik@Erik-VBox-Ubuntu (Erik Cota-Robles)
+**
+** Copyright (c) 2020 Erik Cota-Robles
+**
+** Header file for command line parser class
+**
+** Automatically created by genparse v0.9.3
+**
+** See http://genparse.sourceforge.net for details and updates
+**
+******************************************************************************/
+
+#ifndef CMDLINE_H
+#define CMDLINE_H
+
+#include <iostream>
+#include <string>
+
+/*----------------------------------------------------------------------------
+**
+** class Cmdline
+**
+** command line parser class
+**
+**--------------------------------------------------------------------------*/
+
+class Cmdline
+{
+private:
+  /* parameters */
+  std::string _s;
+  int _t;
+  std::string _w;
+  int _x;
+  bool _h;
+  bool _v;
+
+  /* other stuff to keep track of */
+  std::string _program_name;
+  int _optind;
+
+public:
+  /* constructor and destructor */
+  Cmdline (int, char **); // ISO C++17 not allowed: throw (std::string);
+  ~Cmdline (){}
+
+  /* usage function */
+  void usage (int status);
+
+  /* version function */
+  void version (int status);
+
+  /* return next (non-option) parameter */
+  int next_param () { return _optind; }
+
+  std::string stunServer () const { return _s; }
+  int stunPort () const { return _t; }
+  std::string webSocketServer () const { return _w; }
+  int webSocketPort () const { return _x; }
+  bool h () const { return _h; }
+  bool v () const { return _v; }
+};
+
+#endif


### PR DESCRIPTION
cerik@Erik-VBox-Ubuntu:$ ./examples/client/client -h
usage: ./examples/client/client [ -stwxhv ] 
libdatachannel client implementing WebRTC Data Channels with WebSocket signaling
   [ -s ] [ --stunServer ] (type=STRING, default=stun.l.google.com)
          Stun server URL or IP address.
   [ -t ] [ --stunPort ] (type=INTEGER, range=0...65535, default=19302)
          Stun server port.
   [ -w ] [ --webSocketServer ] (type=STRING, default=localhost)
          Web socket server URL or IP address.
   [ -x ] [ --webSocketPort ] (type=INTEGER, range=0...65535, default=8000)
          Web socket server port.
   [ -h ] [ --help ] (type=FLAG)
          Display this help and exit.
   [ -v ] [ --version ] (type=FLAG)
          Output version information and exit.
cerik@Erik-VBox-Ubuntu:$ ./examples/client/client -s 192.168.0.68 -t 666666
parameter range error: t must be <= 65535
cerik@Erik-VBox-Ubuntu:~$ ./examples/client/client -s 192.168.0.68 -t 3478 -w 192.168.0.61 -x 8000
2020-08-12 13:18:22.464 DEBUG [7060] [rtc::InitLogger@36] Logger initialized
Stun server is stun:192.168.0.68:3478
The local ID is: jOuY
2020-08-12 13:18:22.470 DEBUG [7060] [rtc::{anonymous}::doInit@46] Global initialization
Url is ws://192.168.0.61:8000/jOuY
2020-08-12 13:18:22.474 DEBUG [7060] [rtc::TcpTransport::TcpTransport@88] Initializing TCP transport
Waiting for signaling to be connected...

