### PR TITLE
Rename createTrack to addTrack()

### DIFF
--- a/examples/media/main.cpp
+++ b/examples/media/main.cpp
@@ -65,7 +65,7 @@ int main() {
 		media.setBitrate(
 		    3000); // Request 3Mbps (Browsers do not encode more than 2.5MBps from a webcam)
 
-		auto track = pc->createTrack(media);
+		auto track = pc->addTrack(media);
 
 		auto session = std::make_shared<rtc::RtcpSession>();
 		track->setRtcpHandler(session);

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -86,6 +86,10 @@ public:
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 
+	std::shared_ptr<DataChannel> addDataChannel(string label, string protocol = "",
+	                                            Reliability reliability = {});
+
+	// Equivalent to calling addDataChannel() and setLocalDescription()
 	std::shared_ptr<DataChannel> createDataChannel(string label, string protocol = "",
 	                                               Reliability reliability = {});
 
@@ -102,7 +106,7 @@ public:
 	std::optional<std::chrono::milliseconds> rtt();
 
 	// Track media support requires compiling with libSRTP
-	std::shared_ptr<Track> createTrack(Description::Media description);
+	std::shared_ptr<Track> addTrack(Description::Media description);
 	void onTrack(std::function<void(std::shared_ptr<Track> track)> callback);
 
 	// libnice only

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -119,6 +119,10 @@ RTC_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
 
 // DataChannel
 RTC_EXPORT int rtcSetDataChannelCallback(int pc, rtcDataChannelCallbackFunc cb);
+RTC_EXPORT int rtcAddDataChannel(int pc, const char *label); // returns dc id
+RTC_EXPORT int rtcAddDataChannelExt(int pc, const char *label, const char *protocol,
+                                    const rtcReliability *reliability); // returns dc id
+// Equivalent to calling rtcAddDataChannel() and rtcSetLocalDescription()
 RTC_EXPORT int rtcCreateDataChannel(int pc, const char *label); // returns dc id
 RTC_EXPORT int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
                                        const rtcReliability *reliability); // returns dc id
@@ -130,7 +134,7 @@ RTC_EXPORT int rtcGetDataChannelReliability(int dc, rtcReliability *reliability)
 
 // Track
 RTC_EXPORT int rtcSetTrackCallback(int pc, rtcTrackCallbackFunc cb);
-RTC_EXPORT int rtcCreateTrack(int pc, const char *mediaDescriptionSdp); // returns tr id
+RTC_EXPORT int rtcAddTrack(int pc, const char *mediaDescriptionSdp); // returns tr id
 RTC_EXPORT int rtcDeleteTrack(int tr);
 
 RTC_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);

--- a/src/rtc.cpp
+++ b/src/rtc.cpp
@@ -268,12 +268,12 @@ int rtcDeletePeerConnection(int pc) {
 	});
 }
 
-int rtcCreateDataChannel(int pc, const char *label) {
-	return rtcCreateDataChannelExt(pc, label, nullptr, nullptr);
+int rtcAddDataChannel(int pc, const char *label) {
+	return rtcAddDataChannelExt(pc, label, nullptr, nullptr);
 }
 
-int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
-                            const rtcReliability *reliability) {
+int rtcAddDataChannelExt(int pc, const char *label, const char *protocol,
+                         const rtcReliability *reliability) {
 	return WRAP({
 		Reliability r = {};
 		if (reliability) {
@@ -291,12 +291,23 @@ int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
 			}
 		}
 		auto peerConnection = getPeerConnection(pc);
-		int dc = emplaceDataChannel(peerConnection->createDataChannel(
+		int dc = emplaceDataChannel(peerConnection->addDataChannel(
 		    string(label ? label : ""), string(protocol ? protocol : ""), r));
 		if (auto ptr = getUserPointer(pc))
 			rtcSetUserPointer(dc, *ptr);
 		return dc;
 	});
+}
+
+int rtcCreateDataChannel(int pc, const char *label) {
+	return rtcCreateDataChannelExt(pc, label, nullptr, nullptr);
+}
+
+int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
+                            const rtcReliability *reliability) {
+	int dc = rtcAddDataChannelExt(pc, label, protocol, reliability);
+	rtcSetLocalDescription(pc);
+	return dc;
 }
 
 int rtcDeleteDataChannel(int dc) {
@@ -313,13 +324,13 @@ int rtcDeleteDataChannel(int dc) {
 	});
 }
 
-int rtcCreateTrack(int pc, const char *mediaDescriptionSdp) {
+int rtcAddTrack(int pc, const char *mediaDescriptionSdp) {
 	if (!mediaDescriptionSdp)
 		throw std::invalid_argument("Unexpected null pointer for track media description");
 
 	auto peerConnection = getPeerConnection(pc);
 	Description::Media media{string(mediaDescriptionSdp)};
-	int tr = emplaceTrack(peerConnection->createTrack(std::move(media)));
+	int tr = emplaceTrack(peerConnection->addTrack(std::move(media)));
 	if (auto ptr = getUserPointer(pc))
 		rtcSetUserPointer(tr, *ptr);
 	return tr;

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -151,7 +151,7 @@ int test_capi_track_main() {
 		goto error;
 
 	// Peer 1: Create track
-	peer1->tr = rtcCreateTrack(peer1->pc, mediaDescription);
+	peer1->tr = rtcAddTrack(peer1->pc, mediaDescription);
 	rtcSetOpenCallback(peer1->tr, openCallback);
 	rtcSetClosedCallback(peer1->tr, closedCallback);
 

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -102,7 +102,7 @@ void test_track() {
 		std::atomic_store(&t2, t);
 	});
 
-	auto t1 = pc1->createTrack(Description::Video("test"));
+	auto t1 = pc1->addTrack(Description::Video("test"));
 
 	pc1->setLocalDescription();
 


### PR DESCRIPTION
This PR renames `createTrack()` to `addTrack()` and adds `addDataChannel()` for the sake of consistency.