### PR TITLE
Add parameters to change servers port/endpoint

### DIFF
--- a/examples/signaling-server-python/signaling-server.py
+++ b/examples/signaling-server-python/signaling-server.py
@@ -63,8 +63,11 @@ async def handle_websocket(websocket, path):
             print('Client {} disconnected'.format(client_id))
 
 if __name__ == '__main__':
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8000
+    # Usage: ./server.py [[host:]port] [SSL certificate file]
+    endpoint_or_port = sys.argv[1] if len(sys.argv) > 1 else "8000"
     ssl_cert = sys.argv[2] if len(sys.argv) > 2 else None
+
+    endpoint = endpoint_or_port if ':' in endpoint_or_port else "127.0.0.1:" + endpoint_or_port
 
     if ssl_cert:
         ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -72,7 +75,8 @@ if __name__ == '__main__':
     else:
         ssl_context = None
 
-    print('Listening on port {}'.format(port))
-    start_server = websockets.serve(handle_websocket, '127.0.0.1', port, ssl=ssl_context)
+    print('Listening on {}'.format(endpoint))
+    host, port = endpoint.rsplit(':', 1)
+    start_server = websockets.serve(handle_websocket, host, int(port), ssl=ssl_context)
     asyncio.get_event_loop().run_until_complete(start_server)
     asyncio.get_event_loop().run_forever()

--- a/examples/signaling-server-rust/Cargo.lock
+++ b/examples/signaling-server-rust/Cargo.lock
@@ -348,7 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
 
 [[package]]
-name = "libdatachannel_signaling_example"
+name = "libdatachannel_signaling_server_example"
 version = "0.1.0"
 dependencies = [
  "futures-channel",

--- a/examples/signaling-server-rust/src/main.rs
+++ b/examples/signaling-server-rust/src/main.rs
@@ -92,7 +92,9 @@ async fn handle(clients: ClientsMap, stream: TcpStream) {
 #[tokio::main]
 async fn main() -> Result<(), std::io::Error> {
     let service = env::args().nth(1).unwrap_or("8000".to_string());
-    let endpoint = format!("127.0.0.1:{}", service);
+    let endpoint = if service.contains(':') { service } else { format!("127.0.0.1:{}", service) };
+
+	println!("Listening on {}", endpoint);
 
     let mut listener = TcpListener::bind(endpoint)
     	.await.expect("Listener binding failed");

--- a/examples/web/server.js
+++ b/examples/web/server.js
@@ -98,8 +98,10 @@ wsServer.on('request', (req) => {
   clients[id] = conn;
 });
 
-const hostname = '127.0.0.1';
-const port = 8000;
+const endpoint = process.env.PORT || '8000';
+const splitted = endpoint.split(':');
+const port = splitted.pop();
+const hostname = splitted.join(':') || '127.0.0.1';
 
 httpServer.listen(port, hostname, () => {
   console.log(`Server listening on ${hostname}:${port}`);


### PR DESCRIPTION
This PR adds parameters to signaling servers to allow setting the port/endpoint. For instance, the web server can now be run with `PORT=0.0.0.0:8000 npm start` to listen on any address.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/181