### PR TITLE
example/client has "-n" option to not use STUN server

### DIFF
--- a/examples/client/README-getopt-for-windows.md
+++ b/examples/client/README-getopt-for-windows.md
@@ -1,4 +1,0 @@
-# getopt-for-windows
-getopt.h and getopt.c is very often used in linux, to make it easy for windows user, two files were extracted from glibc. In order to make it works properly in windows, some modification was done and you may compare the change using original source files. Enjoy it!
-
-Source: https://github.com/Chunde/getopt-for-windows.  IMPORTANT: getopt.[ch] are likely not safe for Linux due to conflict with existing getopt.[ch].  They are thus NOT in CMakeFiles.txt and instead both files are #include only on Windows.

--- a/examples/client/main.cpp
+++ b/examples/client/main.cpp
@@ -67,12 +67,16 @@ int main(int argc, char **argv) {
 
 	Configuration config;
 	string stunServer = "";
-	if (params->stunServer().substr(0,5).compare("stun:") != 0) {
-		stunServer = "stun:";
+	if (params->noStun()) {
+		cout << "No stun server is configured.  Only local hosts and public IP addresses suported." << endl;
+	} else {
+		if (params->stunServer().substr(0,5).compare("stun:") != 0) {
+			stunServer = "stun:";
+		}
+		stunServer += params->stunServer() + ":" + to_string(params->stunPort());
+		cout << "Stun server is " << stunServer << endl;
+		config.iceServers.emplace_back(stunServer);
 	}
-	stunServer += params->stunServer() + ":" + to_string(params->stunPort());
-	cout << "Stun server is " << stunServer << endl;
-	config.iceServers.emplace_back(stunServer);
 
 	localId = randomId(4);
 	cout << "The local ID is: " << localId << endl;

--- a/examples/client/parse_cl.cpp
+++ b/examples/client/parse_cl.cpp
@@ -43,6 +43,8 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
 
   static struct option long_options[] =
   {
+    {"echo", no_argument, NULL, 'e'},
+    {"noStun", no_argument, NULL, 'n'},
     {"stunServer", required_argument, NULL, 's'},
     {"stunPort", required_argument, NULL, 't'},
     {"webSocketServer", required_argument, NULL, 'w'},
@@ -55,19 +57,28 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
   _program_name += argv[0];
 
   /* default values */
+  _e = false;
+  _n = false;
   _s = "stun.l.google.com";
   _t = 19302;
   _w = "localhost";
   _x = 8000;
-  _e = false;
   _h = false;
   _v = false;
 
   optind = 0;
-  while ((c = getopt_long (argc, argv, "s:t:w:x:ehv", long_options, &optind)) != - 1)
+  while ((c = getopt_long (argc, argv, "s:t:w:x:enhv", long_options, &optind)) != - 1)
     {
       switch (c)
         {
+        case 'e': 
+          _e = true;
+          break;
+
+        case 'n': 
+          _n = true;
+          break;
+
         case 's': 
           _s = optarg;
           break;
@@ -108,10 +119,6 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
             }
           break;
 
-        case 'e': 
-          _e = true;
-          break;
-
         case 'h': 
           _h = true;
           this->usage (EXIT_SUCCESS);
@@ -146,10 +153,12 @@ void Cmdline::usage (int status)
   else
     {
       std::cout << "\
-usage: " << _program_name << " [ -estwxhv ] \n\
+usage: " << _program_name << " [ -enstwxhv ] \n\
 libdatachannel client implementing WebRTC Data Channels with WebSocket signaling\n\
    [ -e ] [ --echo ] (type=FLAG)\n\
           Echo data channel messages back to sender rather than putting to stdout.\n\
+   [ -n ] [ --noStun ] (type=FLAG)\n\
+          Do NOT use a stun server (overrides -s and -t).\n\
    [ -s ] [ --stunServer ] (type=STRING, default=stun.l.google.com)\n\
           Stun server URL or IP address.\n\
    [ -t ] [ --stunPort ] (type=INTEGER, range=0...65535, default=19302)\n\

--- a/examples/client/parse_cl.h
+++ b/examples/client/parse_cl.h
@@ -34,11 +34,12 @@ class Cmdline
 {
 private:
   /* parameters */
+  bool _e;
+  bool _n;
   std::string _s;
   int _t;
   std::string _w;
   int _x;
-  bool _e;
   bool _h;
   bool _v;
 
@@ -60,11 +61,12 @@ public:
   /* return next (non-option) parameter */
   int next_param () { return _optind; }
 
+  bool echoDataChannelMessages () const { return _e; }
+  bool noStun () const { return _n; }
   std::string stunServer () const { return _s; }
   int stunPort () const { return _t; }
   std::string webSocketServer () const { return _w; }
   int webSocketPort () const { return _x; }
-  bool echoDataChannelMessages () const { return _e; }
   bool h () const { return _h; }
   bool v () const { return _v; }
 };


### PR DESCRIPTION
Bonus: removed README file that's not applicable to the updated getopt for Windows now in the client