### PR TITLE
Clarify message size checks

### DIFF
--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -218,6 +218,8 @@ void DataChannel::incoming(message_ptr message) {
 
 	switch (message->type) {
 	case Message::Control: {
+		if (message->size() == 0)
+			break; // Ignore
 		auto raw = reinterpret_cast<const uint8_t *>(message->data());
 		switch (raw[0]) {
 		case MESSAGE_OPEN:

--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -476,8 +476,6 @@ int SctpTransport::handleRecv(struct socket * /*sock*/, union sctp_sockstore /*a
                               const byte *data, size_t len, struct sctp_rcvinfo info, int flags) {
 	try {
 		PLOG_VERBOSE << "Handle recv, len=" << len;
-		if (!len)
-			return 0; // Ignore
 
 		// SCTP_FRAGMENT_INTERLEAVE does not seem to work as expected for messages > 64KB,
 		// therefore partial notifications and messages need to be handled separately.
@@ -497,7 +495,7 @@ int SctpTransport::handleRecv(struct socket * /*sock*/, union sctp_sockstore /*a
 			if (flags & MSG_EOR) {
 				// Message is complete, process it
 				processData(std::move(mPartialMessage), info.rcv_sid,
-				            PayloadId(htonl(info.rcv_ppid)));
+				            PayloadId(ntohl(info.rcv_ppid)));
 				mPartialMessage.clear();
 			}
 		}


### PR DESCRIPTION
This PR changes the convoluted SCTP message size checking by moving it when reading control messages in `DataChannel`.