### PR TITLE
Fix exception on second call to createDataChannel()

### DIFF
--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -102,6 +102,7 @@ void PeerConnection::setLocalDescription() {
 
 	if (std::atomic_load(&mIceTransport)) {
 		PLOG_DEBUG << "Local description is already set, ignoring";
+		return;
 	}
 
 	// RFC 5763: The endpoint that is the offerer MUST use the setup attribute value of

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -125,6 +125,7 @@ void test_connectivity() {
 		}
 	});
 
+	// Wait a bit
 	int attempts = 10;
 	shared_ptr<DataChannel> adc2;
 	while ((!(adc2 = std::atomic_load(&dc2)) || !adc2->isOpen() || !dc1->isOpen()) && attempts--)
@@ -145,6 +146,49 @@ void test_connectivity() {
 		cout << "Local address 2:  " << *addr << endl;
 	if (auto addr = pc2->remoteAddress())
 		cout << "Remote address 2: " << *addr << endl;
+
+	// Try to open a second data channel with another label
+	shared_ptr<DataChannel> second2;
+	pc2->onDataChannel([&second2](shared_ptr<DataChannel> dc) {
+		cout << "Second DataChannel 2: Received with label \"" << dc->label() << "\"" << endl;
+		if (dc->label() != "second") {
+			cerr << "Wrong second DataChannel label" << endl;
+			return;
+		}
+
+		dc->onMessage([](variant<binary, string> message) {
+			if (holds_alternative<string>(message)) {
+				cout << "Second Message 2: " << get<string>(message) << endl;
+			}
+		});
+
+		dc->send("Send hello from 2");
+
+		std::atomic_store(&second2, dc);
+	});
+
+	auto second1 = pc1->createDataChannel("second");
+	second1->onOpen([wsecond1 = make_weak_ptr(dc1)]() {
+		auto second1 = wsecond1.lock();
+		if (!second1)
+			return;
+
+		cout << "Second DataChannel 1: Open" << endl;
+		second1->send("Second hello from 1");
+	});
+	dc1->onMessage([](const variant<binary, string> &message) {
+		if (holds_alternative<string>(message)) {
+			cout << "Second Message 1: " << get<string>(message) << endl;
+		}
+	});
+
+	// Wait a bit
+	attempts = 10;
+	shared_ptr<DataChannel> asecond2;
+	while (
+	    (!(asecond2 = std::atomic_load(&second2)) || !asecond2->isOpen() || !second1->isOpen()) &&
+	    attempts--)
+		this_thread::sleep_for(1s);
 
 	// Delay close of peer 2 to check closing works properly
 	pc1->close();


### PR DESCRIPTION
This PR fixes the `Local description is already set` exception on second call to `createDataChannel()`.
Fixes https://github.com/paullouisageneau/libdatachannel/issues/190

It makes
```
pc->createDataChannel("a");
pc->createDataChannel("b");
```
behave roughly like
```
pc->addDataChannel("a");
pc->addDataChannel("b");
pc->setLocalDescription();
```