### PR TITLE
Fix OpenSSL recv loop quitting too early

### DIFF
--- a/include/rtc/queue.hpp
+++ b/include/rtc/queue.hpp
@@ -38,6 +38,7 @@ public:
 	~Queue();
 
 	void stop();
+	bool running() const;
 	bool empty() const;
 	bool full() const;
 	size_t size() const;   // elements
@@ -78,6 +79,11 @@ template <typename T> void Queue<T>::stop() {
 	mStopping = true;
 	mPopCondition.notify_all();
 	mPushCondition.notify_all();
+}
+
+template <typename T> bool Queue<T>::running() const {
+	std::lock_guard lock(mMutex);
+	return !mQueue.empty() || !mStopping;
 }
 
 template <typename T> bool Queue<T>::empty() const {

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -435,7 +435,7 @@ void DtlsTransport::runRecvLoop() {
 
 		const size_t bufferSize = maxMtu;
 		byte buffer[bufferSize];
-		while (true) {
+		while (mIncomingQueue.running()) {
 			// Process pending messages
 			while (auto next = mIncomingQueue.tryPop()) {
 				message_ptr message = std::move(*next);
@@ -492,8 +492,7 @@ void DtlsTransport::runRecvLoop() {
 				}
 			}
 
-			if (!mIncomingQueue.wait(duration))
-				break; // queue is stopped
+			mIncomingQueue.wait(duration);
 		}
 	} catch (const std::exception &e) {
 		PLOG_ERROR << "DTLS recv: " << e.what();


### PR DESCRIPTION
This PR fixes a regression where the OpenSSL recv loop quits too early due to an mistake with `queue<>::wait()` which now returns `true` only if there is a new element available.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/193