### PR TITLE
Fix null pointer access if the logger is not initialized

### DIFF
--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -60,7 +60,8 @@ IceTransport::IceTransport(const Configuration &config, Description::Role role,
 	}
 
 	juice_log_level_t level;
-	switch (plog::get()->getMaxSeverity()) {
+	auto logger = plog::get();
+	switch (logger ? logger->getMaxSeverity() : plog::none) {
 	case plog::none:
 		level = JUICE_LOG_LEVEL_NONE;
 		break;


### PR DESCRIPTION
This PR fixes a regression in v0.9.1 resulting in a null pointer access if the logger is not initialized.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/195