### PR TITLE
Fix rtcInitLogger to prevent logging multiple times

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -96,7 +96,8 @@ typedef void (*rtcBufferedAmountLowCallbackFunc)(void *ptr);
 typedef void (*rtcAvailableCallbackFunc)(void *ptr);
 
 // Log
-RTC_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb); // NULL cb to log to stdout
+// NULL cb on the first call will log to stdout
+RTC_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb);
 
 // User pointer
 RTC_EXPORT void rtcSetUserPointer(int id, void *ptr);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -199,9 +199,9 @@ class plog_appender : public plog::IAppender {
 public:
 	plog_appender(rtcLogCallbackFunc cb = nullptr) { set_callback(cb); }
 
-	plog_appender(plog_appender &&appender) {
+	plog_appender(plog_appender &&appender) : callback(nullptr) {
 		std::lock_guard lock(appender.callbackMutex);
-		std::exchange(appender.callback, callback);
+		std::swap(appender.callback, callback);
 	}
 
 	void set_callback(rtcLogCallbackFunc cb) {

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -195,16 +195,16 @@ template <typename F> int wrap(F func) {
 		return RTC_ERR_SUCCESS;                                                                    \
 	})
 
-class plog_appender : public plog::IAppender {
+class plogAppender : public plog::IAppender {
 public:
-	plog_appender(rtcLogCallbackFunc cb = nullptr) { set_callback(cb); }
+	plogAppender(rtcLogCallbackFunc cb = nullptr) { setCallback(cb); }
 
-	plog_appender(plog_appender &&appender) : callback(nullptr) {
+	plogAppender(plogAppender &&appender) : callback(nullptr) {
 		std::lock_guard lock(appender.callbackMutex);
 		std::swap(appender.callback, callback);
 	}
 
-	void set_callback(rtcLogCallbackFunc cb) {
+	void setCallback(rtcLogCallbackFunc cb) {
 		std::lock_guard lock(callbackMutex);
 		callback = cb;
 	}
@@ -235,14 +235,14 @@ private:
 } // namespace
 
 void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb) {
-	static std::optional<plog_appender> appender;
+	static std::optional<plogAppender> appender;
 	const auto severity = static_cast<plog::Severity>(level);
 	std::lock_guard lock(mutex);
 	if (appender) {
-		appender->set_callback(cb);
+		appender->setCallback(cb);
 		InitLogger(severity, nullptr); // change the severity
 	} else if (cb) {
-		appender.emplace(plog_appender(cb));
+		appender.emplace(plogAppender(cb));
 		InitLogger(severity, &appender.value());
 	} else {
 		InitLogger(severity, nullptr); // log to stdout

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -199,6 +199,11 @@ class plog_appender : public plog::IAppender {
 public:
 	plog_appender(rtcLogCallbackFunc cb = nullptr) { set_callback(cb); }
 
+	plog_appender(plog_appender &&appender) {
+		std::lock_guard lock(appender.callbackMutex);
+		std::exchange(appender.callback, callback);
+	}
+
 	void set_callback(rtcLogCallbackFunc cb) {
 		std::lock_guard lock(callbackMutex);
 		callback = cb;

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -230,7 +230,8 @@ private:
 
 void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb) {
 	static std::optional<plog_appender> appender;
-	auto severity = static_cast<plog::Severity>(level);
+	const auto severity = static_cast<plog::Severity>(level);
+	std::lock_guard lock(mutex);
 	if (appender) {
 		appender->set_callback(cb);
 		InitLogger(severity, nullptr); // change the severity

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -230,12 +230,16 @@ private:
 
 void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb) {
 	static std::optional<plog_appender> appender;
-	if (appender)
+	auto severity = static_cast<plog::Severity>(level);
+	if (appender) {
 		appender->set_callback(cb);
-	else if (cb)
+		InitLogger(severity, nullptr); // change the severity
+	} else if (cb) {
 		appender.emplace(plog_appender(cb));
-
-	InitLogger(static_cast<plog::Severity>(level), appender ? &appender.value() : nullptr);
+		InitLogger(severity, &appender.value());
+	} else {
+		InitLogger(severity, nullptr); // log to stdout
+	}
 }
 
 void rtcSetUserPointer(int i, void *ptr) { setUserPointer(i, ptr); }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -24,6 +24,8 @@
 #include "plog/Log.h"
 #include "plog/Logger.h"
 
+#include <mutex>
+
 namespace rtc {
 
 void InitLogger(LogLevel level) { InitLogger(static_cast<plog::Severity>(level)); }
@@ -31,6 +33,8 @@ void InitLogger(LogLevel level) { InitLogger(static_cast<plog::Severity>(level))
 void InitLogger(plog::Severity severity, plog::IAppender *appender) {
 	static plog::ColorConsoleAppender<plog::TxtFormatter> consoleAppender;
 	static plog::Logger<0> *logger = nullptr;
+	static std::mutex mutex;
+	std::lock_guard lock(mutex);
 	if (!logger) {
 		logger = &plog::init(severity, appender ? appender : &consoleAppender);
 		PLOG_DEBUG << "Logger initialized";


### PR DESCRIPTION
This PR changes the behavior of `rtcInitLogger()` in C API to allow calling it multiple times to change or unregister the callback.

Should fix https://github.com/paullouisageneau/libdatachannel/issues/200