### PR TITLE
Add CAPI_STDCALL in cmake as an option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,12 @@ option(NO_WEBSOCKET "Disable WebSocket support" OFF)
 option(NO_EXAMPLES "Disable examples" OFF)
 option(NO_TESTS "Disable tests build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
+option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
+
+message("CAPI_STDCALL: ${CAPI_STDCALL}")
+if(CAPI_STDCALL)
+	add_definitions(-DCAPI_STDCALL)
+endif()
 
 if(USE_NICE)
 	option(USE_JUICE "Use libjuice" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,6 @@ option(NO_TESTS "Disable tests build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 
-message("CAPI_STDCALL: ${CAPI_STDCALL}")
-if(CAPI_STDCALL)
-	add_definitions(-DCAPI_STDCALL)
-endif()
-
 if(USE_NICE)
 	option(USE_JUICE "Use libjuice" OFF)
 else()
@@ -221,6 +216,11 @@ else()
 	target_compile_definitions(datachannel-static PRIVATE USE_NICE=0)
 	target_link_libraries(datachannel PRIVATE LibJuice::LibJuiceStatic)
 	target_link_libraries(datachannel-static PRIVATE LibJuice::LibJuiceStatic)
+endif()
+
+if(CAPI_STDCALL)
+	target_compile_definitions(datachannel PUBLIC CAPI_STDCALL)
+	target_compile_definitions(datachannel-static PUBLIC CAPI_STDCALL)
 endif()
 
 add_library(LibDataChannel::LibDataChannel ALIAS datachannel)

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -29,6 +29,12 @@ extern "C" {
 #define RTC_EXPORT
 #endif
 
+#ifdef CAPI_STDCALL
+#define RTC_API __stdcall
+#else
+#define RTC_API
+#endif
+
 #ifndef RTC_ENABLE_WEBSOCKET
 #define RTC_ENABLE_WEBSOCKET 1
 #endif
@@ -81,19 +87,19 @@ typedef struct {
 	unsigned int maxRetransmits;    // ignored if reliable
 } rtcReliability;
 
-typedef void (*rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
-typedef void (*rtcDescriptionCallbackFunc)(const char *sdp, const char *type, void *ptr);
-typedef void (*rtcCandidateCallbackFunc)(const char *cand, const char *mid, void *ptr);
-typedef void (*rtcStateChangeCallbackFunc)(rtcState state, void *ptr);
-typedef void (*rtcGatheringStateCallbackFunc)(rtcGatheringState state, void *ptr);
-typedef void (*rtcDataChannelCallbackFunc)(int dc, void *ptr);
-typedef void (*rtcTrackCallbackFunc)(int tr, void *ptr);
-typedef void (*rtcOpenCallbackFunc)(void *ptr);
-typedef void (*rtcClosedCallbackFunc)(void *ptr);
-typedef void (*rtcErrorCallbackFunc)(const char *error, void *ptr);
-typedef void (*rtcMessageCallbackFunc)(const char *message, int size, void *ptr);
-typedef void (*rtcBufferedAmountLowCallbackFunc)(void *ptr);
-typedef void (*rtcAvailableCallbackFunc)(void *ptr);
+typedef void (RTC_API *rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
+typedef void (RTC_API *rtcDescriptionCallbackFunc)(const char *sdp, const char *type, void *ptr);
+typedef void (RTC_API *rtcCandidateCallbackFunc)(const char *cand, const char *mid, void *ptr);
+typedef void (RTC_API *rtcStateChangeCallbackFunc)(rtcState state, void *ptr);
+typedef void (RTC_API *rtcGatheringStateCallbackFunc)(rtcGatheringState state, void *ptr);
+typedef void (RTC_API *rtcDataChannelCallbackFunc)(int dc, void *ptr);
+typedef void (RTC_API *rtcTrackCallbackFunc)(int tr, void *ptr);
+typedef void (RTC_API *rtcOpenCallbackFunc)(void *ptr);
+typedef void (RTC_API *rtcClosedCallbackFunc)(void *ptr);
+typedef void (RTC_API *rtcErrorCallbackFunc)(const char *error, void *ptr);
+typedef void (RTC_API *rtcMessageCallbackFunc)(const char *message, int size, void *ptr);
+typedef void (RTC_API *rtcBufferedAmountLowCallbackFunc)(void *ptr);
+typedef void (RTC_API *rtcAvailableCallbackFunc)(void *ptr);
 
 // Log
 RTC_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb); // NULL cb to log to stdout


### PR DESCRIPTION
This option is to turn the calling convention of C API callback functions to __stdcall.

The reason this is needed, in short, is because Unity follows __stdcall even in Windows.

To elaborate this is needed is because of Unity's atypical behavior. In their effort to support many platforms, they decided to stick to __stdcall as their default calling convention for native plugins, not __cdecl, which is the default calling convention of Windows. While this discrepancy can be overcome by providing the calling convention information to C# APIs inside Unity in typical cases of calling native functions, this is not the case when a C# method becomes a callback. To make a C# method as a native function pointer, with Unity's own transpiling backend (C# -> C++), the callback C# method needs to have MonoPInvokeCallback as an attribute. Unfortunately, this attribute lacks ability to pick a calling convention and assumes __stdcall. Since this does not matches with the calling convention of C in Windows (i.e., __cdecl), any call of a callback crashes the application.

As the commit has a large space to improve, feel free to fix it! I won't have any problem as long as there is a way to set the calling convention for the callbacks.