### PR TITLE
Add rtcGetLocalDescriptionSdp() as a C API

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -121,6 +121,8 @@ RTC_EXPORT int rtcSetLocalDescription(int pc);
 RTC_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
 RTC_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid);
 
+RTC_EXPORT int rtcGetLocalDescriptionSdp(int pc, char *buffer, int size);
+
 RTC_EXPORT int rtcGetLocalAddress(int pc, char *buffer, int size);
 RTC_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -529,6 +529,27 @@ int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid) {
 	});
 }
 
+int rtcGetLocalDescriptionSdp(int pc, char *buffer, int size) {
+	return WRAP({
+		auto peerConnection = getPeerConnection(pc);
+
+		if (size <= 0)
+			return 0;
+
+		if (!buffer)
+			throw std::invalid_argument("Unexpected null pointer for buffer");
+
+		if (auto desc = peerConnection->localDescription()) {
+			auto sdp = string(*desc);
+			const char *data = sdp.data();
+			size = std::min(size - 1, int(sdp.size()));
+			std::copy(data, data + size, buffer);
+			buffer[size] = '\0';
+			return size + 1;
+		}
+	});
+}
+
 int rtcGetLocalAddress(int pc, char *buffer, int size) {
 	return WRAP({
 		auto peerConnection = getPeerConnection(pc);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -547,6 +547,8 @@ int rtcGetLocalDescriptionSdp(int pc, char *buffer, int size) {
 			buffer[size] = '\0';
 			return size + 1;
 		}
+
+		return RTC_ERR_FAILURE;
 	});
 }
 


### PR DESCRIPTION
Thanks a lot for keep quickly applying the stuff I submit here.

WebRTC requires setting a description before candidates for it. When sending the description and candidates whenever they are found, in a networked scenario, this means that there needs to be a buffer for candidates from the side the receives the description and candidates as there is often no guarantee that packets sent will arrive in the order they were sent.

An approach that I would much more prefer than having a candidate buffer is sending a SDP message that includes a description with all candidates inside it, as demonstrated in /examples/media. This addition of an API allows this approach.

I am not sure whether gathering candidates can take a long time, but from my experience, they tend to happen almost immediately; There is no feasible reason to hurry sending an incomplete description.