### PR TITLE
Support CMake versions <= 3.8.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 project(libdatachannel
 	VERSION 0.9.4
 	LANGUAGES CXX)
-set(DESCRIPTION "WebRTC Data Channels Library")
+set(PROJECT_DESCRIPTION "WebRTC Data Channels Library")
 
 # Options
 option(USE_GNUTLS "Use GnuTLS instead of OpenSSL" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.7)
 project(libdatachannel
-	DESCRIPTION "WebRTC Data Channels Library"
 	VERSION 0.9.4
 	LANGUAGES CXX)
+set(DESCRIPTION "WebRTC Data Channels Library")
 
 # Options
 option(USE_GNUTLS "Use GnuTLS instead of OpenSSL" OFF)


### PR DESCRIPTION
Needed for Debian 9 (Stretch, supported until 2022) where cmake version is 3.7.2.  Doesn't seem to break anything on Ubuntu 20.