### PR TITLE
Allow updating local track description

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -94,8 +94,7 @@ public:
 	struct Application : public Entry {
 	public:
 		Application(string mid = "data");
-		Application(const Application &other) = default;
-		Application(Application &&other) = default;
+		virtual ~Application() = default;
 
 		string description() const override;
 		Application reciprocate() const;
@@ -121,8 +120,6 @@ public:
 	public:
 		Media(const string &sdp);
 		Media(const string &mline, string mid, Direction dir = Direction::SendOnly);
-		Media(const Media &other) = default;
-		Media(Media &&other) = default;
 		virtual ~Media() = default;
 
 		string description() const override;

--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -43,6 +43,8 @@ public:
 	string mid() const;
 	Description::Media description() const;
 
+	void setDescription(Description::Media description);
+
 	void close(void) override;
 	bool send(message_variant data) override;
 	bool send(const byte *data, size_t size);

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -33,6 +33,9 @@ string Track::mid() const { return mMediaDescription.mid(); }
 Description::Media Track::description() const { return mMediaDescription; }
 
 void Track::setDescription(Description::Media description) {
+	if(description.mid() != mMediaDescription.mid())
+		throw std::logic_error("Media description mid does not match track mid");
+
 	mMediaDescription = std::move(description);
 }
 

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -32,6 +32,10 @@ string Track::mid() const { return mMediaDescription.mid(); }
 
 Description::Media Track::description() const { return mMediaDescription; }
 
+void Track::setDescription(Description::Media description) {
+	mMediaDescription = std::move(description);
+}
+
 void Track::close() {
 	mIsClosed = true;
 	resetCallbacks();


### PR DESCRIPTION
This PR allows updating the local track description with `Track::setDescription()` or `PeerConnection::addTrack()`, which will be picked up during the following negotiation.