### PR TITLE
Fix regressions with answers after renegociation

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -778,7 +778,7 @@ Description::Type Description::stringToType(const string &typeString) {
 	using TypeMap_t = std::unordered_map<string, Type>;
 	static const TypeMap_t TypeMap = {{"unspec", Type::Unspec},
 	                                  {"offer", Type::Offer},
-	                                  {"answer", Type::Pranswer},
+	                                  {"answer", Type::Answer},
 	                                  {"pranswer", Type::Pranswer},
 	                                  {"rollback", Type::Rollback}};
 	auto it = TypeMap.find(typeString);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -907,6 +907,7 @@ void PeerConnection::processLocalDescription(Description description) {
 					        }
 					        return;
 				        }
+				        lock.unlock(); // we are going to call incomingTrack()
 
 				        auto reciprocated = remoteMedia->reciprocate();
 #if !RTC_ENABLE_MEDIA


### PR DESCRIPTION
Fix two regressions introduced by #226 and #228 :
- Deadlock when reciprocating locally existing track
- "answer" string type mapping to `Type::Pranswer`