### PR TITLE
Out-of-band negotiated Data Channels

### DIFF
--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -42,6 +42,7 @@ public:
 	            string protocol, Reliability reliability);
 	virtual ~DataChannel();
 
+	uint16_t id() const;
 	unsigned int stream() const;
 	string label() const;
 	string protocol() const;

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -38,12 +38,12 @@ class PeerConnection;
 
 class DataChannel : public std::enable_shared_from_this<DataChannel>, public Channel {
 public:
-	DataChannel(std::weak_ptr<PeerConnection> pc, unsigned int stream, string label,
+	DataChannel(std::weak_ptr<PeerConnection> pc, uint16_t stream, string label,
 	            string protocol, Reliability reliability);
 	virtual ~DataChannel();
 
+	uint16_t stream() const;
 	uint16_t id() const;
-	unsigned int stream() const;
 	string label() const;
 	string protocol() const;
 	Reliability reliability() const;
@@ -73,7 +73,7 @@ protected:
 	const std::weak_ptr<PeerConnection> mPeerConnection;
 	std::weak_ptr<SctpTransport> mSctpTransport;
 
-	unsigned int mStream;
+	uint16_t mStream;
 	string mLabel;
 	string mProtocol;
 	std::shared_ptr<Reliability> mReliability;
@@ -89,10 +89,10 @@ private:
 
 class NegociatedDataChannel final : public DataChannel {
 public:
-	NegociatedDataChannel(std::weak_ptr<PeerConnection> pc, unsigned int stream, string label,
+	NegociatedDataChannel(std::weak_ptr<PeerConnection> pc, uint16_t stream, string label,
 	            string protocol, Reliability reliability);
 	NegociatedDataChannel(std::weak_ptr<PeerConnection> pc, std::weak_ptr<SctpTransport> transport,
-	            unsigned int stream);
+	            uint16_t stream);
 	~NegociatedDataChannel();
 
 private:

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -178,7 +178,7 @@ private:
 	std::shared_ptr<DtlsTransport> mDtlsTransport;
 	std::shared_ptr<SctpTransport> mSctpTransport;
 
-	std::unordered_map<unsigned int, std::weak_ptr<DataChannel>> mDataChannels; // by stream ID
+	std::unordered_map<uint16_t, std::weak_ptr<DataChannel>> mDataChannels;     // by stream ID
 	std::unordered_map<string, std::weak_ptr<Track>> mTracks;                   // by mid
 	std::shared_mutex mDataChannelsMutex, mTracksMutex;
 

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -52,9 +52,9 @@ using future_certificate_ptr = std::shared_future<certificate_ptr>;
 
 struct DataChannelInit {
 	Reliability reliability = {};
-	string protocol = "";
 	bool negociated = false;
 	std::optional<uint16_t> id = nullopt;
+	string protocol = "";
 };
 
 class PeerConnection final : public std::enable_shared_from_this<PeerConnection> {

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -135,7 +135,8 @@ private:
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
 
 	std::shared_ptr<DataChannel> emplaceDataChannel(Description::Role role, string label,
-	                                                string protocol, Reliability reliability);
+	                                                string protocol, Reliability reliability,
+	                                                std::optional<unsigned int> stream = nullopt);
 	std::shared_ptr<DataChannel> findDataChannel(uint16_t stream);
 	void iterateDataChannels(std::function<void(std::shared_ptr<DataChannel> channel)> func);
 	void openDataChannels();

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -52,7 +52,7 @@ using future_certificate_ptr = std::shared_future<certificate_ptr>;
 
 struct DataChannelInit {
 	Reliability reliability = {};
-	bool negociated = false;
+	bool negotiated = false;
 	std::optional<uint16_t> id = nullopt;
 	string protocol = "";
 };

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -50,6 +50,13 @@ class SctpTransport;
 using certificate_ptr = std::shared_ptr<Certificate>;
 using future_certificate_ptr = std::shared_future<certificate_ptr>;
 
+struct DataChannelInit {
+	Reliability reliability = {};
+	string protocol = "";
+	bool negociated = false;
+	std::optional<uint16_t> id = nullopt;
+};
+
 class PeerConnection final : public std::enable_shared_from_this<PeerConnection> {
 public:
 	enum class State : int {
@@ -98,12 +105,10 @@ public:
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 
-	std::shared_ptr<DataChannel> addDataChannel(string label, string protocol = "",
-	                                            Reliability reliability = {});
+	std::shared_ptr<DataChannel> addDataChannel(string label, DataChannelInit init = {});
 
 	// Equivalent to calling addDataChannel() and setLocalDescription()
-	std::shared_ptr<DataChannel> createDataChannel(string label, string protocol = "",
-	                                               Reliability reliability = {});
+	std::shared_ptr<DataChannel> createDataChannel(string label, DataChannelInit init = {});
 
 	void onDataChannel(std::function<void(std::shared_ptr<DataChannel> dataChannel)> callback);
 	void onLocalDescription(std::function<void(Description description)> callback);
@@ -135,8 +140,7 @@ private:
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
 
 	std::shared_ptr<DataChannel> emplaceDataChannel(Description::Role role, string label,
-	                                                string protocol, Reliability reliability,
-	                                                std::optional<unsigned int> stream = nullopt);
+	                                                DataChannelInit init);
 	std::shared_ptr<DataChannel> findDataChannel(uint16_t stream);
 	void iterateDataChannels(std::function<void(std::shared_ptr<DataChannel> channel)> func);
 	void openDataChannels();

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -106,10 +106,8 @@ typedef struct {
 } rtcDataChannelInit;
 
 typedef void(RTC_API *rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
-typedef void(RTC_API *rtcDescriptionCallbackFunc)(int pc, const char *sdp, const char *type,
-                                                  void *ptr);
-typedef void(RTC_API *rtcCandidateCallbackFunc)(int pc, const char *cand, const char *mid,
-                                                void *ptr);
+typedef void(RTC_API *rtcDescriptionCallbackFunc)(int pc, const char *sdp, const char *type, void *ptr);
+typedef void(RTC_API *rtcCandidateCallbackFunc)(int pc, const char *cand, const char *mid, void *ptr);
 typedef void(RTC_API *rtcStateChangeCallbackFunc)(int pc, rtcState state, void *ptr);
 typedef void(RTC_API *rtcGatheringStateCallbackFunc)(int pc, rtcGatheringState state, void *ptr);
 typedef void(RTC_API *rtcSignalingStateCallbackFunc)(int pc, rtcSignalingState state, void *ptr);

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -100,7 +100,7 @@ typedef struct {
 typedef struct {
 	rtcReliability reliability;
 	const char *protocol; // empty string if NULL
-	bool negociated;
+	bool negotiated;
 	bool manualId;
 	uint16_t id; // ignored if manualId is false
 } rtcDataChannelInit;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -97,20 +97,30 @@ typedef struct {
 	unsigned int maxRetransmits;    // ignored if reliable
 } rtcReliability;
 
-typedef void (RTC_API *rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
-typedef void (RTC_API *rtcDescriptionCallbackFunc)(int pc, const char *sdp, const char *type, void *ptr);
-typedef void (RTC_API *rtcCandidateCallbackFunc)(int pc, const char *cand, const char *mid, void *ptr);
-typedef void (RTC_API *rtcStateChangeCallbackFunc)(int pc, rtcState state, void *ptr);
-typedef void (RTC_API *rtcGatheringStateCallbackFunc)(int pc, rtcGatheringState state, void *ptr);
-typedef void (RTC_API *rtcSignalingStateCallbackFunc)(int pc, rtcSignalingState state, void *ptr);
-typedef void (RTC_API *rtcDataChannelCallbackFunc)(int pc, int dc, void *ptr);
-typedef void (RTC_API *rtcTrackCallbackFunc)(int pc, int tr, void *ptr);
-typedef void (RTC_API *rtcOpenCallbackFunc)(int id, void *ptr);
-typedef void (RTC_API *rtcClosedCallbackFunc)(int id, void *ptr);
-typedef void (RTC_API *rtcErrorCallbackFunc)(int id, const char *error, void *ptr);
-typedef void (RTC_API *rtcMessageCallbackFunc)(int id, const char *message, int size, void *ptr);
-typedef void (RTC_API *rtcBufferedAmountLowCallbackFunc)(int id, void *ptr);
-typedef void (RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
+typedef struct {
+	rtcReliability reliability;
+	const char *protocol; // empty string if NULL
+	bool negociated;
+	bool manualId;
+	uint16_t id; // ignored if manualId is false
+} rtcDataChannelInit;
+
+typedef void(RTC_API *rtcLogCallbackFunc)(rtcLogLevel level, const char *message);
+typedef void(RTC_API *rtcDescriptionCallbackFunc)(int pc, const char *sdp, const char *type,
+                                                  void *ptr);
+typedef void(RTC_API *rtcCandidateCallbackFunc)(int pc, const char *cand, const char *mid,
+                                                void *ptr);
+typedef void(RTC_API *rtcStateChangeCallbackFunc)(int pc, rtcState state, void *ptr);
+typedef void(RTC_API *rtcGatheringStateCallbackFunc)(int pc, rtcGatheringState state, void *ptr);
+typedef void(RTC_API *rtcSignalingStateCallbackFunc)(int pc, rtcSignalingState state, void *ptr);
+typedef void(RTC_API *rtcDataChannelCallbackFunc)(int pc, int dc, void *ptr);
+typedef void(RTC_API *rtcTrackCallbackFunc)(int pc, int tr, void *ptr);
+typedef void(RTC_API *rtcOpenCallbackFunc)(int id, void *ptr);
+typedef void(RTC_API *rtcClosedCallbackFunc)(int id, void *ptr);
+typedef void(RTC_API *rtcErrorCallbackFunc)(int id, const char *error, void *ptr);
+typedef void(RTC_API *rtcMessageCallbackFunc)(int id, const char *message, int size, void *ptr);
+typedef void(RTC_API *rtcBufferedAmountLowCallbackFunc)(int id, void *ptr);
+typedef void(RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
 
 // Log
 // NULL cb on the first call will log to stdout
@@ -139,17 +149,18 @@ RTC_EXPORT int rtcGetRemoteDescription(int pc, char *buffer, int size);
 RTC_EXPORT int rtcGetLocalAddress(int pc, char *buffer, int size);
 RTC_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
 
-RTC_EXPORT int rtcGetSelectedCandidatePair(int pc, char *local, int localSize, char *remote, int remoteSize);
+RTC_EXPORT int rtcGetSelectedCandidatePair(int pc, char *local, int localSize, char *remote,
+                                           int remoteSize);
 
 // DataChannel
 RTC_EXPORT int rtcSetDataChannelCallback(int pc, rtcDataChannelCallbackFunc cb);
 RTC_EXPORT int rtcAddDataChannel(int pc, const char *label); // returns dc id
-RTC_EXPORT int rtcAddDataChannelExt(int pc, const char *label, const char *protocol,
-                                    const rtcReliability *reliability); // returns dc id
+RTC_EXPORT int rtcAddDataChannelExt(int pc, const char *label,
+                                    const rtcDataChannelInit *init); // returns dc id
 // Equivalent to calling rtcAddDataChannel() and rtcSetLocalDescription()
 RTC_EXPORT int rtcCreateDataChannel(int pc, const char *label); // returns dc id
-RTC_EXPORT int rtcCreateDataChannelExt(int pc, const char *label, const char *protocol,
-                                       const rtcReliability *reliability); // returns dc id
+RTC_EXPORT int rtcCreateDataChannelExt(int pc, const char *label,
+                                       const rtcDataChannelInit *init); // returns dc id
 RTC_EXPORT int rtcDeleteDataChannel(int dc);
 
 RTC_EXPORT int rtcGetDataChannelLabel(int dc, char *buffer, int size);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -328,7 +328,10 @@ int rtcAddDataChannelExt(int pc, const char *label, const char *protocol,
 		}
 		auto peerConnection = getPeerConnection(pc);
 		int dc = emplaceDataChannel(peerConnection->addDataChannel(
-		    string(label ? label : ""), string(protocol ? protocol : ""), r));
+		    string(label ? label : ""), {.reliability = std::move(r),
+		                                 .protocol = protocol ? protocol : "",
+		                                 .negociated = false,
+		                                 .id = nullopt}));
 		if (auto ptr = getUserPointer(pc))
 			rtcSetUserPointer(dc, *ptr);
 		return dc;
@@ -610,11 +613,11 @@ int rtcGetSelectedCandidatePair(int pc, char *local, int localSize, char *remote
 			return RTC_ERR_NOT_AVAIL;
 
 		int localRet = copyAndReturn(string(localCand), local, localSize);
-		if(localRet < 0)
+		if (localRet < 0)
 			return localRet;
 
 		int remoteRet = copyAndReturn(string(remoteCand), remote, remoteSize);
-		if(remoteRet < 0)
+		if (remoteRet < 0)
 			return remoteRet;
 
 		return std::max(localRet, remoteRet);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -331,9 +331,9 @@ int rtcAddDataChannelExt(int pc, const char *label, const rtcDataChannelInit *in
 		int dc = emplaceDataChannel(peerConnection->addDataChannel(
 		    string(label ? label : ""),
 		    {.reliability = std::move(r),
-		     .protocol = init && init->protocol ? init->protocol : "",
 		     .negociated = init ? init->negociated : false,
-		     .id = init && init->manualId ? std::make_optional(init->id) : nullopt}));
+		     .id = init && init->manualId ? std::make_optional(init->id) : nullopt,
+		     .protocol = init && init->protocol ? init->protocol : ""}));
 
 		if (auto ptr = getUserPointer(pc))
 			rtcSetUserPointer(dc, *ptr);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -326,7 +326,7 @@ int rtcAddDataChannelExt(int pc, const char *label, const rtcDataChannelInit *in
 				dci.reliability.type = Reliability::Type::Reliable;
 			}
 
-			dci.negociated = init->negociated;
+			dci.negotiated = init->negotiated;
 			dci.id = init->manualId ? std::make_optional(init->id) : nullopt;
 			dci.protocol = init->protocol ? init->protocol : "";
 		}

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -170,7 +170,7 @@ void DataChannel::open(shared_ptr<SctpTransport> transport) {
 }
 
 void DataChannel::processOpenMessage(message_ptr) {
-	PLOG_WARNING << "Received an open message for a user-negociated DataChannel, ignoring";
+	PLOG_WARNING << "Received an open message for a user-negotiated DataChannel, ignoring";
 }
 
 bool DataChannel::outgoing(message_ptr message) {

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -72,7 +72,7 @@ struct CloseMessage {
 };
 #pragma pack(pop)
 
-DataChannel::DataChannel(weak_ptr<PeerConnection> pc, unsigned int stream, string label,
+DataChannel::DataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
                          string protocol, Reliability reliability)
     : mPeerConnection(pc), mStream(stream), mLabel(std::move(label)),
       mProtocol(std::move(protocol)),
@@ -81,9 +81,9 @@ DataChannel::DataChannel(weak_ptr<PeerConnection> pc, unsigned int stream, strin
 
 DataChannel::~DataChannel() { close(); }
 
-uint16_t DataChannel::id() const { return uint16_t(mStream); }
+uint16_t DataChannel::stream() const { return mStream; }
 
-unsigned int DataChannel::stream() const { return mStream; }
+uint16_t DataChannel::id() const { return uint16_t(mStream); }
 
 string DataChannel::label() const { return mLabel; }
 
@@ -230,13 +230,13 @@ void DataChannel::incoming(message_ptr message) {
 	}
 }
 
-NegociatedDataChannel::NegociatedDataChannel(std::weak_ptr<PeerConnection> pc, unsigned int stream,
+NegociatedDataChannel::NegociatedDataChannel(std::weak_ptr<PeerConnection> pc, uint16_t stream,
                                              string label, string protocol, Reliability reliability)
     : DataChannel(pc, stream, std::move(label), std::move(protocol), std::move(reliability)) {}
 
 NegociatedDataChannel::NegociatedDataChannel(std::weak_ptr<PeerConnection> pc,
                                              std::weak_ptr<SctpTransport> transport,
-                                             unsigned int stream)
+                                             uint16_t stream)
     : DataChannel(pc, stream, "", "", {}) {
 	mSctpTransport = transport;
 }

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -81,6 +81,8 @@ DataChannel::DataChannel(weak_ptr<PeerConnection> pc, unsigned int stream, strin
 
 DataChannel::~DataChannel() { close(); }
 
+uint16_t DataChannel::id() const { return uint16_t(mStream); }
+
 unsigned int DataChannel::stream() const { return mStream; }
 
 string DataChannel::label() const { return mLabel; }

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -751,9 +751,9 @@ shared_ptr<DataChannel> PeerConnection::emplaceDataChannel(Description::Role rol
 			stream += 2;
 		}
 	}
-	// If the DataChannel is user-negociated, do not negociate it here
+	// If the DataChannel is user-negotiated, do not negociate it here
 	auto channel =
-	    init.negociated
+	    init.negotiated
 	        ? std::make_shared<DataChannel>(shared_from_this(), stream, std::move(label),
 	                                        std::move(init.protocol), std::move(init.reliability))
 	        : std::make_shared<NegociatedDataChannel>(shared_from_this(), stream, std::move(label),

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -738,7 +738,7 @@ shared_ptr<DataChannel> PeerConnection::emplaceDataChannel(Description::Role rol
 	if (init.id) {
 		stream = *init.id;
 		if (stream == 65535)
-			throw std::runtime_error("Invalid DataChannel id");
+			throw std::invalid_argument("Invalid DataChannel id");
 	} else {
 		// The active side must use streams with even identifiers, whereas the passive side must use
 		// streams with odd identifiers.

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -212,10 +212,11 @@ void test_connectivity() {
 		throw runtime_error("Second DataChannel is not open");
 
 	// Try to open a negociated channel
-	auto negociated1 =
-	    pc1->createDataChannel("negociated", {.reliability = {}, .negociated = true, .id = 42});
-	auto negociated2 =
-	    pc2->createDataChannel("negoctated", {.reliability = {}, .negociated = true, .id = 42});
+	DataChannelInit init;
+	init.negociated = true;
+	init.id = 42;
+	auto negociated1 = pc1->createDataChannel("negociated", init);
+	auto negociated2 = pc2->createDataChannel("negoctated", init);
 
 	if (!negociated1->isOpen() || !negociated2->isOpen())
 		throw runtime_error("Negociated DataChannel is not open");

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -211,25 +211,25 @@ void test_connectivity() {
 	if (!asecond2 || !asecond2->isOpen() || !second1->isOpen())
 		throw runtime_error("Second DataChannel is not open");
 
-	// Try to open a negociated channel
+	// Try to open a negotiated channel
 	DataChannelInit init;
-	init.negociated = true;
+	init.negotiated = true;
 	init.id = 42;
-	auto negociated1 = pc1->createDataChannel("negociated", init);
-	auto negociated2 = pc2->createDataChannel("negoctated", init);
+	auto negotiated1 = pc1->createDataChannel("negotiated", init);
+	auto negotiated2 = pc2->createDataChannel("negoctated", init);
 
-	if (!negociated1->isOpen() || !negociated2->isOpen())
+	if (!negotiated1->isOpen() || !negotiated2->isOpen())
 		throw runtime_error("Negociated DataChannel is not open");
 
 	std::atomic<bool> received = false;
-	negociated2->onMessage([&received](const variant<binary, string> &message) {
+	negotiated2->onMessage([&received](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {
 			cout << "Second Message 2: " << get<string>(message) << endl;
 			received = true;
 		}
 	});
 
-	negociated1->send("Hello from negociated channel");
+	negotiated1->send("Hello from negotiated channel");
 
 	// Wait a bit
 	attempts = 5;

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -212,10 +212,12 @@ void test_connectivity() {
 		throw runtime_error("Second DataChannel is not open");
 
 	// Try to open a negociated channel
-	auto negociated1 = pc1->createDataChannel("negociated", {.negociated = true, .id = 42});
-	auto negociated2 = pc2->createDataChannel("negoctated", {.negociated = true, .id = 42});
+	auto negociated1 =
+	    pc1->createDataChannel("negociated", {.reliability = {}, .negociated = true, .id = 42});
+	auto negociated2 =
+	    pc2->createDataChannel("negoctated", {.reliability = {}, .negociated = true, .id = 42});
 
-	if(!negociated1->isOpen() || !negociated2->isOpen())
+	if (!negociated1->isOpen() || !negociated2->isOpen())
 		throw runtime_error("Negociated DataChannel is not open");
 
 	std::atomic<bool> received = false;

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -133,7 +133,7 @@ void test_track() {
 		this_thread::sleep_for(1s);
 
 	if (!at2 || !at2->isOpen() || !t1->isOpen())
-		throw runtime_error("Renegociated track is not open");
+		throw runtime_error("Renegotiated track is not open");
 
 	// TODO: Test sending RTP packets in track
 


### PR DESCRIPTION
This PR implements out-of-band negotiated Data Channels. The signature of `DataChannel::createDataChannel()` and  `rtcAddDataChannelExt()` have been modified in accordance.

Resolves https://github.com/paullouisageneau/libdatachannel/issues/233