### PR TITLE
Fix DSCP for tracks

### DIFF
--- a/include/rtc/message.hpp
+++ b/include/rtc/message.hpp
@@ -43,7 +43,7 @@ struct RTC_CPP_EXPORT Message : binary {
 
 	Type type;
 	unsigned int stream = 0; // Stream id (SCTP stream or SSRC)
-	int dscp = 0;            // Differentiated Services Code Point
+	unsigned int dscp = 0;   // Differentiated Services Code Point
 	std::shared_ptr<Reliability> reliability;
 };
 

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -80,14 +80,10 @@ public:
 	void setTimestamp(uint32_t i) { _timestamp = htonl(i); }
 
 	void log() {
-		PLOG_VERBOSE  << "RTP V: " << (int) version()
-		            << " P: " << (padding() ? "P" : " ")
-		            << " X: " << (extension() ? "X" : " ")
-		            << " CC: "  << (int) csrcCount()
-		            << " M: " << (marker() ? "M" : " ")
-		            << " PT: " << (int) payloadType()
-		            << " SEQNO: " << seqNumber()
-		            << " TS: " << timestamp();
+		PLOG_VERBOSE << "RTP V: " << (int)version() << " P: " << (padding() ? "P" : " ")
+		             << " X: " << (extension() ? "X" : " ") << " CC: " << (int)csrcCount()
+		             << " M: " << (marker() ? "M" : " ") << " PT: " << (int)payloadType()
+		             << " SEQNO: " << seqNumber() << " TS: " << timestamp();
 	}
 };
 
@@ -199,9 +195,9 @@ public:
 
 	inline void log() const {
 		PLOG_VERBOSE << "RTCP header: "
-		          << "version=" << unsigned(version()) << ", padding=" << padding()
-		          << ", reportCount=" << unsigned(reportCount())
-		          << ", payloadType=" << unsigned(payloadType()) << ", length=" << length();
+		             << "version=" << unsigned(version()) << ", padding=" << padding()
+		             << ", reportCount=" << unsigned(reportCount())
+		             << ", payloadType=" << unsigned(payloadType()) << ", length=" << length();
 	}
 };
 
@@ -428,7 +424,7 @@ public:
 
 public:
 	void preparePacket(SSRC ssrc, unsigned int discreteSeqNoCount) {
-		header.header.prepareHeader(205, 1, 2 + static_cast<uint16_t>(discreteSeqNoCount));
+		header.header.prepareHeader(205, 1, 2 + uint16_t(discreteSeqNoCount));
 		header.setMediaSourceSSRC(ssrc);
 		header.setPacketSenderSSRC(ssrc);
 	}

--- a/src/dtlssrtptransport.cpp
+++ b/src/dtlssrtptransport.cpp
@@ -142,8 +142,13 @@ bool DtlsSrtpTransport::sendMedia(message_ptr message) {
 
 	message->resize(size);
 
-	// DSCP is set by Track according to the type
-	return outgoing(message);
+	if (message->dscp == 0) { // Track might override the value
+		// Set recommended medium-priority DSCP value
+		// See https://tools.ietf.org/html/draft-ietf-tsvwg-rtcweb-qos-18
+		message->dscp = 36; // AF42: Assured Forwarding class 4, medium drop probability
+	}
+
+	return Transport::outgoing(message); // bypass DTLS DSCP marking
 }
 
 void DtlsSrtpTransport::incoming(message_ptr message) {

--- a/src/dtlstransport.cpp
+++ b/src/dtlstransport.cpp
@@ -145,7 +145,9 @@ void DtlsTransport::incoming(message_ptr message) {
 }
 
 bool DtlsTransport::outgoing(message_ptr message) {
-	message->dscp = mCurrentDscp;
+	if (message->dscp == 0)
+		message->dscp = mCurrentDscp;
+
 	return Transport::outgoing(std::move(message));
 }
 
@@ -427,7 +429,9 @@ void DtlsTransport::incoming(message_ptr message) {
 }
 
 bool DtlsTransport::outgoing(message_ptr message) {
-	message->dscp = mCurrentDscp;
+	if (message->dscp == 0)
+		message->dscp = mCurrentDscp;
+
 	return Transport::outgoing(std::move(message));
 }
 

--- a/src/dtlstransport.hpp
+++ b/src/dtlstransport.hpp
@@ -63,7 +63,7 @@ protected:
 
 	Queue<message_ptr> mIncomingQueue;
 	std::thread mRecvThread;
-	std::atomic<int> mCurrentDscp;
+	std::atomic<unsigned int> mCurrentDscp;
 
 #if USE_GNUTLS
 	gnutls_session_t mSession;

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -223,7 +223,7 @@ bool IceTransport::send(message_ptr message) {
 
 bool IceTransport::outgoing(message_ptr message) {
 	// Explicit Congestion Notification takes the least-significant 2 bits of the DS field
-	int ds = message->dscp << 2;
+	int ds = int(message->dscp << 2);
 	return juice_send_diffserv(mAgent.get(), reinterpret_cast<const char *>(message->data()),
 	                           message->size(), ds) >= 0;
 }
@@ -623,7 +623,7 @@ bool IceTransport::outgoing(message_ptr message) {
 	if (mOutgoingDscp != message->dscp) {
 		mOutgoingDscp = message->dscp;
 		// Explicit Congestion Notification takes the least-significant 2 bits of the DS field
-		int ds = message->dscp << 2;
+		int ds = int(message->dscp << 2);
 		nice_agent_set_stream_tos(mNiceAgent.get(), mStreamId, ds); // ToS is the legacy name for DS
 	}
 	return nice_agent_send(mNiceAgent.get(), mStreamId, 1, message->size(),

--- a/src/icetransport.hpp
+++ b/src/icetransport.hpp
@@ -101,7 +101,7 @@ private:
 	std::thread mMainLoopThread;
 	guint mTimeoutId = 0;
 	std::mutex mOutgoingMutex;
-	int mOutgoingDscp;
+	unsigned int mOutgoingDscp;
 
 	static string AddressToString(const NiceAddress &addr);
 

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -155,7 +155,7 @@ void Track::incoming(message_ptr message) {
 void Track::setRtcpHandler(std::shared_ptr<RtcpHandler> handler) {
 	mRtcpHandler = std::move(handler);
 	if (mRtcpHandler) {
-		mRtcpHandler->onOutgoing([&]([[maybe_unused]] const rtc::message_ptr &message) {
+		mRtcpHandler->onOutgoing([&]([[maybe_unused]] message_ptr message) {
 #if RTC_ENABLE_MEDIA
 			auto transport = mDtlsSrtpTransport.lock();
 			if (!transport)


### PR DESCRIPTION
This PR prevents the DSCP set by a Track from being overridden by the DTLS transport.