### PR TITLE
Fixed a typo during the protection of RTP packets

### DIFF
--- a/src/dtlssrtptransport.cpp
+++ b/src/dtlssrtptransport.cpp
@@ -130,8 +130,8 @@ bool DtlsSrtpTransport::sendMedia(message_ptr message) {
 				auto ssrc = ((RTP *)message->data())->ssrc();
 				PLOG_INFO << "Adding SSRC to RTP: " << ssrc;
 				addSSRC(ssrc);
-				if ((err = srtp_protect_rtcp(mSrtpOut, message->data(), &size)))
-					throw std::runtime_error("SRTCP protect error, status=" +
+				if ((err = srtp_protect(mSrtpOut, message->data(), &size)))
+					throw std::runtime_error("SRTP protect error, status=" +
 					                         to_string(static_cast<int>(err)));
 			} else
 				throw std::runtime_error("SRTP protect error, status=" +
@@ -224,7 +224,7 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 					PLOG_INFO << "Adding SSRC to RTP: " << ssrc;
 					addSSRC(ssrc);
 					if ((err = srtp_unprotect(mSrtpIn, message->data(), &size)))
-						throw std::runtime_error("SRTCP unprotect error, status=" +
+						throw std::runtime_error("SRTP unprotect error, status=" +
 						                         to_string(static_cast<int>(err)));
 				} else
 					PLOG_WARNING << "SRTP unprotect error, status=" << err


### PR DESCRIPTION
There is a typo in the protection of SRTP packets.