### PR TITLE
Fix WebSocket Upgrade header check

### DIFF
--- a/src/wstransport.cpp
+++ b/src/wstransport.cpp
@@ -24,6 +24,7 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include <chrono>
+#include <iterator>
 #include <list>
 #include <map>
 #include <random>
@@ -227,8 +228,14 @@ size_t WsTransport::readHttpResponse(const byte *buffer, size_t size) {
 	}
 
 	auto h = headers.find("upgrade");
-	if (h == headers.end() || h->second != "websocket")
-		throw std::runtime_error("WebSocket update header missing or mismatching");
+	if (h == headers.end())
+		throw std::runtime_error("WebSocket update header missing");
+
+	string upgrade;
+	std::transform(h->second.begin(), h->second.end(), std::back_inserter(upgrade),
+	               [](char c) { return std::tolower(c); });
+	if (upgrade != "websocket")
+		throw std::runtime_error("WebSocket update header mismatching: " + h->second);
 
 	h = headers.find("sec-websocket-accept");
 	if (h == headers.end())


### PR DESCRIPTION
This PR makes WebSocket Upgrade header check case-insensitive as it should be.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/276