### PR TITLE
support Subprotocols

### DIFF
--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -49,6 +49,7 @@ public:
 
 	struct Configuration {
 		bool disableTlsVerification = false; // if true, don't verify the TLS certificate
+		std::vector<string> protocols;
 	};
 
 	WebSocket(std::optional<Configuration> config = nullopt);

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -49,7 +49,7 @@ public:
 
 	struct Configuration {
 		bool disableTlsVerification = false; // if true, don't verify the TLS certificate
-		std::vector<string> protocols;
+		std::optional<std::vector<string>> protocols = std::nullopt;
 	};
 
 	WebSocket(std::optional<Configuration> config = nullopt);

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -288,6 +288,7 @@ shared_ptr<WsTransport> WebSocket::initWsTransport() {
 		if (!lower)
 			lower = std::atomic_load(&mTcpTransport);
 		auto transport = std::make_shared<WsTransport>(
+			WsTransport::Configuration{{.protocols = mConfig.protocols}},
 		    lower, mHost, mPath, weak_bind(&WebSocket::incoming, this, _1),
 		    [this, weak_this = weak_from_this()](State state) {
 			    auto shared_this = weak_this.lock();

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -287,8 +287,14 @@ shared_ptr<WsTransport> WebSocket::initWsTransport() {
 		shared_ptr<Transport> lower = std::atomic_load(&mTlsTransport);
 		if (!lower)
 			lower = std::atomic_load(&mTcpTransport);
+
+		auto wsConfig = WsTransport::Configuration();
+		if(mConfig.protocols) {
+			wsConfig.protocols = *mConfig.protocols;
+		}
+
 		auto transport = std::make_shared<WsTransport>(
-			WsTransport::Configuration{{.protocols = mConfig.protocols}},
+			wsConfig,
 		    lower, mHost, mPath, weak_bind(&WebSocket::incoming, this, _1),
 		    [this, weak_this = weak_from_this()](State state) {
 			    auto shared_this = weak_this.lock();

--- a/src/wstransport.cpp
+++ b/src/wstransport.cpp
@@ -29,6 +29,7 @@
 #include <map>
 #include <random>
 #include <regex>
+#include <numeric>
 
 #ifdef _WIN32
 #include <winsock2.h>

--- a/src/wstransport.cpp
+++ b/src/wstransport.cpp
@@ -53,9 +53,9 @@ using std::to_string;
 using random_bytes_engine =
     std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned short>;
 
-WsTransport::WsTransport(std::shared_ptr<Transport> lower, string host, string path,
+WsTransport::WsTransport(std::optional<Configuration> config, std::shared_ptr<Transport> lower, string host, string path,
                          message_callback recvCallback, state_callback stateCallback)
-    : Transport(lower, std::move(stateCallback)), mHost(std::move(host)), mPath(std::move(path)) {
+    : Transport(lower, std::move(stateCallback)), mHost(std::move(host)), mPath(std::move(path)), mConfig(config ? std::move(*config) : Configuration()) {
 	onRecv(recvCallback);
 
 	PLOG_DEBUG << "Initializing WebSocket transport";
@@ -164,6 +164,15 @@ bool WsTransport::sendHttpRequest() {
 	auto k = reinterpret_cast<uint8_t *>(key.data());
 	std::generate(k, k + key.size(), [&]() { return uint8_t(generator()); });
 
+	string appendHeader = "";
+	if(mConfig.protocols.size() > 0) {
+		appendHeader += "Sec-WebSocket-Protocol: " +
+						std::accumulate(mConfig.protocols.begin(), mConfig.protocols.end(), string(), [](const string& a, const string& b) -> string { 
+							return a + (a.length() > 0 ? "," : "") + b; 
+						}) +
+						"\r\n";
+	}
+	
 	const string request = "GET " + mPath +
 	                       " HTTP/1.1\r\n"
 	                       "Host: " +
@@ -174,8 +183,9 @@ bool WsTransport::sendHttpRequest() {
 	                       "Sec-WebSocket-Version: 13\r\n"
 	                       "Sec-WebSocket-Key: " +
 	                       to_base64(key) +
-	                       "\r\n"
-	                       "\r\n";
+	                       "\r\n" +
+						   std::move(appendHeader) +
+						   "\r\n";
 
 	auto data = reinterpret_cast<const byte *>(request.data());
 	auto size = request.size();

--- a/src/wstransport.hpp
+++ b/src/wstransport.hpp
@@ -31,7 +31,11 @@ class TlsTransport;
 
 class WsTransport : public Transport {
 public:
-	WsTransport(std::shared_ptr<Transport> lower, string host, string path,
+	struct Configuration {
+		std::vector<string> protocols;
+	};
+
+	WsTransport(std::optional<Configuration> config, std::shared_ptr<Transport> lower, string host, string path,
 	            message_callback recvCallback, state_callback stateCallback);
 	~WsTransport();
 
@@ -74,6 +78,8 @@ private:
 	binary mBuffer;
 	binary mPartial;
 	Opcode mPartialOpcode;
+
+	const Configuration mConfig;
 };
 
 } // namespace rtc


### PR DESCRIPTION
Janus WebRTC Server requires a non-standard subprotocol any  WebSocket client that works correctly won't be able to connect.

[Subprotocols](https://tools.ietf.org/html/rfc6455#section-1.9)

https://github.com/meetecho/janus-gateway/blob/master/transports/janus_websockets.c#L223-L242
```
/* Protocol mappings */
static struct lws_protocols ws_protocols[] = {
	{ "http-only", janus_websockets_callback_http, 0, 0 },
	{ "janus-protocol", janus_websockets_callback, sizeof(janus_websockets_client), 0 },
	{ NULL, NULL, 0 }
};
static struct lws_protocols sws_protocols[] = {
	{ "http-only", janus_websockets_callback_https, 0, 0 },
	{ "janus-protocol", janus_websockets_callback_secure, sizeof(janus_websockets_client), 0 },
	{ NULL, NULL, 0 }
};
static struct lws_protocols admin_ws_protocols[] = {
	{ "http-only", janus_websockets_callback_http, 0, 0 },
	{ "janus-admin-protocol", janus_websockets_admin_callback, sizeof(janus_websockets_client), 0 },
	{ NULL, NULL, 0 }
};
static struct lws_protocols admin_sws_protocols[] = {
	{ "http-only", janus_websockets_callback_https, 0, 0 },
	{ "janus-admin-protocol", janus_websockets_admin_callback_secure, sizeof(janus_websockets_client), 0 },
	{ NULL, NULL, 0 }
};
```