### PR TITLE
Audio/Video profile is now only applied to H264/Opus.

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -32,13 +32,13 @@
 
 namespace rtc {
 
-const string DEFAULT_AUDIO_PROFILE =
+const string DEFAULT_OPUS_AUDIO_PROFILE =
     "minptime=10;maxaveragebitrate=96000;stereo=1;sprop-stereo=1;useinbandfec=1";
 
 // Use Constrained Baseline profile Level 4.2 (necessary for Firefox)
 // https://developer.mozilla.org/en-US/docs/Web/Media/Formats/WebRTC_codecs#Supported_video_codecs
 // TODO: Should be 42E0 but 42C0 appears to be more compatible. Investigate this.
-const string DEFAULT_VIDEO_PROFILE =
+const string DEFAULT_H264_VIDEO_PROFILE =
     "profile-level-id=42e01f;packetization-mode=1;level-asymmetry-allowed=1";
 
 class RTC_CPP_EXPORT Description {
@@ -203,9 +203,9 @@ public:
 		Audio(string mid = "audio", Direction dir = Direction::SendOnly);
 
 		void addAudioCodec(int payloadType, string codec,
-		                   std::optional<string> profile = DEFAULT_AUDIO_PROFILE);
+		                   std::optional<string> profile = std::nullopt);
 
-		void addOpusCodec(int payloadType);
+		void addOpusCodec(int payloadType, std::optional<string> profile = DEFAULT_OPUS_AUDIO_PROFILE);
 	};
 
 	class RTC_CPP_EXPORT Video : public Media {
@@ -213,9 +213,9 @@ public:
 		Video(string mid = "video", Direction dir = Direction::SendOnly);
 
 		void addVideoCodec(int payloadType, string codec,
-		                   std::optional<string> profile = DEFAULT_VIDEO_PROFILE);
+		                   std::optional<string> profile = std::nullopt);
 
-		void addH264Codec(int payloadType);
+		void addH264Codec(int payloadType, std::optional<string> profile = DEFAULT_H264_VIDEO_PROFILE);
 		void addVP8Codec(int payloadType);
 		void addVP9Codec(int payloadType);
 	};

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -744,7 +744,7 @@ void Description::Media::addRTXCodec(unsigned int payloadType, unsigned int orig
 	addRTPMap(map);
 }
 
-void Description::Video::addH264Codec(int pt) { addVideoCodec(pt, "H264"); }
+void Description::Video::addH264Codec(int pt, std::optional<string> profile) { addVideoCodec(pt, "H264", profile); }
 
 void Description::Video::addVP8Codec(int payloadType) { addVideoCodec(payloadType, "VP8", nullopt); }
 
@@ -901,7 +901,7 @@ void Description::Media::RTPMap::setMLine(string_view mline) {
 Description::Audio::Audio(string mid, Direction dir)
     : Media("audio 9 UDP/TLS/RTP/SAVPF", std::move(mid), dir) {}
 
-void Description::Audio::addOpusCodec(int payloadType) { addAudioCodec(payloadType, "OPUS"); }
+void Description::Audio::addOpusCodec(int payloadType, std::optional<string> profile) { addAudioCodec(payloadType, "OPUS", profile); }
 
 Description::Video::Video(string mid, Direction dir)
     : Media("video 9 UDP/TLS/RTP/SAVPF", std::move(mid), dir) {}


### PR DESCRIPTION
The A/V profile only applies to H264 and Opus and not to VPX or other audio codecs that are supported by peers. These profiles should not be applied unless they are for H264/Opus.