### PR TITLE
Fixes a few potential seg-faults in the sending of RTP and fixes the building of NACK packets

### DIFF
--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -459,8 +459,9 @@ public:
 			return true;
 		} else {
 			// TODO SPEEED!
-			parts[(*fciCount) - 1].blp = htons(ntohs(parts[(*fciCount) - 1].blp) |
-			                                   (1u << (unsigned int)(missingPacket - *fciPID)));
+			auto blp = ntohs(parts[(*fciCount) - 1].blp);
+			auto newBit = 1u << (unsigned int)(missingPacket - (1 + *fciPID));
+			parts[(*fciCount) - 1].blp = htons(blp | newBit);
 			return false;
 		}
 	}

--- a/src/dtlssrtptransport.hpp
+++ b/src/dtlssrtptransport.hpp
@@ -58,6 +58,7 @@ private:
 	std::atomic<bool> mInitDone = false;
 	unsigned char mClientSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
 	unsigned char mServerSessionKey[SRTP_AES_ICM_128_KEY_LEN_WSALT];
+	std::mutex sendMutex;
 };
 
 } // namespace rtc


### PR DESCRIPTION
Goodness gracious! I have been struggling to identify this bug for weeks now! I added a `std::lock_guard` at `DtlsSrtpTransport::sendMedia` because I can call `RtcpHandler::outgoingCallback` at the same time as `Track::send` and cause race conditions that shows visible data corruption and can even potentially cause a segfault in SRTP! I also removed that double decode of SRTP and I have opened #286 to discuss how to fix it. It can't be done because the documentation doesn't guarantee the safety of those parameters (although the code shows no reason why it can't be done).