### PR TITLE
Refactored runtime errors to be logged periodically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ set(LIBDATACHANNEL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/log.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/message.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/peerconnection.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/logcounter.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/rtcp.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/sctptransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/threadpool.cpp

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -20,6 +20,7 @@
 #include "include.hpp"
 #include "peerconnection.hpp"
 #include "sctptransport.hpp"
+#include "logcounter.hpp"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -27,6 +28,7 @@
 #include <arpa/inet.h>
 #endif
 
+rtc::LogCounter COUNTER_USERNEG_OPEN_MESSAGE(plog::warning, "Number of open messages for a user-negotiated DataChannel received");
 namespace rtc {
 
 using std::shared_ptr;
@@ -170,7 +172,7 @@ void DataChannel::open(shared_ptr<SctpTransport> transport) {
 }
 
 void DataChannel::processOpenMessage(message_ptr) {
-	PLOG_WARNING << "Received an open message for a user-negotiated DataChannel, ignoring";
+    COUNTER_USERNEG_OPEN_MESSAGE++;
 }
 
 bool DataChannel::outgoing(message_ptr message) {

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -172,6 +172,7 @@ void DataChannel::open(shared_ptr<SctpTransport> transport) {
 }
 
 void DataChannel::processOpenMessage(message_ptr) {
+    PLOG_DEBUG << "Received an open message for a user-negotiated DataChannel, ignoring";
     COUNTER_USERNEG_OPEN_MESSAGE++;
 }
 

--- a/src/dtlssrtptransport.cpp
+++ b/src/dtlssrtptransport.cpp
@@ -18,6 +18,7 @@
 
 #include "dtlssrtptransport.hpp"
 #include "tls.hpp"
+#include "logcounter.hpp"
 
 #if RTC_ENABLE_MEDIA
 
@@ -27,6 +28,16 @@
 using std::shared_ptr;
 using std::to_integer;
 using std::to_string;
+
+static rtc::LogCounter COUNTER_MEDIA_SENT_EARLY(plog::warning, "Number of RTP packets sent before keys have been derived");
+static rtc::LogCounter COUNTER_MEDIA_TRUNCATED(plog::warning, "Number of truncated SRT(C)P packets received");
+static rtc::LogCounter COUNTER_UNKNOWN_PACKET_TYPE(plog::warning, "Number of RTP packets received with an unknown packet type");
+static rtc::LogCounter COUNTER_SRTCP_REPLAY(plog::warning, "Number of SRTCP replay packets received");
+static rtc::LogCounter COUNTER_SRTCP_AUTH_FAIL(plog::warning, "Number of SRTCP packets received that failed authentication checks");
+static rtc::LogCounter COUNTER_SRTCP_FAIL(plog::warning, "Number of SRTCP packets received that had an unknown libSRTP failure");
+static rtc::LogCounter COUNTER_SRTP_REPLAY(plog::warning, "Number of SRTP replay packets received");
+static rtc::LogCounter COUNTER_SRTP_AUTH_FAIL(plog::warning, "Number of SRTP packets received that failed authentication checks");
+static rtc::LogCounter COUNTER_SRTP_FAIL(plog::warning, "Number of SRTP packets received that had an unknown libSRTP failure");
 
 namespace rtc {
 
@@ -73,13 +84,14 @@ DtlsSrtpTransport::~DtlsSrtpTransport() {
 	srtp_dealloc(mSrtpOut);
 }
 
+
 bool DtlsSrtpTransport::sendMedia(message_ptr message) {
 	std::lock_guard lock(sendMutex);
 	if (!message)
 		return false;
 
 	if (!mInitDone) {
-		PLOG_WARNING << "SRTP media sent before keys are derived";
+		COUNTER_MEDIA_SENT_EARLY++;
 		return false;
 	}
 
@@ -137,6 +149,7 @@ bool DtlsSrtpTransport::sendMedia(message_ptr message) {
 	return Transport::outgoing(message); // bypass DTLS DSCP marking
 }
 
+
 void DtlsSrtpTransport::incoming(message_ptr message) {
 	if (!mInitDone) {
 		// Bypas
@@ -165,7 +178,8 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 		// The RTP header has a minimum size of 12 bytes
 		// An RTCP packet can have a minimum size of 8 bytes
 		if (size < 8) {
-			PLOG_WARNING << "Incoming SRTP/SRTCP packet too short, size=" << size;
+            COUNTER_MEDIA_TRUNCATED++;
+			PLOG_VERBOSE << "Incoming SRTP/SRTCP packet too short, size=" << size;
 			return;
 		}
 
@@ -178,11 +192,13 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 			PLOG_VERBOSE << "Incoming SRTCP packet, size=" << size;
 			if (srtp_err_status_t err = srtp_unprotect_rtcp(mSrtpIn, message->data(), &size)) {
 				if (err == srtp_err_status_replay_fail)
-					PLOG_WARNING << "Incoming SRTCP packet is a replay";
+				    COUNTER_SRTCP_REPLAY++;
 				else if (err == srtp_err_status_auth_fail)
-					PLOG_WARNING << "Incoming SRTCP packet failed authentication check";
-				else
-					PLOG_WARNING << "SRTCP unprotect error, status=" << err;
+                    COUNTER_SRTCP_AUTH_FAIL++;
+				else {
+                    COUNTER_SRTCP_FAIL++;
+                    PLOG_VERBOSE << "SRTCP unprotect error, status=" << err;
+                }
 
 				return;
 			}
@@ -193,13 +209,14 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 		} else {
 			PLOG_VERBOSE << "Incoming SRTP packet, size=" << size;
 			if (srtp_err_status_t err = srtp_unprotect(mSrtpIn, message->data(), &size)) {
-				if (err == srtp_err_status_replay_fail)
-					PLOG_WARNING << "Incoming SRTP packet is a replay";
-				else if (err == srtp_err_status_auth_fail)
-					PLOG_WARNING << "Incoming SRTP packet failed authentication check";
-				else
-					PLOG_WARNING << "SRTP unprotect error, status=" << err;
-
+                if (err == srtp_err_status_replay_fail)
+                    COUNTER_SRTP_REPLAY++;
+                else if (err == srtp_err_status_auth_fail)
+                    COUNTER_SRTP_AUTH_FAIL++;
+                else {
+                    COUNTER_SRTP_FAIL++;
+                    PLOG_VERBOSE << "SRTP unprotect error, status=" << err;
+                }
 				return;
 			}
 			PLOG_VERBOSE << "Unprotected SRTP packet, size=" << size;
@@ -211,7 +228,8 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 		mSrtpRecvCallback(message);
 
 	} else {
-		PLOG_WARNING << "Unknown packet type, value=" << unsigned(value1) << ", size=" << size;
+	    COUNTER_UNKNOWN_PACKET_TYPE++;
+		PLOG_VERBOSE << "Unknown packet type, value=" << unsigned(value1) << ", size=" << size;
 	}
 }
 

--- a/src/logcounter.cpp
+++ b/src/logcounter.cpp
@@ -25,16 +25,19 @@ rtc::LogCounter& rtc::LogCounter::operator++(int) {
     std::lock_guard lock(mutex);
     count++;
     if (!future) {
-        future = ThreadPool::Instance().schedule(duration, [this]() {
-            int countCopy;
-            {
-                std::lock_guard lock(mutex);
-                countCopy = count;
-                count = 0;
-                future = std::nullopt;
+        future = ThreadPool::Instance().schedule(duration, [](std::weak_ptr<LogCounter> ptr) {
+            if (auto log = ptr.lock()) {
+                int countCopy;
+                {
+                    std::lock_guard lock(log->mutex);
+                    countCopy = log->count;
+                    log->count = 0;
+                    log->future = std::nullopt;
+                }
+                PLOG(log->severity) << log->text << ": " << countCopy << " (over "
+                               << std::chrono::duration_cast<std::chrono::seconds>(log->duration).count() << " seconds)";
             }
-            PLOG(severity) << text << ": " << countCopy << " (over " << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)";
-        });
+        }, std::weak_ptr(shared_from_this()));
     }
     return *this;
 }

--- a/src/logcounter.cpp
+++ b/src/logcounter.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2021 Staz Modrzynski
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "logcounter.hpp"
+
+rtc::LogCounter::LogCounter(plog::Severity severity, const std::string &text, std::chrono::seconds duration) :
+        severity(severity), text(text), duration(duration) {}
+
+rtc::LogCounter& rtc::LogCounter::operator++(int) {
+    std::lock_guard lock(mutex);
+    count++;
+    if (!future) {
+        future = ThreadPool::Instance().schedule(duration, [this]() {
+            int countCopy;
+            {
+                std::lock_guard lock(mutex);
+                countCopy = count;
+                count = 0;
+                future = std::nullopt;
+            }
+            PLOG(severity) << text << ": " << countCopy << " (over " << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)";
+        });
+    }
+    return *this;
+}
+
+rtc::LogCounter::~LogCounter() {
+    if (future) {
+        future->wait();
+    }
+}

--- a/src/logcounter.cpp
+++ b/src/logcounter.cpp
@@ -38,9 +38,3 @@ rtc::LogCounter& rtc::LogCounter::operator++(int) {
     }
     return *this;
 }
-
-rtc::LogCounter::~LogCounter() {
-    if (future) {
-        future->wait();
-    }
-}

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -1,0 +1,48 @@
+//
+// Created by staz on 1/3/21.
+//
+
+#ifndef WEBRTC_SERVER_LOGCOUNTER_HPP
+#define WEBRTC_SERVER_LOGCOUNTER_HPP
+
+#include <plog/Util.h>
+#include <plog/Severity.h>
+#include "threadpool.hpp"
+#include "include.hpp"
+
+namespace rtc {
+class LogCounter {
+private:
+    plog::Severity severity;
+    std::string text;
+    std::chrono::steady_clock::duration duration;
+
+    int count = 0;
+    std::mutex mutex;
+    std::optional<invoke_future_t<void (*)()>> future;
+public:
+
+    LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1)):
+        severity(severity), text(text), duration(duration) {}
+
+    LogCounter& operator++(int) {
+        std::lock_guard lock(mutex);
+        count++;
+        if (!future) {
+            future = ThreadPool::Instance().schedule(duration, [this]() {
+                int countCopy;
+                {
+                    std::lock_guard lock(mutex);
+                    countCopy = count;
+                    count = 0;
+                    future = std::nullopt;
+                }
+                PLOG(severity) << text << ": " << countCopy << " (over " << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)";
+            });
+        }
+        return *this;
+    }
+};
+}
+
+#endif //WEBRTC_SERVER_LOGCOUNTER_HPP

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -23,17 +23,22 @@
 #include "include.hpp"
 
 namespace rtc {
-class LogCounter: public std::enable_shared_from_this<LogCounter> {
+class LogCounter {
 private:
-    plog::Severity severity;
-    std::string text;
-    std::chrono::steady_clock::duration duration;
+    plog::Severity mSeverity;
+    std::string mText;
+    std::chrono::steady_clock::duration mDuration;
 
-    int count = 0;
-    std::mutex mutex;
+    std::atomic<int> mCount = 0;
+
+    std::shared_ptr<std::mutex> mIsValidMutex;
+    std::shared_ptr<bool> mIsValid;
+
 public:
 
     LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1));
+
+    ~LogCounter();
 
     LogCounter& operator++(int);
 };

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -23,7 +23,7 @@
 #include "include.hpp"
 
 namespace rtc {
-class LogCounter {
+class LogCounter: public std::enable_shared_from_this<LogCounter> {
 private:
     plog::Severity severity;
     std::string text;

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -25,20 +25,19 @@
 namespace rtc {
 class LogCounter {
 private:
-    plog::Severity mSeverity;
-    std::string mText;
-    std::chrono::steady_clock::duration mDuration;
+    struct LogData {
+        plog::Severity mSeverity;
+        std::string mText;
+        std::chrono::steady_clock::duration mDuration;
 
-    std::atomic<int> mCount = 0;
+        std::atomic<int> mCount = 0;
+    };
 
-    std::shared_ptr<std::mutex> mIsValidMutex;
-    std::shared_ptr<bool> mIsValid;
+    std::shared_ptr<LogData> mData;
 
 public:
 
     LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1));
-
-    ~LogCounter();
 
     LogCounter& operator++(int);
 };

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -1,12 +1,24 @@
-//
-// Created by staz on 1/3/21.
-//
+/**
+ * Copyright (c) 2021 Staz Modrzynski
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
 
 #ifndef WEBRTC_SERVER_LOGCOUNTER_HPP
 #define WEBRTC_SERVER_LOGCOUNTER_HPP
 
-#include <plog/Util.h>
-#include <plog/Severity.h>
 #include "threadpool.hpp"
 #include "include.hpp"
 
@@ -22,26 +34,11 @@ private:
     std::optional<invoke_future_t<void (*)()>> future;
 public:
 
-    LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1)):
-        severity(severity), text(text), duration(duration) {}
+    LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1));
 
-    LogCounter& operator++(int) {
-        std::lock_guard lock(mutex);
-        count++;
-        if (!future) {
-            future = ThreadPool::Instance().schedule(duration, [this]() {
-                int countCopy;
-                {
-                    std::lock_guard lock(mutex);
-                    countCopy = count;
-                    count = 0;
-                    future = std::nullopt;
-                }
-                PLOG(severity) << text << ": " << countCopy << " (over " << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " seconds)";
-            });
-        }
-        return *this;
-    }
+    ~LogCounter();
+
+    LogCounter& operator++(int);
 };
 }
 

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -31,7 +31,6 @@ private:
 
     int count = 0;
     std::mutex mutex;
-    std::optional<invoke_future_t<void (*)()>> future;
 public:
 
     LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1));

--- a/src/logcounter.hpp
+++ b/src/logcounter.hpp
@@ -36,8 +36,6 @@ public:
 
     LogCounter(plog::Severity severity, const std::string& text, std::chrono::seconds duration=std::chrono::seconds(1));
 
-    ~LogCounter();
-
     LogCounter& operator++(int);
 };
 }


### PR DESCRIPTION
I added a new class called `LogCounter` using the scheduling changes in #300. This now causes all common errors (such as replay attacks) to be logged periodically. I used a lot of static globals here which I will argue are okay in this context, but I fully understand how my approach may be discouraged. I concluded that it was rather pointless to have these initialized in the class because you can't differentiate between multiple peer connections anyways.