### PR TITLE
Added a mutex for RtcpHandler

### DIFF
--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -77,6 +77,8 @@ private:
 	std::atomic<bool> mIsClosed = false;
 
 	Queue<message_ptr> mRecvQueue;
+
+	std::shared_mutex mRtcpHandlerMutex;
 	std::shared_ptr<RtcpHandler> mRtcpHandler;
 
 	friend class PeerConnection;

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -136,7 +136,7 @@ void Track::incoming(message_ptr message) {
 
 	// Tail drop if queue is full
 	if (mRecvQueue.full()) {
-        COUNTER_QUEUE_FULL++;
+		COUNTER_QUEUE_FULL++;
 		return;
 	}
 

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -62,7 +62,7 @@ bool Track::send(message_variant data) {
 
 	auto message = make_message(std::move(data));
 
-    if (auto handler = getRtcpHandler()) {
+	if (auto handler = getRtcpHandler()) {
 		message = handler->outgoing(message);
 		if (!message)
 			return false;
@@ -122,7 +122,7 @@ void Track::incoming(message_ptr message) {
 		return;
 	}
 
-    if (auto handler = getRtcpHandler()) {
+	if (auto handler = getRtcpHandler()) {
 		message = handler->incoming(message);
 		if (!message)
 			return;
@@ -159,25 +159,25 @@ bool Track::outgoing([[maybe_unused]] message_ptr message) {
 }
 
 void Track::setRtcpHandler(std::shared_ptr<RtcpHandler> handler) {
-    std::unique_lock lock(mRtcpHandlerMutex);
-    mRtcpHandler = std::move(handler);
+	std::unique_lock lock(mRtcpHandlerMutex);
+	mRtcpHandler = std::move(handler);
 	if (mRtcpHandler) {
-	    auto copy = mRtcpHandler;
-        lock.unlock();
-        copy->onOutgoing(std::bind(&Track::outgoing, this, std::placeholders::_1));
-    }
+		auto copy = mRtcpHandler;
+		lock.unlock();
+		copy->onOutgoing(std::bind(&Track::outgoing, this, std::placeholders::_1));
+	}
 }
 
 bool Track::requestKeyframe() {
-    if (auto handler = getRtcpHandler()) {
-        return handler->requestKeyframe();
-    }
+	if (auto handler = getRtcpHandler()) {
+		return handler->requestKeyframe();
+	}
 	return false;
 }
 
 std::shared_ptr<RtcpHandler> Track::getRtcpHandler() {
-    std::shared_lock lock(mRtcpHandlerMutex);
-    return mRtcpHandler;
+	std::shared_lock lock(mRtcpHandlerMutex);
+	return mRtcpHandler;
 }
 
 } // namespace rtc

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -62,11 +62,8 @@ bool Track::send(message_variant data) {
 
 	auto message = make_message(std::move(data));
 
-    std::shared_lock lock(mRtcpHandlerMutex);
-    if (mRtcpHandler) {
-        auto copy = mRtcpHandler;
-        lock.unlock();
-		message = copy->outgoing(message);
+    if (auto handler = getRtcpHandler()) {
+		message = handler->outgoing(message);
 		if (!message)
 			return false;
 	}
@@ -125,11 +122,8 @@ void Track::incoming(message_ptr message) {
 		return;
 	}
 
-    std::shared_lock lock(mRtcpHandlerMutex);
-    if (mRtcpHandler) {
-        auto copy = mRtcpHandler;
-        lock.unlock();
-		message = copy->incoming(message);
+    if (auto handler = getRtcpHandler()) {
+		message = handler->incoming(message);
 		if (!message)
 			return;
 	}
@@ -175,11 +169,8 @@ void Track::setRtcpHandler(std::shared_ptr<RtcpHandler> handler) {
 }
 
 bool Track::requestKeyframe() {
-    std::shared_lock lock(mRtcpHandlerMutex);
-    if (mRtcpHandler) {
-        auto copy = mRtcpHandler;
-        lock.unlock();
-        return copy->requestKeyframe();
+    if (auto handler = getRtcpHandler()) {
+        return handler->requestKeyframe();
     }
 	return false;
 }


### PR DESCRIPTION
Fixes #312. The purpose behind unlocking the lock before using the handler is to prevent a deadlock should the `RtcpHandler` end up sending something again.