### PR TITLE
Add checks on std::stoul()

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -44,7 +44,7 @@ struct RTC_CPP_EXPORT IceServer {
 	          RelayType relayType_ = RelayType::TurnUdp);
 
 	string hostname;
-	string service;
+	uint16_t port;
 	Type type;
 	string username;
 	string password;
@@ -54,11 +54,11 @@ struct RTC_CPP_EXPORT IceServer {
 struct RTC_CPP_EXPORT ProxyServer {
 	enum class Type { None = 0, Socks5, Http, Last = Http };
 
-	ProxyServer(Type type_, string ip_, uint16_t port_, string username_ = "",
+	ProxyServer(Type type_, string hostname_, uint16_t port_, string username_ = "",
 	            string password_ = "");
 
 	Type type;
-	string ip;
+	string hostname;
 	uint16_t port;
 	string username;
 	string password;

--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -167,9 +167,12 @@ bool Candidate::resolve(ResolveMode mode) {
 				if (getnameinfo(p->ai_addr, socklen_t(p->ai_addrlen), nodebuffer,
 				                MAX_NUMERICNODE_LEN, servbuffer, MAX_NUMERICSERV_LEN,
 				                NI_NUMERICHOST | NI_NUMERICSERV) == 0) {
-
+					try {
+						mPort = uint16_t(std::stoul(servbuffer));
+					} catch (...) {
+						return false;
+					}
 					mAddress = nodebuffer;
-					mPort = uint16_t(std::stoul(servbuffer));
 					mFamily = p->ai_family == AF_INET6 ? Family::Ipv6 : Family::Ipv4;
 					PLOG_VERBOSE << "Resolved candidate: " << mAddress << ' ' << mPort;
 					break;

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -60,32 +60,51 @@ IceServer::IceServer(const string &url) {
 
 	username = opt[6].value_or("");
 	password = opt[8].value_or("");
-	hostname = opt[10].value();
-	service = opt[12].value_or(relayType == RelayType::TurnTls ? "5349" : "3478");
 
+	hostname = opt[10].value();
 	while (!hostname.empty() && hostname.front() == '[')
 		hostname.erase(hostname.begin());
 	while (!hostname.empty() && hostname.back() == ']')
 		hostname.pop_back();
+
+	string service = opt[12].value_or(relayType == RelayType::TurnTls ? "5349" : "3478");
+	try {
+		port = uint16_t(std::stoul(service));
+	} catch (...) {
+		throw std::invalid_argument("Invalid ICE server port in URL: " + service);
+	}
 }
 
 IceServer::IceServer(string hostname_, uint16_t port_)
-    : IceServer(std::move(hostname_), std::to_string(port_)) {}
+    : hostname(std::move(hostname_)), port(port_), type(Type::Stun) {}
 
 IceServer::IceServer(string hostname_, string service_)
-    : hostname(std::move(hostname_)), service(std::move(service_)), type(Type::Stun) {}
+    : hostname(std::move(hostname_)), type(Type::Stun) {
+	try {
+		port = uint16_t(std::stoul(service_));
+	} catch (...) {
+		throw std::invalid_argument("Invalid ICE server port: " + service_);
+	}
+}
 
 IceServer::IceServer(string hostname_, uint16_t port_, string username_, string password_,
                      RelayType relayType_)
-    : IceServer(hostname_, std::to_string(port_), std::move(username_), std::move(password_),
-                relayType_) {}
+    : hostname(std::move(hostname_)), port(port_), type(Type::Turn), username(std::move(username_)),
+      password(std::move(password_)), relayType(relayType_) {}
 
 IceServer::IceServer(string hostname_, string service_, string username_, string password_,
                      RelayType relayType_)
-    : hostname(std::move(hostname_)), service(std::move(service_)), type(Type::Turn),
-      username(std::move(username_)), password(std::move(password_)), relayType(relayType_) {}
+    : hostname(std::move(hostname_)), type(Type::Turn), username(std::move(username_)),
+      password(std::move(password_)), relayType(relayType_) {
+	try {
+		port = uint16_t(std::stoul(service_));
+	} catch (...) {
+		throw std::invalid_argument("Invalid ICE server port: " + service_);
+	}
+}
 
-ProxyServer::ProxyServer(Type type_, string ip_, uint16_t port_, string username_, string password_)
-    : type(type_), ip(ip_), port(port_), username(username_), password(password_) {}
+ProxyServer::ProxyServer(Type type_, string hostname_, uint16_t port_, string username_,
+                         string password_)
+    : type(type_), hostname(hostname_), port(port_), username(username_), password(password_) {}
 
 } // namespace rtc

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -59,7 +59,13 @@ inline std::pair<string_view, string_view> parse_pair(string_view attr) {
 }
 
 template <typename T> T to_integer(string_view s) {
-	return std::is_signed<T>::value ? T(std::stol(string(s))) : T(std::stoul(string(s)));
+	const string str(s);
+	try {
+		return std::is_signed<T>::value ? T(std::stol(str)) : T(std::stoul(str));
+	}
+	catch(...) {
+		throw std::invalid_argument("Invalid integer \"" + str + "\" in description");
+	}
 }
 
 } // namespace
@@ -823,7 +829,7 @@ void Description::Media::parseSdpLine(string_view line) {
 		} else if (key == "rtcp-mux") {
 			// always added
 		} else if (key == "ssrc") {
-			mSsrcs.emplace_back(std::stoul(string(value)));
+			mSsrcs.emplace_back(to_integer<uint32_t>(value));
 		} else {
 			Entry::parseSdpLine(line);
 		}
@@ -843,7 +849,7 @@ std::vector<uint32_t> Description::Media::getSSRCs() {
 	for (auto &val : mAttributes) {
 		PLOG_DEBUG << val;
 		if (val.find("ssrc:") == 0) {
-			vec.emplace_back(std::stoul(string(val.substr(5, val.find(" ")))));
+			vec.emplace_back(to_integer<uint32_t>(val.substr(5, val.find(" "))));
 		}
 	}
 	return vec;

--- a/src/icetransport.cpp
+++ b/src/icetransport.cpp
@@ -103,11 +103,11 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	// Pick a STUN server
 	for (auto &server : servers) {
 		if (!server.hostname.empty() && server.type == IceServer::Type::Stun) {
-			if (server.service.empty())
-				server.service = "3478"; // STUN UDP port
-			PLOG_INFO << "Using STUN server \"" << server.hostname << ":" << server.service << "\"";
+			if (server.port == 0)
+				server.port = 3478; // STUN UDP port
+			PLOG_INFO << "Using STUN server \"" << server.hostname << ":" << server.port << "\"";
 			jconfig.stun_server_host = server.hostname.c_str();
-			jconfig.stun_server_port = uint16_t(std::stoul(server.service));
+			jconfig.stun_server_port = server.port;
 			break;
 		}
 	}
@@ -119,13 +119,13 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	int k = 0;
 	for (auto &server : servers) {
 		if (!server.hostname.empty() && server.type == IceServer::Type::Turn) {
-			if (server.service.empty())
-				server.service = "3478"; // TURN UDP port
-			PLOG_INFO << "Using TURN server \"" << server.hostname << ":" << server.service << "\"";
+			if (server.port == 0)
+				server.port = 3478; // TURN UDP port
+			PLOG_INFO << "Using TURN server \"" << server.hostname << ":" << server.port << "\"";
 			turn_servers[k].host = server.hostname.c_str();
 			turn_servers[k].username = server.username.c_str();
 			turn_servers[k].password = server.password.c_str();
-			turn_servers[k].port = uint16_t(std::stoul(server.service));
+			turn_servers[k].port = server.port;
 			if (++k >= MAX_TURN_SERVERS_COUNT)
 				break;
 		}


### PR DESCRIPTION
This PR replaces the string `service` by an integer `port` in `IceServer` and catches potential exceptions thrown by `std::stoul()`.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/321