### PR TITLE
Add API to set track id in msid

### DIFF
--- a/examples/streamer/client.js
+++ b/examples/streamer/client.js
@@ -54,12 +54,10 @@ function createPeerConnection() {
 
     // connect audio / video
     pc.addEventListener('track', function (evt) {
-        if (evt.track.kind == 'video') {
-            document.getElementById('media').style.display = 'block';
-            document.getElementById('video').srcObject = evt.streams[0];
-        } else {
-            document.getElementById('audio').srcObject = evt.streams[0];
-        }
+        document.getElementById('media').style.display = 'block';
+        const videoTag = document.getElementById('video');
+        videoTag.srcObject = evt.streams[0];
+        videoTag.play();
     });
 
     let time_start = null;

--- a/examples/streamer/index.html
+++ b/examples/streamer/index.html
@@ -52,7 +52,6 @@
 
 <div id="media" style="display: none">
     <h2>Media</h2>
-    <audio id="audio" autoplay></audio>
     <video id="video" autoplay playsinline></video>
 </div>
 

--- a/examples/streamer/main.cpp
+++ b/examples/streamer/main.cpp
@@ -214,7 +214,7 @@ int main(int argc, char **argv) try {
 shared_ptr<ClientTrackData> addVideo(const shared_ptr<PeerConnection> pc, const uint8_t payloadType, const uint32_t ssrc, const string cname, const string msid, const function<void (void)> onOpen) {
     auto video = Description::Video(cname);
     video.addH264Codec(payloadType);
-    video.addSSRC(ssrc, cname, msid);
+    video.addSSRC(ssrc, cname, msid, cname);
     auto track = pc->addTrack(video);
     // create RTP configuration
     auto rtpConfig = shared_ptr<RtpPacketizationConfig>(new RtpPacketizationConfig(ssrc, cname, payloadType, H264RtpPacketizer::defaultClockRate));
@@ -232,7 +232,7 @@ shared_ptr<ClientTrackData> addVideo(const shared_ptr<PeerConnection> pc, const 
 shared_ptr<ClientTrackData> addAudio(const shared_ptr<PeerConnection> pc, const uint8_t payloadType, const uint32_t ssrc, const string cname, const string msid, const function<void (void)> onOpen) {
     auto audio = Description::Audio(cname);
     audio.addOpusCodec(payloadType);
-    audio.addSSRC(ssrc, cname, msid);
+    audio.addSSRC(ssrc, cname, msid, cname);
     auto track = pc->addTrack(audio);
     // create RTP configuration
     auto rtpConfig = shared_ptr<RtpPacketizationConfig>(new RtpPacketizationConfig(ssrc, cname, payloadType, OpusRtpPacketizer::defaultClockRate));

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -141,9 +141,9 @@ public:
 		void removeFormat(const string &fmt);
 
 		void addSSRC(uint32_t ssrc, std::optional<string> name,
-		             std::optional<string> msid = nullopt);
+					 std::optional<string> msid = nullopt, std::optional<string> trackID = nullopt);
 		void replaceSSRC(uint32_t oldSSRC, uint32_t ssrc, std::optional<string> name,
-		                 std::optional<string> msid = nullopt);
+						 std::optional<string> msid = nullopt, std::optional<string> trackID = nullopt);
 		bool hasSSRC(uint32_t ssrc);
 		std::vector<uint32_t> getSSRCs();
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -215,8 +215,9 @@ RTC_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
 /// @param _direction Direction
 /// @param _name Name (optional)
 /// @param _msid MSID (optional)
+/// @param _trackID Track ID used in MSID (optional) 
 /// @returns Track id
-RTC_EXPORT int rtcAddTrackEx(int pc, rtcCodec codec, int payloadType, uint32_t ssrc, const char *_mid, rtcDirection direction, const char *_name, const char *_msid);
+RTC_EXPORT int rtcAddTrackEx(int pc, rtcCodec codec, int payloadType, uint32_t ssrc, const char *_mid, rtcDirection direction, const char *_name, const char *_msid, const char *_trackID);
 
 /// Set H264PacketizationHandler for track
 /// @param tr Track id

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -435,7 +435,7 @@ int rtcDeleteDataChannel(int dc) {
 
 #if RTC_ENABLE_MEDIA
 
-void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, const char *_msid) {
+void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, const char *_msid, const char *_trackID) {
 
 	optional<string> name = nullopt;
 	if (_name) {
@@ -447,11 +447,16 @@ void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, 
 		msid = string(_msid);
 	}
 
-	description->addSSRC(ssrc, name, msid);
+	optional<string> trackID = nullopt;
+	if (_trackID) {
+		trackID = string(_trackID);
+	}
+
+	description->addSSRC(ssrc, name, msid, trackID);
 }
 
 int rtcAddTrackEx(int pc, rtcCodec codec, int payloadType, uint32_t ssrc, const char *_mid,
-                  rtcDirection _direction, const char *_name, const char *_msid) {
+				  rtcDirection _direction, const char *_name, const char *_msid, const char *_trackID) {
 	return WRAP({
 		auto peerConnection = getPeerConnection(pc);
 
@@ -516,7 +521,7 @@ int rtcAddTrackEx(int pc, rtcCodec codec, int payloadType, uint32_t ssrc, const 
 			throw std::invalid_argument("Unexpected codec");
 		} else {
 			auto description = optDescription.value();
-			setSSRC(&description, ssrc, _name, _msid);
+			setSSRC(&description, ssrc, _name, _msid, _trackID);
 
 			int tr = emplaceTrack(peerConnection->addTrack(std::move(description)));
 			if (auto ptr = getUserPointer(pc)) {

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -525,20 +525,20 @@ Description::Entry::removeAttribute(std::vector<string>::iterator it) {
 }
 
 void Description::Media::addSSRC(uint32_t ssrc, std::optional<string> name,
-                                 std::optional<string> msid) {
+								 std::optional<string> msid, std::optional<string> trackID) {
 	if (name)
 		mAttributes.emplace_back("ssrc:" + std::to_string(ssrc) + " cname:" + *name);
 	else
 		mAttributes.emplace_back("ssrc:" + std::to_string(ssrc));
 
 	if (msid)
-		mAttributes.emplace_back("ssrc:" + std::to_string(ssrc) + " msid:" + *msid + " " + *msid);
+		mAttributes.emplace_back("ssrc:" + std::to_string(ssrc) + " msid:" + *msid + " " + trackID.value_or(*msid));
 
 	mSsrcs.emplace_back(ssrc);
 }
 
 void Description::Media::replaceSSRC(uint32_t oldSSRC, uint32_t ssrc, std::optional<string> name,
-                                     std::optional<string> msid) {
+									 std::optional<string> msid, std::optional<string> trackID) {
 	auto it = mAttributes.begin();
 	while (it != mAttributes.end()) {
 		if (it->find("ssrc:" + std::to_string(oldSSRC)) == 0) {
@@ -546,7 +546,7 @@ void Description::Media::replaceSSRC(uint32_t oldSSRC, uint32_t ssrc, std::optio
 		} else
 			it++;
 	}
-	addSSRC(ssrc, std::move(name), std::move(msid));
+	addSSRC(ssrc, std::move(name), std::move(msid), std::move(trackID));
 }
 
 void Description::Media::removeSSRC(uint32_t oldSSRC) {


### PR DESCRIPTION
SDP line with msid contains stream id and track id. API in master branch sets stream id and track id to same value. Safari requires unique track id value for every track in same stream. This feature solves this issue by adding new optional argument in `Description::Media::addSSRC` function.