### PR TITLE
Fix: splitting of h264 NALU by start sequence

### DIFF
--- a/src/h264packetizationhandler.cpp
+++ b/src/h264packetizationhandler.cpp
@@ -110,7 +110,6 @@ shared_ptr<NalUnits> H264PacketizationHandler::splitMessage(message_ptr message)
 				break;
 			}
 		}
-		index++;
 		unsigned long long naluStartIndex = index;
 
 		while (index < message->size()) {


### PR DESCRIPTION
This may fix issue in #325 