### PR TITLE
Add copy commands that copies datachannel.dll to examples when examples built 

### DIFF
--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -4,10 +4,10 @@ if(POLICY CMP0079)
 endif()
 
 if(WIN32)
-add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h)
-target_compile_definitions(datachannel-client PUBLIC STATIC_GETOPT)
+	add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h)
+	target_compile_definitions(datachannel-client PUBLIC STATIC_GETOPT)
 else()
-add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h)
+	add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h)
 endif()
 
 set_target_properties(datachannel-client PROPERTIES
@@ -15,3 +15,10 @@ set_target_properties(datachannel-client PROPERTIES
 	OUTPUT_NAME client)
 target_link_libraries(datachannel-client datachannel nlohmann_json)
 
+if(WIN32)
+	add_custom_command(TARGET datachannel-client POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-client>
+	)
+endif()

--- a/examples/copy-paste-capi/CMakeLists.txt
+++ b/examples/copy-paste-capi/CMakeLists.txt
@@ -13,3 +13,15 @@ set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
 	OUTPUT_NAME answerer)
 target_link_libraries(datachannel-copy-paste-capi-answerer datachannel)
 
+if(WIN32)
+	add_custom_command(TARGET datachannel-copy-paste-capi-offerer POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-copy-paste-capi-offerer>
+	)
+	add_custom_command(TARGET datachannel-copy-paste-capi-answerer POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-copy-paste-capi-answerer>
+	)
+endif()

--- a/examples/copy-paste/CMakeLists.txt
+++ b/examples/copy-paste/CMakeLists.txt
@@ -12,3 +12,15 @@ set_target_properties(datachannel-copy-paste-answerer PROPERTIES
 	OUTPUT_NAME answerer)
 target_link_libraries(datachannel-copy-paste-answerer datachannel)
 
+if(WIN32)
+	add_custom_command(TARGET datachannel-copy-paste-offerer POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-copy-paste-offerer>
+	)
+	add_custom_command(TARGET datachannel-copy-paste-answerer POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-copy-paste-answerer>
+	)
+endif()

--- a/examples/media/CMakeLists.txt
+++ b/examples/media/CMakeLists.txt
@@ -6,3 +6,10 @@ set_target_properties(datachannel-media PROPERTIES
         OUTPUT_NAME media)
 target_link_libraries(datachannel-media datachannel nlohmann_json)
 
+if(WIN32)
+	add_custom_command(TARGET datachannel-media POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-media>
+	)
+endif()

--- a/examples/sfu-media/CMakeLists.txt
+++ b/examples/sfu-media/CMakeLists.txt
@@ -6,3 +6,10 @@ set_target_properties(datachannel-sfu-media PROPERTIES
 		OUTPUT_NAME sfu-media)
 target_link_libraries(datachannel-sfu-media datachannel nlohmann_json)
 
+if(WIN32)
+	add_custom_command(TARGET datachannel-sfu-media POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:datachannel-sfu-media>
+	)
+endif()

--- a/examples/streamer/CMakeLists.txt
+++ b/examples/streamer/CMakeLists.txt
@@ -4,10 +4,10 @@ if(POLICY CMP0079)
 endif()
 
 if(WIN32)
-add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
-target_compile_definitions(streamer PUBLIC STATIC_GETOPT)
+	add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
+	target_compile_definitions(streamer PUBLIC STATIC_GETOPT)
 else()
-add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
+	add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
 endif()
 set_target_properties(streamer PROPERTIES
 	CXX_STANDARD 17
@@ -17,3 +17,10 @@ target_link_libraries(streamer datachannel)
 
 target_link_libraries(streamer datachannel nlohmann_json)
 
+if(WIN32)
+	add_custom_command(TARGET streamer POST_BUILD
+		COMMAND ${CMAKE_COMMAND} -E copy_if_different
+		"$<TARGET_FILE_DIR:datachannel>/datachannel.dll"
+		$<TARGET_FILE_DIR:streamer>
+	)
+endif()

--- a/examples/streamer/CMakeLists.txt
+++ b/examples/streamer/CMakeLists.txt
@@ -3,17 +3,31 @@ if(POLICY CMP0079)
 	cmake_policy(SET CMP0079 NEW)
 endif()
 
+add_executable(streamer
+	main.cpp
+	dispatchqueue.cpp
+	dispatchqueue.hpp
+	h264fileparser.cpp
+	h264fileparser.hpp
+	helpers.cpp
+	helpers.hpp
+	opusfileparser.cpp
+	opusfileparser.hpp
+	fileparser.cpp
+	fileparser.hpp
+	stream.cpp
+	stream.hpp
+	ArgParser.cpp
+	ArgParser.hpp
+)
+
 if(WIN32)
-	add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
 	target_compile_definitions(streamer PUBLIC STATIC_GETOPT)
-else()
-	add_executable(streamer main.cpp dispatchqueue.cpp dispatchqueue.hpp h264fileparser.cpp h264fileparser.hpp helpers.cpp helpers.hpp opusfileparser.cpp opusfileparser.hpp fileparser.cpp fileparser.hpp stream.cpp stream.hpp ArgParser.hpp ArgParser.cpp)
 endif()
+
 set_target_properties(streamer PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME streamer)
-
-target_link_libraries(streamer datachannel)
 
 target_link_libraries(streamer datachannel nlohmann_json)
 


### PR DESCRIPTION
This addresses #331. Besides that, I trimmed steamer/CMakeLists.txt.