### PR TITLE
Fix path MTU

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -70,6 +70,7 @@ struct RTC_CPP_EXPORT Configuration {
 	bool enableIceTcp = false;
 	uint16_t portRangeBegin = 1024;
 	uint16_t portRangeEnd = 65535;
+	std::optional<size_t> mtu;
 };
 
 } // namespace rtc

--- a/include/rtc/include.hpp
+++ b/include/rtc/include.hpp
@@ -77,6 +77,8 @@ const size_t RECV_QUEUE_LIMIT = 1024 * 1024; // Max per-channel queue size
 
 const int THREADPOOL_SIZE = 4; // Number of threads in the global thread pool
 
+const size_t DEFAULT_IPV4_MTU = 1200; // IPv4 safe MTU value recommended by RFC 8261
+
 // overloaded helper
 template <class... Ts> struct overloaded : Ts... { using Ts::operator()...; };
 template <class... Ts> overloaded(Ts...) -> overloaded<Ts...>;

--- a/src/dtlssrtptransport.cpp
+++ b/src/dtlssrtptransport.cpp
@@ -58,10 +58,11 @@ void DtlsSrtpTransport::Cleanup() { srtp_shutdown(); }
 
 DtlsSrtpTransport::DtlsSrtpTransport(std::shared_ptr<IceTransport> lower,
                                      shared_ptr<Certificate> certificate,
+                                     std::optional<size_t> mtu,
                                      verifier_callback verifierCallback,
                                      message_callback srtpRecvCallback,
                                      state_callback stateChangeCallback)
-    : DtlsTransport(lower, certificate, std::move(verifierCallback),
+    : DtlsTransport(lower, certificate, mtu, std::move(verifierCallback),
                     std::move(stateChangeCallback)),
       mSrtpRecvCallback(std::move(srtpRecvCallback)) { // distinct from Transport recv callback
 

--- a/src/dtlssrtptransport.hpp
+++ b/src/dtlssrtptransport.hpp
@@ -39,9 +39,9 @@ public:
 	static void Init();
 	static void Cleanup();
 
-	DtlsSrtpTransport(std::shared_ptr<IceTransport> lower, std::shared_ptr<Certificate> certificate,
-	                  verifier_callback verifierCallback, message_callback srtpRecvCallback,
-	                  state_callback stateChangeCallback);
+	DtlsSrtpTransport(std::shared_ptr<IceTransport> lower, certificate_ptr certificate,
+	                  std::optional<size_t> mtu, verifier_callback verifierCallback,
+	                  message_callback srtpRecvCallback, state_callback stateChangeCallback);
 	~DtlsSrtpTransport();
 
 	bool sendMedia(message_ptr message);

--- a/src/dtlstransport.hpp
+++ b/src/dtlstransport.hpp
@@ -44,7 +44,8 @@ public:
 	using verifier_callback = std::function<bool(const std::string &fingerprint)>;
 
 	DtlsTransport(std::shared_ptr<IceTransport> lower, certificate_ptr certificate,
-	              verifier_callback verifierCallback, state_callback stateChangeCallback);
+	              std::optional<size_t> mtu, verifier_callback verifierCallback,
+	              state_callback stateChangeCallback);
 	~DtlsTransport();
 
 	virtual void start() override;
@@ -57,6 +58,7 @@ protected:
 	virtual void postHandshake();
 	void runRecvLoop();
 
+	const std::optional<size_t> mMtu;
 	const certificate_ptr mCertificate;
 	const verifier_callback mVerifierCallback;
 	const bool mIsClient;

--- a/src/sctptransport.hpp
+++ b/src/sctptransport.hpp
@@ -43,8 +43,9 @@ public:
 
 	using amount_callback = std::function<void(uint16_t streamId, size_t amount)>;
 
-	SctpTransport(std::shared_ptr<Transport> lower, uint16_t port, message_callback recvCallback,
-	              amount_callback bufferedAmountCallback, state_callback stateChangeCallback);
+	SctpTransport(std::shared_ptr<Transport> lower, uint16_t port, std::optional<size_t> mtu,
+	              message_callback recvCallback, amount_callback bufferedAmountCallback,
+	              state_callback stateChangeCallback);
 	~SctpTransport();
 
 	void start() override;

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -40,11 +40,13 @@ size_t benchmark(milliseconds duration) {
 
 	Configuration config1;
 	// config1.iceServers.emplace_back("stun:stun.l.google.com:19302");
+	// config1.mtu = 1500;
 
 	auto pc1 = std::make_shared<PeerConnection>(config1);
 
 	Configuration config2;
 	// config2.iceServers.emplace_back("stun:stun.l.google.com:19302");
+	// config2.mtu = 1500;
 
 	auto pc2 = std::make_shared<PeerConnection>(config2);
 

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -36,6 +36,8 @@ void test_connectivity() {
 	// STUN server example (not necessary to connect locally)
 	// Please do not use outside of libdatachannel tests
 	config1.iceServers.emplace_back("stun:stun.ageneau.net:3478");
+	// Custom MTU example
+	config1.mtu = 1500;
 
 	auto pc1 = std::make_shared<PeerConnection>(config1);
 
@@ -43,6 +45,8 @@ void test_connectivity() {
 	// STUN server example (not necessary to connect locally)
 	// Please do not use outside of libdatachannel tests
 	config2.iceServers.emplace_back("stun:stun.ageneau.net:3478");
+	// Custom MTU example
+	config2.mtu = 1500;
 	// Port range example
 	config2.portRangeBegin = 5000;
 	config2.portRangeEnd = 6000;


### PR DESCRIPTION
This PR fixes the path MTU to actually set it to 1200 as suggested by RFC 8261 and introduces an optional setting `mtu` in `Configuration` to change the MTU.