### PR TITLE
Candidate == operator compares also mNode and mService

### DIFF
--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -220,7 +220,9 @@ Candidate::operator string() const {
 }
 
 bool Candidate::operator==(const Candidate &other) const {
-	return mFoundation == other.mFoundation;
+	return (mFoundation == other.mFoundation &&
+	        mService == other.mService &&
+	        mNode == other.mNode);
 }
 
 bool Candidate::operator!=(const Candidate &other) const {


### PR DESCRIPTION
This takes into account some libertine implementations that don't vary foundation when they should