### PR TITLE
Fix unsynchronized access in thread pool

### DIFF
--- a/src/threadpool.hpp
+++ b/src/threadpool.hpp
@@ -72,7 +72,7 @@ protected:
 	std::function<void()> dequeue(); // returns null function if joining
 
 	std::vector<std::thread> mWorkers;
-	int mWaitingWorkers = 0;
+	int mBusyWorkers = 0;
 	std::atomic<bool> mJoining = false;
 
 	struct Task {


### PR DESCRIPTION
This PR fixes an unsynchronized access to `mWorkers` in `ThreadPool::join()` introduced by https://github.com/paullouisageneau/libdatachannel/commit/efe12f0b73dcf138ca7df32b7941d5a19ad6deb7.