### PR TITLE
Do not enable SCTP NR-SACKs

### DIFF
--- a/src/sctptransport.cpp
+++ b/src/sctptransport.cpp
@@ -87,9 +87,6 @@ void SctpTransport::Init() {
 	// Enable Partial Reliability Extension (RFC 3758)
 	usrsctp_sysctl_set_sctp_pr_enable(1);
 
-	// Enable Non-Renegable Selective Acknowledgments (NR-SACKs)
-	usrsctp_sysctl_set_sctp_nrsack_enable(1);
-
 	// Increase the initial window size to 10 MTUs (RFC 6928)
 	usrsctp_sysctl_set_sctp_initial_cwnd(10);
 


### PR DESCRIPTION
This PR removes SCTP Non-Renegable Selective Acknowledgments (NR-SACK). This option should enable the sender to free space sooner in its buffer, but they seem to cause performance issues, especially with higher RTTs.