### PR TITLE
Use default congestion control

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -82,8 +82,10 @@ void SctpTransport::Init() {
 
 	usrsctp_sysctl_set_sctp_max_chunks_on_queue(10 * 1024);
 
-	// Change congestion control from the default TCP Reno (RFC 2581) to H-TCP
-	usrsctp_sysctl_set_sctp_default_cc_module(SCTP_CC_HTCP);
+	// Use default congestion control same as WebRTC
+	// SCTP_CC_HTCP mode is problematic
+	// See https://github.com/paullouisageneau/libdatachannel/issues/354
+	// usrsctp_sysctl_set_sctp_default_cc_module(SCTP_CC_HTCP);
 
 	// Enable Partial Reliability Extension (RFC 3758)
 	usrsctp_sysctl_set_sctp_pr_enable(1);


### PR DESCRIPTION
Using SCTP_CC_HTCP mode seems problematic. Use default congestion control mode.

For reference: https://github.com/paullouisageneau/libdatachannel/issues/354