### PR TITLE
Follow-up on #365

### DIFF
--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -182,11 +182,11 @@ bool Track::transportSend([[maybe_unused]] message_ptr message) {
 void Track::setMediaHandler(shared_ptr<MediaHandler> handler) {
 	{
 		std::unique_lock lock(mMutex);
-		mMediaHandler = std::move(handler);
+		mMediaHandler = handler;
 	}
 
-	if (mMediaHandler)
-		mMediaHandler->onOutgoing(std::bind(&Track::transportSend, this, std::placeholders::_1));
+	if (handler)
+		handler->onOutgoing(std::bind(&Track::transportSend, this, std::placeholders::_1));
 }
 
 shared_ptr<MediaHandler> Track::getMediaHandler() {

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -182,6 +182,9 @@ bool Track::transportSend([[maybe_unused]] message_ptr message) {
 void Track::setMediaHandler(shared_ptr<MediaHandler> handler) {
 	{
 		std::unique_lock lock(mMutex);
+		if (mMediaHandler)
+			mMediaHandler->onOutgoing(nullptr);
+
 		mMediaHandler = handler;
 	}
 


### PR DESCRIPTION
This PR fixes the synchronization regression introduced in https://github.com/paullouisageneau/libdatachannel/pull/365 and resets outgoing callback when switching media handlers.