### PR TITLE
Always negotiate SRTP profile in DTLS handshake

### DIFF
--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -68,18 +68,6 @@ DtlsSrtpTransport::DtlsSrtpTransport(shared_ptr<IceTransport> lower,
 
 	PLOG_DEBUG << "Initializing DTLS-SRTP transport";
 
-#if USE_GNUTLS
-	PLOG_DEBUG << "Setting SRTP profile (GnuTLS)";
-	gnutls::check(gnutls_srtp_set_profile(mSession, GNUTLS_SRTP_AES128_CM_HMAC_SHA1_80),
-	              "Failed to set SRTP profile");
-#else
-	PLOG_DEBUG << "Setting SRTP profile (OpenSSL)";
-	// returns 0 on success, 1 on error
-	if (SSL_set_tlsext_use_srtp(mSsl, "SRTP_AES128_CM_SHA1_80"))
-		throw std::runtime_error("Failed to set SRTP profile: " +
-		                         openssl::error_string(ERR_get_error()));
-#endif
-
 	if (srtp_err_status_t err = srtp_create(&mSrtpIn, nullptr)) {
 		throw std::runtime_error("SRTP create failed, status=" + to_string(static_cast<int>(err)));
 	}


### PR DESCRIPTION
This PR makes the DTLS handshake always negotiate the SRTP profile.

Fixes https://github.com/pion/dtls/issues/356