### PR TITLE
Queue for incoming Data Channels and Tracks

### DIFF
--- a/include/rtc/utils.hpp
+++ b/include/rtc/utils.hpp
@@ -85,10 +85,13 @@ public:
 		return *this;
 	}
 
-	void operator()(Args... args) const {
+	bool operator()(Args... args) const {
 		std::lock_guard lock(mutex);
-		if (callback)
-			callback(std::move(args)...);
+		if (!callback)
+			return false;
+
+		callback(std::move(args)...);
+		return true;
 	}
 
 	operator bool() const {

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -85,8 +85,9 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void processRemoteCandidate(Candidate candidate);
 	string localBundleMid() const;
 
-	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel);
-	void triggerTrack(shared_ptr<Track> track);
+	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel = {});
+	void triggerTrack(weak_ptr<Track> weakTrack = {});
+
 	bool changeState(State newState);
 	bool changeGatheringState(GatheringState newState);
 	bool changeSignalingState(SignalingState newState);
@@ -126,6 +127,9 @@ private:
 	std::unordered_map<string, weak_ptr<Track>> mTracks;               // by mid
 	std::vector<weak_ptr<Track>> mTrackLines;                          // by SDP order
 	std::shared_mutex mDataChannelsMutex, mTracksMutex;
+
+	Queue<shared_ptr<DataChannel>> mPendingDataChannels;
+	Queue<shared_ptr<Track>> mPendingTracks;
 
 	std::unordered_map<uint32_t, string> mMidFromSsrc; // cache
 };

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -278,6 +278,7 @@ shared_ptr<DataChannel> PeerConnection::createDataChannel(string label, DataChan
 void PeerConnection::onDataChannel(
     std::function<void(shared_ptr<DataChannel> dataChannel)> callback) {
 	impl()->dataChannelCallback = callback;
+	impl()->triggerDataChannel(); // trigger pending DataChannels
 }
 
 std::shared_ptr<Track> PeerConnection::addTrack(Description::Media description) {
@@ -292,6 +293,7 @@ std::shared_ptr<Track> PeerConnection::addTrack(Description::Media description) 
 
 void PeerConnection::onTrack(std::function<void(std::shared_ptr<Track>)> callback) {
 	impl()->trackCallback = callback;
+	impl()->triggerTrack(); // trigger pending tracks
 }
 
 void PeerConnection::onLocalDescription(std::function<void(Description description)> callback) {


### PR DESCRIPTION
This PR adds a pending queue for incoming Data Channels and Tracks. It allows setting callbacks later without missing Data Channels and Tracks.

Addresses https://github.com/murat-dogan/node-datachannel/issues/25#issuecomment-792605397