### PR TITLE
Fix DataChannel stream number assignment on double offer

### DIFF
--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -170,6 +170,7 @@ size_t DataChannel::maxMessageSize() const {
 }
 
 void DataChannel::shiftStream() {
+	std::shared_lock lock(mMutex);
 	if (mStream % 2 == 1)
 		mStream -= 1;
 }

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -65,8 +65,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
 	optional<string> getMidFromSsrc(uint32_t ssrc);
 
-	shared_ptr<DataChannel> emplaceDataChannel(Description::Role role, string label,
-	                                           DataChannelInit init);
+	shared_ptr<DataChannel> emplaceDataChannel(string label, DataChannelInit init);
 	shared_ptr<DataChannel> findDataChannel(uint16_t stream);
 	void shiftDataChannels();
 	void iterateDataChannels(std::function<void(shared_ptr<DataChannel> channel)> func);


### PR DESCRIPTION
This PR fixes Data Channel stream number shifting when the negotiation starts with offers on both sides. Stream numbers could have the wrong parity if the final answer arrived too late.