### PR TITLE
Call DataChannel::onOpen() callback on receiving side

### DIFF
--- a/examples/client/main.cpp
+++ b/examples/client/main.cpp
@@ -222,17 +222,20 @@ shared_ptr<PeerConnection> createPeerConnection(const Configuration &config,
 		cout << "DataChannel from " << id << " received with label \"" << dc->label() << "\""
 		     << endl;
 
+		dc->onOpen([wdc = make_weak_ptr(dc)]() {
+			if (auto dc = wdc.lock())
+				dc->send("Hello from " + localId);
+		});
+
 		dc->onClosed([id]() { cout << "DataChannel from " << id << " closed" << endl; });
 
-		dc->onMessage([id, wdc = make_weak_ptr(dc)](variant<binary, string> data) {
+		dc->onMessage([id](variant<binary, string> data) {
 			if (holds_alternative<string>(data))
 				cout << "Message from " << id << " received: " << get<string>(data) << endl;
 			else
 				cout << "Binary message from " << id
 				     << " received, size=" << get<binary>(data).size() << endl;
 		});
-
-		dc->send("Hello from " + localId);
 
 		dataChannelMap.emplace(id, dc);
 	});
@@ -251,4 +254,3 @@ string randomId(size_t length) {
 	generate(id.begin(), id.end(), [&]() { return characters.at(dist(rng)); });
 	return id;
 }
-

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -43,10 +43,7 @@ void Channel::onError(std::function<void(string error)> callback) {
 
 void Channel::onMessage(std::function<void(message_variant data)> callback) {
 	impl()->messageCallback = callback;
-
-	// Pass pending messages
-	while (auto message = receive())
-		impl()->messageCallback(*message);
+	impl()->flushPendingMessages();
 }
 
 void Channel::onMessage(std::function<void(binary data)> binaryCallback,

--- a/src/impl/channel.cpp
+++ b/src/impl/channel.cpp
@@ -20,22 +20,21 @@
 
 namespace rtc::impl {
 
-void Channel::triggerOpen() { openCallback(); }
+void Channel::triggerOpen() {
+	mOpenTriggered = true;
+	openCallback();
+	flushPendingMessages();
+}
 
 void Channel::triggerClosed() { closedCallback(); }
 
-void Channel::triggerError(string error) { errorCallback(error); }
+void Channel::triggerError(string error) { errorCallback(std::move(error)); }
 
 void Channel::triggerAvailable(size_t count) {
 	if (count == 1)
 		availableCallback();
 
-	while (messageCallback && count--) {
-		auto message = receive();
-		if (!message)
-			break;
-		messageCallback(*message);
-	}
+	flushPendingMessages();
 }
 
 void Channel::triggerBufferedAmount(size_t amount) {
@@ -43,6 +42,24 @@ void Channel::triggerBufferedAmount(size_t amount) {
 	size_t threshold = bufferedAmountLowThreshold.load();
 	if (previous > threshold && amount <= threshold)
 		bufferedAmountLowCallback();
+}
+
+void Channel::flushPendingMessages() {
+	if (!mOpenTriggered)
+		return;
+
+	while (messageCallback) {
+		auto next = receive();
+		if (!next)
+			break;
+
+		messageCallback(*next);
+	}
+}
+
+void Channel::resetOpenCallback() {
+	mOpenTriggered = false;
+	openCallback = nullptr;
 }
 
 void Channel::resetCallbacks() {

--- a/src/impl/channel.cpp
+++ b/src/impl/channel.cpp
@@ -63,12 +63,13 @@ void Channel::resetOpenCallback() {
 }
 
 void Channel::resetCallbacks() {
+	mOpenTriggered = false;
 	openCallback = nullptr;
 	closedCallback = nullptr;
 	errorCallback = nullptr;
-	messageCallback = nullptr;
 	availableCallback = nullptr;
 	bufferedAmountLowCallback = nullptr;
+	messageCallback = nullptr;
 }
 
 } // namespace rtc::impl

--- a/src/impl/channel.hpp
+++ b/src/impl/channel.hpp
@@ -38,7 +38,9 @@ struct Channel {
 	virtual void triggerAvailable(size_t count);
 	virtual void triggerBufferedAmount(size_t amount);
 
-	virtual void resetCallbacks();
+	void flushPendingMessages();
+	void resetOpenCallback();
+	void resetCallbacks();
 
 	synchronized_callback<> openCallback;
 	synchronized_callback<> closedCallback;
@@ -49,6 +51,9 @@ struct Channel {
 
 	std::atomic<size_t> bufferedAmount = 0;
 	std::atomic<size_t> bufferedAmountLowThreshold = 0;
+
+private:
+	std::atomic<bool> mOpenTriggered = false;
 };
 
 } // namespace rtc::impl

--- a/src/impl/channel.hpp
+++ b/src/impl/channel.hpp
@@ -42,12 +42,13 @@ struct Channel {
 	void resetOpenCallback();
 	void resetCallbacks();
 
-	synchronized_callback<> openCallback;
-	synchronized_callback<> closedCallback;
-	synchronized_callback<string> errorCallback;
+	synchronized_stored_callback<> openCallback;
+	synchronized_stored_callback<> closedCallback;
+	synchronized_stored_callback<string> errorCallback;
+	synchronized_stored_callback<> availableCallback;
+	synchronized_stored_callback<> bufferedAmountLowCallback;
+
 	synchronized_callback<message_variant> messageCallback;
-	synchronized_callback<> availableCallback;
-	synchronized_callback<> bufferedAmountLowCallback;
 
 	std::atomic<size_t> bufferedAmount = 0;
 	std::atomic<size_t> bufferedAmountLowThreshold = 0;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -973,17 +973,19 @@ string PeerConnection::localBundleMid() const {
 
 void PeerConnection::triggerDataChannel(weak_ptr<DataChannel> weakDataChannel) {
 	auto dataChannel = weakDataChannel.lock();
-	if (dataChannel)
+	if (dataChannel) {
+		dataChannel->openCallback = nullptr; // might be set internally
 		mPendingDataChannels.push(std::move(dataChannel));
-
+	}
 	triggerPendingDataChannels();
 }
 
 void PeerConnection::triggerTrack(weak_ptr<Track> weakTrack) {
 	auto track = weakTrack.lock();
-	if (track)
+	if (track) {
+		track->openCallback = nullptr; // might be set internally
 		mPendingTracks.push(std::move(track));
-
+	}
 	triggerPendingTracks();
 }
 
@@ -995,6 +997,7 @@ void PeerConnection::triggerPendingDataChannels() {
 
 		auto impl = std::move(*next);
 		dataChannelCallback(std::make_shared<rtc::DataChannel>(impl));
+		impl->triggerOpen();
 	}
 }
 
@@ -1006,6 +1009,7 @@ void PeerConnection::triggerPendingTracks() {
 
 		auto impl = std::move(*next);
 		trackCallback(std::make_shared<rtc::Track>(std::move(impl)));
+		impl->triggerOpen();
 	}
 }
 

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -974,7 +974,7 @@ string PeerConnection::localBundleMid() const {
 void PeerConnection::triggerDataChannel(weak_ptr<DataChannel> weakDataChannel) {
 	auto dataChannel = weakDataChannel.lock();
 	if (dataChannel) {
-		dataChannel->openCallback = nullptr; // might be set internally
+		dataChannel->resetOpenCallback(); // might be set internally
 		mPendingDataChannels.push(std::move(dataChannel));
 	}
 	triggerPendingDataChannels();
@@ -983,7 +983,7 @@ void PeerConnection::triggerDataChannel(weak_ptr<DataChannel> weakDataChannel) {
 void PeerConnection::triggerTrack(weak_ptr<Track> weakTrack) {
 	auto track = weakTrack.lock();
 	if (track) {
-		track->openCallback = nullptr; // might be set internally
+		track->resetOpenCallback(); // might be set internally
 		mPendingTracks.push(std::move(track));
 	}
 	triggerPendingTracks();
@@ -1008,7 +1008,7 @@ void PeerConnection::triggerPendingTracks() {
 			break;
 
 		auto impl = std::move(*next);
-		trackCallback(std::make_shared<rtc::Track>(std::move(impl)));
+		trackCallback(std::make_shared<rtc::Track>(impl));
 		impl->triggerOpen();
 	}
 }

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -84,8 +84,14 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void processRemoteCandidate(Candidate candidate);
 	string localBundleMid() const;
 
-	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel = {});
-	void triggerTrack(weak_ptr<Track> weakTrack = {});
+	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel);
+	void triggerTrack(weak_ptr<Track> weakTrack);
+
+	void triggerPendingDataChannels();
+	void triggerPendingTracks();
+
+	void flushPendingDataChannels();
+	void flushPendingTracks();
 
 	bool changeState(State newState);
 	bool changeGatheringState(GatheringState newState);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -267,7 +267,7 @@ shared_ptr<DataChannel> PeerConnection::createDataChannel(string label, DataChan
 void PeerConnection::onDataChannel(
     std::function<void(shared_ptr<DataChannel> dataChannel)> callback) {
 	impl()->dataChannelCallback = callback;
-	impl()->triggerDataChannel(); // trigger pending DataChannels
+	impl()->flushPendingDataChannels();
 }
 
 std::shared_ptr<Track> PeerConnection::addTrack(Description::Media description) {
@@ -282,7 +282,7 @@ std::shared_ptr<Track> PeerConnection::addTrack(Description::Media description) 
 
 void PeerConnection::onTrack(std::function<void(std::shared_ptr<Track>)> callback) {
 	impl()->trackCallback = callback;
-	impl()->triggerTrack(); // trigger pending tracks
+	impl()->flushPendingTracks();
 }
 
 void PeerConnection::onLocalDescription(std::function<void(Description description)> callback) {

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -137,11 +137,11 @@ static void RTC_API dataChannelCallback(int pc, int dc, void *ptr) {
 		return;
 	}
 
+	rtcSetOpenCallback(dc, openCallback);
 	rtcSetClosedCallback(dc, closedCallback);
 	rtcSetMessageCallback(dc, messageCallback);
 
 	peer->dc = dc;
-	peer->connected = true;
 
 	const char *message = peer == peer1 ? "Hello from 1" : "Hello from 2";
 	rtcSendMessage(peer->dc, message, -1); // negative size indicates a null-terminated string

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -83,7 +83,7 @@ static void RTC_API closedCallback(int id, void *ptr) {
 static void RTC_API trackCallback(int pc, int tr, void *ptr) {
 	Peer *peer = (Peer *)ptr;
 	peer->tr = tr;
-	peer->connected = true;
+	rtcSetOpenCallback(tr, openCallback);
 	rtcSetClosedCallback(tr, closedCallback);
 
 	char buffer[1024];

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -107,26 +107,29 @@ void test_connectivity() {
 			return;
 		}
 
+		dc->onOpen([wdc = make_weak_ptr(dc)]() {
+			if (auto dc = wdc.lock())
+				dc->send("Hello from 2");
+		});
+
 		dc->onMessage([](variant<binary, string> message) {
 			if (holds_alternative<string>(message)) {
 				cout << "Message 2: " << get<string>(message) << endl;
 			}
 		});
 
-		dc->send("Hello from 2");
-
 		std::atomic_store(&dc2, dc);
 	});
 
 	auto dc1 = pc1.createDataChannel("test");
-	dc1->onOpen([wdc1 = make_weak_ptr(dc1)]() {
-		auto dc1 = wdc1.lock();
-		if (!dc1)
-			return;
 
-		cout << "DataChannel 1: Open" << endl;
-		dc1->send("Hello from 1");
+	dc1->onOpen([wdc1 = make_weak_ptr(dc1)]() {
+		if (auto dc1 = wdc1.lock()) {
+			cout << "DataChannel 1: Open" << endl;
+			dc1->send("Hello from 1");
+		}
 	});
+
 	dc1->onMessage([](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {
 			cout << "Message 1: " << get<string>(message) << endl;
@@ -177,25 +180,26 @@ void test_connectivity() {
 			return;
 		}
 
+		dc->onOpen([wdc = make_weak_ptr(dc)]() {
+			if (auto dc = wdc.lock())
+				dc->send("Second hello from 2");
+		});
+
 		dc->onMessage([](variant<binary, string> message) {
 			if (holds_alternative<string>(message)) {
 				cout << "Second Message 2: " << get<string>(message) << endl;
 			}
 		});
 
-		dc->send("Send hello from 2");
-
 		std::atomic_store(&second2, dc);
 	});
 
 	auto second1 = pc1.createDataChannel("second");
 	second1->onOpen([wsecond1 = make_weak_ptr(dc1)]() {
-		auto second1 = wsecond1.lock();
-		if (!second1)
-			return;
-
-		cout << "Second DataChannel 1: Open" << endl;
-		second1->send("Second hello from 1");
+		if (auto second1 = wsecond1.lock()) {
+			cout << "Second DataChannel 1: Open" << endl;
+			second1->send("Second hello from 1");
+		}
 	});
 	dc1->onMessage([](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {

--- a/test/turn_connectivity.cpp
+++ b/test/turn_connectivity.cpp
@@ -108,13 +108,16 @@ void test_turn_connectivity() {
 			return;
 		}
 
+		dc->onOpen([wdc = make_weak_ptr(dc)]() {
+			if (auto dc = wdc.lock())
+				dc->send("Hello from 2");
+		});
+
 		dc->onMessage([](variant<binary, string> message) {
 			if (holds_alternative<string>(message)) {
 				cout << "Message 2: " << get<string>(message) << endl;
 			}
 		});
-
-		dc->send("Hello from 2");
 
 		std::atomic_store(&dc2, dc);
 	});
@@ -175,13 +178,16 @@ void test_turn_connectivity() {
 			return;
 		}
 
+		dc->onOpen([wdc = make_weak_ptr(dc)]() {
+			if (auto dc = wdc.lock())
+				dc->send("Second hello from 2");
+		});
+
 		dc->onMessage([](variant<binary, string> message) {
 			if (holds_alternative<string>(message)) {
 				cout << "Second Message 2: " << get<string>(message) << endl;
 			}
 		});
-
-		dc->send("Send hello from 2");
 
 		std::atomic_store(&second2, dc);
 	});


### PR DESCRIPTION
This PR introduces a retro-compatible behavior change to mimic the browser API behavior: the `DataChannel::onOpen()` callback is now scheduled to be called just after the `onDataChannel()` callback. 

The incoming `DataChannel` is still guaranteed to be open when passed to the `onDataChannel()` callback, meaning there is no impact on existing user code.

Implements https://github.com/paullouisageneau/libdatachannel/issues/403