### PR TITLE
Remove usrsctp data race mitigation

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -416,9 +416,6 @@ void SctpTransport::incoming(message_ptr message) {
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
 
-	// TODO: There seems to be a possible data race between usrsctp_sendv() and usrsctp_conninput()
-	// As a mitigation, lock the send mutex before calling usrsctp_conninput()
-	std::lock_guard lock(mSendMutex);
 	usrsctp_conninput(this, message->data(), message->size(), 0);
 }
 


### PR DESCRIPTION
This PR removes the (probably useless) usrsctp data race mitigation as it can introduce a delay on closing. It means `usrsctp_sendv()` probably introduces the delay in the first place, this should be investigated later.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/422