### PR TITLE
Add bind address in configuration

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -74,6 +74,7 @@ struct RTC_CPP_EXPORT Configuration {
 	// ICE settings
 	std::vector<IceServer> iceServers;
 	optional<ProxyServer> proxyServer; // libnice only
+	optional<string> bindAddress;      // libjuice only, default any
 
 	// Options
 	CertificateType certificateType = CertificateType::Default;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -150,13 +150,14 @@ RTC_EXPORT void *rtcGetUserPointer(int i);
 typedef struct {
 	const char **iceServers;
 	int iceServersCount;
+	const char *bindAddress; // libjuice only, NULL means any
 	rtcCertificateType certificateType;
 	bool enableIceTcp;
 	bool disableAutoNegotiation;
-	uint16_t portRangeBegin;
-	uint16_t portRangeEnd;
-	int mtu;            // <= 0 means automatic
-	int maxMessageSize; // <= 0 means default
+	uint16_t portRangeBegin; // 0 means automatic
+	uint16_t portRangeEnd;   // 0 means automatic
+	int mtu;                 // <= 0 means automatic
+	int maxMessageSize;      // <= 0 means default
 } rtcConfiguration;
 
 RTC_EXPORT int rtcCreatePeerConnection(const rtcConfiguration *config); // returns pc id

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -290,14 +290,17 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 		for (int i = 0; i < config->iceServersCount; ++i)
 			c.iceServers.emplace_back(string(config->iceServers[i]));
 
-		c.certificateType = static_cast<CertificateType>(config->certificateType);
-		c.enableIceTcp = config->enableIceTcp;
-		c.disableAutoNegotiation = config->disableAutoNegotiation;
+		if (config->bindAddress)
+			c.bindAddress = string(config->bindAddress);
 
 		if (config->portRangeBegin > 0 || config->portRangeEnd > 0) {
 			c.portRangeBegin = config->portRangeBegin;
 			c.portRangeEnd = config->portRangeEnd;
 		}
+
+		c.certificateType = static_cast<CertificateType>(config->certificateType);
+		c.enableIceTcp = config->enableIceTcp;
+		c.disableAutoNegotiation = config->disableAutoNegotiation;
 
 		if (config->mtu > 0)
 			c.mtu = size_t(config->mtu);

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -131,6 +131,11 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	jconfig.turn_servers = k > 0 ? turn_servers : nullptr;
 	jconfig.turn_servers_count = k;
 
+	// Bind address
+	if (config.bindAddress) {
+		jconfig.bind_address = config.bindAddress->c_str();
+	}
+
 	// Port range
 	if (config.portRangeBegin > 1024 ||
 	    (config.portRangeEnd != 0 && config.portRangeEnd != 65535)) {


### PR DESCRIPTION
This PR adds a `bindAddress` setting in `Configuration` to bind only on a specific local interface (ignored with libnice as ICE backend).

Solves https://github.com/paullouisageneau/libdatachannel/issues/421