### PR TITLE
Expose more SCTP settings and reduce min RTO

### DIFF
--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -54,6 +54,11 @@ struct SctpSettings {
 	optional<size_t> maxBurst;                      // in MTUs
 	optional<unsigned int> congestionControlModule; // 0: RFC2581, 1: HSTCP, 2: H-TCP, 3: RTCC
 	optional<std::chrono::milliseconds> delayedSackTime;
+	optional<std::chrono::milliseconds> minRetransmitTimeout;
+	optional<std::chrono::milliseconds> maxRetransmitTimeout;
+	optional<std::chrono::milliseconds> initialRetransmitTimeout;
+	optional<unsigned int> maxRetransmitAttempts;
+	optional<std::chrono::milliseconds> heartbeatInterval;
 };
 
 RTC_EXPORT void SetSctpSettings(SctpSettings s);

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -346,7 +346,7 @@ typedef struct {
 	int initialCongestionWindow;    // in MTUs, <= 0 means optimized default
 	int maxBurst;                   // in MTUs, 0 means optimized default, < 0 means disabled
 	int congestionControlModule;    // 0: RFC2581 (default), 1: HSTCP, 2: H-TCP, 3: RTCC
-	int delayedSackTimeMs;          // in msecs, <= 0 means optimized default
+	int delayedSackTimeMs;          // in msecs, 0 means optimized default, < 0 means disabled
 	int minRetransmitTimeoutMs;     // in msecs, <= 0 means optimized default
 	int maxRetransmitTimeoutMs;     // in msecs, <= 0 means optimized default
 	int initialRetransmitTimeoutMs; // in msecs, <= 0 means optimized default

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -340,13 +340,18 @@ RTC_EXPORT void rtcCleanup(void);
 // SCTP global settings
 
 typedef struct {
-	int recvBufferSize;          // in bytes, <= 0 means optimized default
-	int sendBufferSize;          // in bytes, <= 0 means optimized default
-	int maxChunksOnQueue;        // in chunks, <= 0 means optimized default
-	int initialCongestionWindow; // in MTUs, <= 0 means optimized default
-	int maxBurst;                // in MTUs, 0 means optimized default, < 0 means disabled
-	int congestionControlModule; // 0: RFC2581 (default), 1: HSTCP, 2: H-TCP, 3: RTCC
-	int delayedSackTimeMs;       // in msecs, <= 0 means optimized default
+	int recvBufferSize;             // in bytes, <= 0 means optimized default
+	int sendBufferSize;             // in bytes, <= 0 means optimized default
+	int maxChunksOnQueue;           // in chunks, <= 0 means optimized default
+	int initialCongestionWindow;    // in MTUs, <= 0 means optimized default
+	int maxBurst;                   // in MTUs, 0 means optimized default, < 0 means disabled
+	int congestionControlModule;    // 0: RFC2581 (default), 1: HSTCP, 2: H-TCP, 3: RTCC
+	int delayedSackTimeMs;          // in msecs, <= 0 means optimized default
+	int minRetransmitTimeoutMs;     // in msecs, <= 0 means optimized default
+	int maxRetransmitTimeoutMs;     // in msecs, <= 0 means optimized default
+	int initialRetransmitTimeoutMs; // in msecs, <= 0 means optimized default
+	int maxRetransmitAttempts;      // number of retransmissions, <= 0 means optimized default
+	int heartbeatIntervalMs;        // in msecs, <= 0 means optimized default
 } rtcSctpSettings;
 
 // Note: SCTP settings apply to newly-created PeerConnections only

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1139,6 +1139,8 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 
 		if (settings->delayedSackTimeMs > 0)
 			s.delayedSackTime = std::chrono::milliseconds(settings->delayedSackTimeMs);
+		else if (settings->delayedSackTimeMs < 0)
+			s.delayedSackTime = std::chrono::milliseconds(0);
 
 		if (settings->minRetransmitTimeoutMs > 0)
 			s.minRetransmitTimeout = std::chrono::milliseconds(settings->minRetransmitTimeoutMs);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1140,6 +1140,21 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 		if (settings->delayedSackTimeMs > 0)
 			s.delayedSackTime = std::chrono::milliseconds(settings->delayedSackTimeMs);
 
+		if (settings->minRetransmitTimeoutMs > 0)
+			s.minRetransmitTimeout = std::chrono::milliseconds(settings->minRetransmitTimeoutMs);
+
+		if (settings->maxRetransmitTimeoutMs > 0)
+			s.maxRetransmitTimeout = std::chrono::milliseconds(settings->maxRetransmitTimeoutMs);
+
+		if (settings->initialRetransmitTimeoutMs > 0)
+			s.initialRetransmitTimeout = std::chrono::milliseconds(settings->initialRetransmitTimeoutMs);
+
+		if (settings->maxRetransmitAttempts > 0)
+			s.maxRetransmitAttempts = settings->maxRetransmitAttempts;
+
+		if (settings->heartbeatIntervalMs > 0)
+			s.heartbeatInterval = std::chrono::milliseconds(settings->heartbeatIntervalMs);
+
 		SetSctpSettings(std::move(s));
 		return RTC_ERR_SUCCESS;
 	});

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -118,17 +118,21 @@ void SctpTransport::SetSettings(const SctpSettings &s) {
 	usrsctp_sysctl_set_sctp_delayed_sack_time_default(
 	    to_uint32(s.delayedSackTime.value_or(20ms).count()));
 
-	// RTO
+	// RTO settings
+	// RFC 2988 recommends a 1s min RTO, which is very high, but TCP on Linux has a 200ms min RTO
 	usrsctp_sysctl_set_sctp_rto_min_default(
-	    to_uint32(s.minRetransmitTimeout.value_or(1000ms).count()));
+	    to_uint32(s.minRetransmitTimeout.value_or(200ms).count()));
+	// Set only 10s as max RTO instead of 60s for shorter connection timeout
 	usrsctp_sysctl_set_sctp_rto_max_default(
 	    to_uint32(s.maxRetransmitTimeout.value_or(10000ms).count()));
-	usrsctp_sysctl_set_sctp_rto_initial_default(
-	    to_uint32(s.initialRetransmitTimeout.value_or(1000ms).count()));
 	usrsctp_sysctl_set_sctp_init_rto_max_default(
 	    to_uint32(s.maxRetransmitTimeout.value_or(10000ms).count()));
+	// Still set 1s as initial RTO
+	usrsctp_sysctl_set_sctp_rto_initial_default(
+	    to_uint32(s.initialRetransmitTimeout.value_or(1000ms).count()));
 
-	// RTX
+	// RTX settings
+	// 5 retransmissions instead of 8 to shorten the backoff for shorter connection timeout
 	auto maxRtx = to_uint32(s.maxRetransmitAttempts.value_or(5));
 	usrsctp_sysctl_set_sctp_init_rtx_max_default(maxRtx);
 	usrsctp_sysctl_set_sctp_assoc_rtx_max_default(maxRtx);


### PR DESCRIPTION
This PR exposes SCTP RTO, RTX, and heartbeat settings and reduces SCTP min RTO to 200ms. It also allows disabling SCTP SACK from C API.

Should help with https://github.com/paullouisageneau/libdatachannel/issues/409