### PR TITLE
Fix possible static de-initialization order issue in SctpTransport 

### DIFF
--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -120,8 +120,8 @@ private:
 	static void UpcallCallback(struct socket *sock, void *arg, int flags);
 	static int WriteCallback(void *sctp_ptr, void *data, size_t len, uint8_t tos, uint8_t set_df);
 
-	static std::unordered_set<SctpTransport *> Instances;
-	static std::shared_mutex InstancesMutex;
+	class InstancesSet;
+	static InstancesSet *Instances;
 };
 
 } // namespace rtc::impl


### PR DESCRIPTION
This PR fixes a static de-initialization order issue that could arise with globally-owned `PeerConnection` resulting in invalid accesses to the global `Instances` set.