### PR TITLE
Add ostream operator for LogLevel

### DIFF
--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -22,6 +22,7 @@
 #include "common.hpp"
 
 #include <chrono>
+#include <iostream>
 
 namespace rtc {
 
@@ -42,8 +43,8 @@ RTC_CPP_EXPORT void InitLogger(LogLevel level, LogCallback callback = nullptr);
 RTC_CPP_EXPORT void InitLogger(plog::Severity severity, plog::IAppender *appender = nullptr);
 #endif
 
-RTC_EXPORT void Preload();
-RTC_EXPORT void Cleanup();
+RTC_CPP_EXPORT void Preload();
+RTC_CPP_EXPORT void Cleanup();
 
 struct SctpSettings {
 	// For the following settings, not set means optimized default
@@ -56,8 +57,10 @@ struct SctpSettings {
 	optional<std::chrono::milliseconds> delayedSackTime;
 };
 
-RTC_EXPORT void SetSctpSettings(SctpSettings s);
+RTC_CPP_EXPORT void SetSctpSettings(SctpSettings s);
 
 } // namespace rtc
+
+RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, rtc::LogLevel level);
 
 #endif

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -980,18 +980,17 @@ std::ostream &operator<<(std::ostream &out, rtc::Description::Type type) {
 
 std::ostream &operator<<(std::ostream &out, rtc::Description::Role role) {
 	using Role = rtc::Description::Role;
-	const char *str;
 	// Used for SDP generation, do not change
 	switch (role) {
 	case Role::Active:
-		str = "active";
+		out << "active";
 		break;
 	case Role::Passive:
-		str = "passive";
+		out << "passive";
 		break;
 	default:
-		str = "actpass";
+		out << "actpass";
 		break;
 	}
-	return out << str;
+	return out;
 }

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -93,3 +93,31 @@ void Cleanup() { Init::Cleanup(); }
 void SetSctpSettings(SctpSettings s) { Init::SetSctpSettings(std::move(s)); }
 
 } // namespace rtc
+
+RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, rtc::LogLevel level) {
+	switch (level) {
+	case rtc::LogLevel::Fatal:
+		out << "fatal";
+		break;
+	case rtc::LogLevel::Error:
+		out << "error";
+		break;
+	case rtc::LogLevel::Warning:
+		out << "warning";
+		break;
+	case rtc::LogLevel::Info:
+		out << "info";
+		break;
+	case rtc::LogLevel::Debug:
+		out << "debug";
+		break;
+	case rtc::LogLevel::Verbose:
+		out << "verbose";
+		break;
+	default:
+		out << "none";
+		break;
+	}
+	return out;
+}
+


### PR DESCRIPTION
This PR adds an ostream operator << for `rtc::LogLevel`.