### PR TITLE
Removed ThreadPool join at exit

### DIFF
--- a/src/impl/threadpool.cpp
+++ b/src/impl/threadpool.cpp
@@ -20,12 +20,6 @@
 
 #include <cstdlib>
 
-namespace {
-
-void joinThreadPoolInstance() { rtc::impl::ThreadPool::Instance().join(); }
-
-} // namespace
-
 namespace rtc::impl {
 
 ThreadPool &ThreadPool::Instance() {
@@ -33,7 +27,7 @@ ThreadPool &ThreadPool::Instance() {
 	return *instance;
 }
 
-ThreadPool::ThreadPool() { std::atexit(joinThreadPoolInstance); }
+ThreadPool::ThreadPool() {}
 
 ThreadPool::~ThreadPool() {}
 


### PR DESCRIPTION
This PR removes `ThreadPool` joining at exit, as it is not indispensable and it might result in the program hanging at exit if a `PeerConnection` is closed from a global destructor. The threads may still be stopped following a call to `rtc::Cleanup()`.

Fixes the issue reported in https://github.com/arvidn/libtorrent/pull/6233#issuecomment-860110806