### PR TITLE
Add ICE transport policy option

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -72,6 +72,7 @@ typedef struct {
 	const char **iceServers;
 	int iceServersCount;
 	rtcCertificateType certificateType;
+	rtcTransportPolicy iceTransportPolicy;
 	bool enableIceTcp;
 	bool disableAutoNegotiation;
 	uint16_t portRangeBegin;
@@ -88,6 +89,7 @@ Arguments:
   - `iceServersCount` (optional): number of URLs in the array pointed by `iceServers` (0 if unused)
   - `bindAddress` (optional): if non-NULL, bind only to the given local address (ignored with libnice as ICE backend)
   - `certificateType` (optional): certificate type, either `RTC_CERTIFICATE_ECDSA` or `RTC_CERTIFICATE_RSA` (0 or `RTC_CERTIFICATE_DEFAULT` if default)
+  - `iceTransportPolicy` (optional): ICE transport policy, if set to `RTC_TRANSPORT_POLICY_RELAY`, the PeerConnection will emit only relayed candidates (0 or `RTC_TRANSPORT_POLICY_ALL` if default)
   - `enableIceTcp`: if true, generate TCP candidates for ICE (ignored with libjuice as ICE backend)
   - `disableAutoNegotiation`: if true, the user is responsible for calling `rtcSetLocalDescription` after creating a Data Channel and after setting the remote description
   - `portRangeBegin` (optional): first port (included) of the allowed local port range (0 if unused)

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -70,6 +70,11 @@ enum class CertificateType {
 	Rsa = RTC_CERTIFICATE_RSA
 };
 
+enum class TransportPolicy {
+	All = RTC_TRANSPORT_POLICY_ALL,
+	Relay = RTC_TRANSPORT_POLICY_RELAY
+};
+
 struct RTC_CPP_EXPORT Configuration {
 	// ICE settings
 	std::vector<IceServer> iceServers;
@@ -78,6 +83,7 @@ struct RTC_CPP_EXPORT Configuration {
 
 	// Options
 	CertificateType certificateType = CertificateType::Default;
+	TransportPolicy iceTransportPolicy = TransportPolicy::All;
 	bool enableIceTcp = false;
 	bool disableAutoNegotiation = false;
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -113,6 +113,11 @@ typedef enum {
 	RTC_DIRECTION_INACTIVE = 4
 } rtcDirection;
 
+typedef enum {
+	RTC_TRANSPORT_POLICY_ALL = 0,
+	RTC_TRANSPORT_POLICY_RELAY = 1
+} rtcTransportPolicy;
+
 #define RTC_ERR_SUCCESS 0
 #define RTC_ERR_INVALID -1   // invalid argument
 #define RTC_ERR_FAILURE -2   // runtime error
@@ -152,6 +157,7 @@ typedef struct {
 	int iceServersCount;
 	const char *bindAddress; // libjuice only, NULL means any
 	rtcCertificateType certificateType;
+	rtcTransportPolicy iceTransportPolicy;
 	bool enableIceTcp;
 	bool disableAutoNegotiation;
 	uint16_t portRangeBegin; // 0 means automatic

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -343,6 +343,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 		}
 
 		c.certificateType = static_cast<CertificateType>(config->certificateType);
+		c.iceTransportPolicy = static_cast<TransportPolicy>(config->iceTransportPolicy);
 		c.enableIceTcp = config->enableIceTcp;
 		c.disableAutoNegotiation = config->disableAutoNegotiation;
 


### PR DESCRIPTION
This PR adds the configuration option `iceTransportPolicy`, similar to [RTCConfiguration.iceTransportPolicy](https://developer.mozilla.org/en-US/docs/Web/API/RTCConfiguration/iceTransportPolicy) in the Web API.

Implements https://github.com/paullouisageneau/libdatachannel/issues/449