### PR TITLE
Replace OpenSSL PEM_read methods with FILE by methods with BIO

### DIFF
--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -76,6 +76,8 @@ string error_string(unsigned long err);
 bool check(int success, const string &message = "OpenSSL error");
 bool check(SSL *ssl, int ret, const string &message = "OpenSSL error");
 
+BIO *BIO_new_from_file(const string &filename);
+
 } // namespace rtc::openssl
 
 #endif


### PR DESCRIPTION
This PR replaces calls to OpenSSL `PEM_read` methods with `FILE` pointer by calls to equivalent  methods with `BIO` for compatibility with OpenSSL built without stdio methods, since it seems to be necessary for UWP.

This should fix the issue encountered in https://github.com/microsoft/vcpkg/pull/19305 as detailed in https://github.com/paullouisageneau/libdatachannel/issues/388#issuecomment-890852788.