### PR TITLE
CMake: Fix exported target name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,7 +407,7 @@ if(NOT NO_TESTS)
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.tests)
 
 	target_include_directories(datachannel-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-	target_link_libraries(datachannel-tests datachannel)
+	target_link_libraries(datachannel-tests datachannel Threads::Threads)
 
 	# Benchmark
 	if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
@@ -427,7 +427,7 @@ if(NOT NO_TESTS)
 
 	target_compile_definitions(datachannel-benchmark PRIVATE BENCHMARK_MAIN=1)
 	target_include_directories(datachannel-benchmark PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-	target_link_libraries(datachannel-benchmark datachannel)
+	target_link_libraries(datachannel-benchmark datachannel Threads::Threads)
 endif()
 
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,10 @@ if(CAPI_STDCALL)
 	target_compile_definitions(datachannel-static PUBLIC CAPI_STDCALL)
 endif()
 
+set_target_properties(datachannel PROPERTIES EXPORT_NAME LibDataChannel)
 add_library(LibDataChannel::LibDataChannel ALIAS datachannel)
+
+set_target_properties(datachannel-static PROPERTIES EXPORT_NAME LibDataChannelStatic)
 add_library(LibDataChannel::LibDataChannelStatic ALIAS datachannel-static)
 
 if(NOT MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,12 +397,15 @@ if(NOT NO_TESTS)
 	else()
 		add_executable(datachannel-tests ${TESTS_SOURCES})
 	endif()
+
 	set_target_properties(datachannel-tests PROPERTIES
 		VERSION ${PROJECT_VERSION}
-		CXX_STANDARD 17)
-	set_target_properties(datachannel-tests PROPERTIES OUTPUT_NAME tests)
+		CXX_STANDARD 17
+		OUTPUT_NAME tests)
+
 	set_target_properties(datachannel-tests PROPERTIES
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.tests)
+
 	target_include_directories(datachannel-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 	target_link_libraries(datachannel-tests datachannel)
 
@@ -413,12 +416,15 @@ if(NOT NO_TESTS)
 	else()
 		add_executable(datachannel-benchmark test/benchmark.cpp)
 	endif()
+
 	set_target_properties(datachannel-benchmark PROPERTIES
 		VERSION ${PROJECT_VERSION}
-		CXX_STANDARD 17)
-	set_target_properties(datachannel-benchmark PROPERTIES OUTPUT_NAME benchmark)
+		CXX_STANDARD 17
+		OUTPUT_NAME benchmark)
+
 	set_target_properties(datachannel-benchmark PROPERTIES
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.benchmark)
+
 	target_compile_definitions(datachannel-benchmark PRIVATE BENCHMARK_MAIN=1)
 	target_include_directories(datachannel-benchmark PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 	target_link_libraries(datachannel-benchmark datachannel)
@@ -428,6 +434,7 @@ endif()
 if(NOT NO_EXAMPLES)
 	set(JSON_BuildTests OFF CACHE INTERNAL "")
 	add_subdirectory(deps/json EXCLUDE_FROM_ALL)
+
 	if(NOT NO_WEBSOCKET)
 		add_subdirectory(examples/client)
 		add_subdirectory(examples/client-benchmark)

--- a/examples/client-benchmark/CMakeLists.txt
+++ b/examples/client-benchmark/CMakeLists.txt
@@ -2,19 +2,33 @@ cmake_minimum_required(VERSION 3.7)
 if(POLICY CMP0079)
 	cmake_policy(SET CMP0079 NEW)
 endif()
-find_package(Threads)
+
+set(CLIENT_SOURCES
+	main.cpp
+	parse_cl.cpp
+	parse_cl.h
+)
+
+set(GETOPT_SOURCES
+	getopt.cpp
+	getopt.h
+)
+
 if(WIN32)
-	add_executable(datachannel-client-benchmark main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h)
+	add_executable(datachannel-client-benchmark ${CLIENT_SOURCES} ${GETOPT_SOURCES})
 	target_compile_definitions(datachannel-client-benchmark PUBLIC STATIC_GETOPT)
 else()
-	add_executable(datachannel-client-benchmark main.cpp parse_cl.cpp parse_cl.h)
+	add_executable(datachannel-client-benchmark ${CLIENT_SOURCES})
 endif()
 
 set_target_properties(datachannel-client-benchmark PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME client-benchmark)
+
 set_target_properties(datachannel-client-benchmark PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.client.benchmark)
+
+find_package(Threads)
 target_link_libraries(datachannel-client-benchmark datachannel nlohmann_json Threads::Threads)
 
 if(WIN32)

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -3,6 +3,17 @@ if(POLICY CMP0079)
 	cmake_policy(SET CMP0079 NEW)
 endif()
 
+set(CLIENT_SOURCES
+	main.cpp
+	parse_cl.cpp
+	parse_cl.h
+)
+
+set(GETOPT_SOURCES
+	getopt.cpp
+	getopt.h
+)
+
 set(CLIENT_UWP_RESOURCES
 	uwp/Logo.png
 	uwp/package.appxManifest
@@ -15,21 +26,24 @@ set(CLIENT_UWP_RESOURCES
 
 if(WIN32)
 	if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-	add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h ${CLIENT_UWP_RESOURCES})
+		add_executable(datachannel-client ${CLIENT_SOURCES} ${GETOPT_SOURCES} ${CLIENT_UWP_RESOURCES})
 	else()
-	    add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h getopt.cpp getopt.h)
+	    add_executable(datachannel-client ${CLIENT_SOURCES} ${GETOPT_SOURCES})
 	endif()
 	target_compile_definitions(datachannel-client PUBLIC STATIC_GETOPT)
 else()
-	add_executable(datachannel-client main.cpp parse_cl.cpp parse_cl.h)
+	add_executable(datachannel-client ${CLIENT_SOURCES})
 endif()
 
 set_target_properties(datachannel-client PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME client)
+
 set_target_properties(datachannel-client PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.client)
-target_link_libraries(datachannel-client datachannel nlohmann_json)
+
+find_package(Threads)
+target_link_libraries(datachannel-client datachannel nlohmann_json Threads::Threads)
 
 if(WIN32)
 	add_custom_command(TARGET datachannel-client POST_BUILD

--- a/examples/copy-paste-capi/CMakeLists.txt
+++ b/examples/copy-paste-capi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.7)
 project(offerer C)
 
 set(CMAKE_C_STANDARD 11)
@@ -23,27 +23,35 @@ set(ANSWERER_UWP_RESOURCES
 	uwp/answerer/Windows_TemporaryKey.pfx
 )
 
+find_package(Threads)
+
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 	add_executable(datachannel-copy-paste-capi-offerer offerer.c ${OFFERER_UWP_RESOURCES})
 else()
 	add_executable(datachannel-copy-paste-capi-offerer offerer.c)
 endif()
+
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
 	OUTPUT_NAME offerer)
+
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.offerer)
-target_link_libraries(datachannel-copy-paste-capi-offerer datachannel)
+
+target_link_libraries(datachannel-copy-paste-capi-offerer datachannel Threads::Threads)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 	add_executable(datachannel-copy-paste-capi-answerer answerer.c ${ANSWERER_UWP_RESOURCES})
 else()
 	add_executable(datachannel-copy-paste-capi-answerer answerer.c)
 endif()
+
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
 	OUTPUT_NAME answerer)
+
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.answerer)
-target_link_libraries(datachannel-copy-paste-capi-answerer datachannel)
+
+target_link_libraries(datachannel-copy-paste-capi-answerer datachannel Threads::Threads)
 
 if(WIN32)
 	add_custom_command(TARGET datachannel-copy-paste-capi-offerer POST_BUILD

--- a/examples/copy-paste/CMakeLists.txt
+++ b/examples/copy-paste/CMakeLists.txt
@@ -25,11 +25,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 else()
 	add_executable(datachannel-copy-paste-offerer offerer.cpp)
 endif()
+
 set_target_properties(datachannel-copy-paste-offerer PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME offerer)
+
 set_target_properties(datachannel-copy-paste-offerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.offerer)
+
 target_link_libraries(datachannel-copy-paste-offerer datachannel)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
@@ -37,11 +40,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 else()
 	add_executable(datachannel-copy-paste-answerer answerer.cpp)
 endif()
+
 set_target_properties(datachannel-copy-paste-answerer PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME answerer)
+
 set_target_properties(datachannel-copy-paste-answerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.answerer)
+
 target_link_libraries(datachannel-copy-paste-answerer datachannel)
 
 if(WIN32)

--- a/examples/media/CMakeLists.txt
+++ b/examples/media/CMakeLists.txt
@@ -15,11 +15,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 else()
 	add_executable(datachannel-media main.cpp)
 endif()
+
 set_target_properties(datachannel-media PROPERTIES
-        CXX_STANDARD 17
-        OUTPUT_NAME media)
+    CXX_STANDARD 17
+    OUTPUT_NAME media)
+
 set_target_properties(datachannel-media PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.media)
+
 target_link_libraries(datachannel-media datachannel nlohmann_json)
 
 if(WIN32)

--- a/examples/sfu-media/CMakeLists.txt
+++ b/examples/sfu-media/CMakeLists.txt
@@ -15,11 +15,14 @@ if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
 else()
 	add_executable(datachannel-sfu-media main.cpp)
 endif()
+
 set_target_properties(datachannel-sfu-media PROPERTIES
-		CXX_STANDARD 17
-		OUTPUT_NAME sfu-media)
+	CXX_STANDARD 17
+	OUTPUT_NAME sfu-media)
+
 set_target_properties(datachannel-sfu-media PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.sfumedia)
+
 target_link_libraries(datachannel-sfu-media datachannel nlohmann_json)
 
 if(WIN32)

--- a/examples/streamer/CMakeLists.txt
+++ b/examples/streamer/CMakeLists.txt
@@ -37,15 +37,13 @@ else()
 	add_executable(streamer ${STREAMER_SOURCES})
 endif()
 
-if(WIN32)
-	target_compile_definitions(streamer PUBLIC STATIC_GETOPT)
-endif()
-
 set_target_properties(streamer PROPERTIES
 	CXX_STANDARD 17
 	OUTPUT_NAME streamer)
+
 set_target_properties(streamer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.streamer)
+
 find_package(Threads)
 target_link_libraries(streamer datachannel nlohmann_json Threads::Threads)
 


### PR DESCRIPTION
This PR fixes the CMake exported target name from `LibDataChannel::datachannel` to `LibDataChannel::LibDataChannel` to match the existing alias. It also does a bit of cleanup and reformatting to CMakeLists files across the project.