### PR TITLE
Fix CMake exported package name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,11 +392,11 @@ install(
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake"
-    VERSION ${PROJECT_VERSION}
-    COMPATIBILITY AnyNewerVersion)
-install(FILES "${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake"
-    DESTINATION share/cmake/LibDataChannel)
+	${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake
+	VERSION ${PROJECT_VERSION}
+	COMPATIBILITY SameMajorVersion)
+install(FILES ${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake
+	DESTINATION share/cmake/LibDataChannel)
 
 # Tests
 if(NOT NO_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ if(WARNINGS_AS_ERRORS)
 	endif()
 endif()
 
-install(TARGETS datachannel EXPORT libdatachannel-config
+install(TARGETS datachannel EXPORT LibDataChannel-config
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib
@@ -384,18 +384,18 @@ install(FILES ${LIBDATACHANNEL_HEADERS}
 )
 
 install(
-  EXPORT libdatachannel-config
-  NAMESPACE LibDatachannel::
-  DESTINATION share/cmake/libdatachannel
+	EXPORT LibDataChannel-config
+	NAMESPACE LibDataChannel::
+	DESTINATION share/cmake/LibDataChannel
 )
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${CMAKE_BINARY_DIR}/libdatachannelConfigVersion.cmake"
+    "${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake"
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion)
-install(FILES "${CMAKE_BINARY_DIR}/libdatachannelConfigVersion.cmake"
-    DESTINATION share/cmake/libdatachannel)
+install(FILES "${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake"
+    DESTINATION share/cmake/LibDataChannel)
 
 # Tests
 if(NOT NO_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,7 +373,7 @@ if(WARNINGS_AS_ERRORS)
 	endif()
 endif()
 
-install(TARGETS datachannel EXPORT LibDataChannel-config
+install(TARGETS datachannel EXPORT LibDataChannelConfig
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib
@@ -384,7 +384,8 @@ install(FILES ${LIBDATACHANNEL_HEADERS}
 )
 
 install(
-	EXPORT LibDataChannel-config
+	EXPORT LibDataChannelConfig
+	FILE LibDataChannelConfig.cmake
 	NAMESPACE LibDataChannel::
 	DESTINATION share/cmake/LibDataChannel
 )


### PR DESCRIPTION
This PR changes the CMake package name to `LibDataChannel` instead of `libdatachannel` to be consistent with the namespace. It also changes the CMake config version compatibility to `SameMajorVersion`.

Related to https://github.com/paullouisageneau/libdatachannel/issues/471