### PR TITLE
CMake: Add retro-compatibility target alias and fix config file destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,13 +387,13 @@ install(
 	EXPORT LibDataChannelTargets
 	FILE LibDataChannelTargets.cmake
 	NAMESPACE LibDataChannel::
-	DESTINATION share/cmake/LibDataChannel
+	DESTINATION lib/cmake/LibDataChannel
 )
 
 # Export config
 install(
 	FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibDataChannelConfig.cmake
-	DESTINATION share/cmake/LibDataChannel
+	DESTINATION lib/cmake/LibDataChannel
 )
 
 # Export config version
@@ -403,7 +403,7 @@ write_basic_package_version_file(
 	VERSION ${PROJECT_VERSION}
 	COMPATIBILITY SameMajorVersion)
 install(FILES ${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake
-	DESTINATION share/cmake/LibDataChannel)
+	DESTINATION lib/cmake/LibDataChannel)
 
 # Tests
 if(NOT NO_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,7 +372,7 @@ if(WARNINGS_AS_ERRORS)
 	endif()
 endif()
 
-install(TARGETS datachannel EXPORT LibDataChannelConfig
+install(TARGETS datachannel EXPORT LibDataChannelTargets
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib
@@ -382,13 +382,21 @@ install(FILES ${LIBDATACHANNEL_HEADERS}
 	DESTINATION include/rtc
 )
 
+# Export targets
 install(
-	EXPORT LibDataChannelConfig
-	FILE LibDataChannelConfig.cmake
+	EXPORT LibDataChannelTargets
+	FILE LibDataChannelTargets.cmake
 	NAMESPACE LibDataChannel::
 	DESTINATION share/cmake/LibDataChannel
 )
 
+# Export config
+install(
+	FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/LibDataChannelConfig.cmake
+	DESTINATION share/cmake/LibDataChannel
+)
+
+# Export config version
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
 	${CMAKE_BINARY_DIR}/LibDataChannelConfigVersion.cmake

--- a/cmake/LibDataChannelConfig.cmake
+++ b/cmake/LibDataChannelConfig.cmake
@@ -1,0 +1,5 @@
+include("${CMAKE_CURRENT_LIST_DIR}/LibDataChannelTargets.cmake")
+
+# For forward compatibility
+add_library(LibDataChannel::datachannel ALIAS LibDataChannel::LibDataChannel)
+


### PR DESCRIPTION
This PR introduces a CMake config file to add the former installed target name `LibDataChannel::datachannel` as an alias for retro-compatibility (The installed target name was fixed to be `LibDataChannel::LibDataChannel` in  https://github.com/paullouisageneau/libdatachannel/pull/464). It also changes the CMake config file destination to `lib` instead of `share`, as `share` should be reserved to platform-independent macros.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/474