### PR TITLE
 Replace select() by poll() for WebSockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ set(LIBDATACHANNEL_IMPL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/processor.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/selectinterrupter.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollinterrupter.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcpserver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcptransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tlstransport.cpp
@@ -149,7 +149,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/processor.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/selectinterrupter.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollinterrupter.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcpserver.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcptransport.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tlstransport.hpp

--- a/src/impl/pollinterrupter.hpp
+++ b/src/impl/pollinterrupter.hpp
@@ -16,8 +16,8 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef RTC_IMPL_SELECT_INTERRUPTER_H
-#define RTC_IMPL_SELECT_INTERRUPTER_H
+#ifndef RTC_IMPL_POLL_INTERRUPTER_H
+#define RTC_IMPL_POLL_INTERRUPTER_H
 
 #include "common.hpp"
 #include "socket.hpp"
@@ -28,13 +28,13 @@
 
 namespace rtc::impl {
 
-// Utility class to interrupt select()
-class SelectInterrupter final {
+// Utility class to interrupt poll()
+class PollInterrupter final {
 public:
-	SelectInterrupter();
-	~SelectInterrupter();
+	PollInterrupter();
+	~PollInterrupter();
 
-	int prepare(fd_set &readfds);
+	void prepare(struct pollfd &pfd);
 	void interrupt();
 
 private:

--- a/src/impl/socket.hpp
+++ b/src/impl/socket.hpp
@@ -49,12 +49,14 @@
 
 typedef SOCKET socket_t;
 typedef SOCKADDR sockaddr;
-typedef u_long ctl_t;
+typedef ULONG ctl_t;
 typedef DWORD sockopt_t;
 #define sockerrno ((int)WSAGetLastError())
 #define IP_DONTFRAG IP_DONTFRAGMENT
-#define SOCKET_TO_INT(x) 0
 #define HOST_NAME_MAX 256
+
+#define poll WSAPoll
+typedef ULONG nfds_t;
 
 #define SEADDRINUSE WSAEADDRINUSE
 #define SEINTR WSAEINTR
@@ -76,6 +78,7 @@ typedef DWORD sockopt_t;
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -99,7 +102,6 @@ typedef int ctl_t;
 typedef int sockopt_t;
 #define sockerrno errno
 #define INVALID_SOCKET -1
-#define SOCKET_TO_INT(x) (x)
 #define ioctlsocket ioctl
 #define closesocket close
 

--- a/src/impl/tcpserver.hpp
+++ b/src/impl/tcpserver.hpp
@@ -20,6 +20,7 @@
 #define RTC_IMPL_TCP_SERVER_H
 
 #include "common.hpp"
+#include "pollinterrupter.hpp"
 #include "queue.hpp"
 #include "socket.hpp"
 #include "tcptransport.hpp"
@@ -44,7 +45,7 @@ private:
 	uint16_t mPort;
 	socket_t mSock = INVALID_SOCKET;
 	std::mutex mSockMutex;
-	SelectInterrupter mInterrupter;
+	PollInterrupter mInterrupter;
 };
 
 } // namespace rtc::impl

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -21,7 +21,7 @@
 
 #include "common.hpp"
 #include "queue.hpp"
-#include "selectinterrupter.hpp"
+#include "pollinterrupter.hpp"
 #include "socket.hpp"
 #include "transport.hpp"
 
@@ -65,7 +65,7 @@ private:
 	socket_t mSock = INVALID_SOCKET;
 	std::mutex mSockMutex;
 	std::thread mThread;
-	SelectInterrupter mInterrupter;
+	PollInterrupter mInterrupter;
 	Queue<message_ptr> mSendQueue;
 };
 


### PR DESCRIPTION
This PR replaces select() by poll() for WebSockets, whose behavior is nowadays available on Microsoft Windows with WSAPoll(), to fix the limitation to 1024 file descriptors.