### PR TITLE
Fix race condition between close and transport start

### DIFF
--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -320,9 +320,9 @@ ssize_t DtlsTransport::ReadCallback(gnutls_transport_ptr_t ptr, void *data, size
 int DtlsTransport::TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms) {
 	DtlsTransport *t = static_cast<DtlsTransport *>(ptr);
 	try {
-		bool notEmpty = t->mIncomingQueue.wait(
+		bool isReadable = t->mIncomingQueue.wait(
 		    ms != GNUTLS_INDEFINITE_TIMEOUT ? std::make_optional(milliseconds(ms)) : nullopt);
-		return notEmpty ? 1 : 0;
+		return isReadable ? 1 : 0;
 
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -149,7 +149,7 @@ shared_ptr<IceTransport> PeerConnection::initIceTransport() {
 				    changeState(State::Failed);
 				    break;
 			    case IceTransport::State::Connected:
-				    initDtlsTransport();
+				    mProcessor->enqueue(&PeerConnection::initDtlsTransport, this);
 				    break;
 			    case IceTransport::State::Disconnected:
 				    changeState(State::Disconnected);
@@ -208,7 +208,7 @@ shared_ptr<DtlsTransport> PeerConnection::initDtlsTransport() {
 			    switch (transportState) {
 			    case DtlsTransport::State::Connected:
 				    if (auto remote = remoteDescription(); remote && remote->hasApplication())
-					    initSctpTransport();
+					    mProcessor->enqueue(&PeerConnection::initSctpTransport, this);
 				    else
 					    changeState(State::Connected);
 

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -123,7 +123,7 @@ shared_ptr<T> emplaceTransport(PeerConnection *pc, shared_ptr<T> *member, shared
 	if (pc->state.load() == PeerConnection::State::Closed) {
 		std::atomic_store(member, decltype(transport)(nullptr));
 		transport->stop();
-		throw std::runtime_error("Connection is closed");
+		return nullptr;
 	}
 	return transport;
 }
@@ -933,6 +933,9 @@ void PeerConnection::processRemoteDescription(Description description) {
 	}
 
 	auto iceTransport = initIceTransport();
+	if (!iceTransport)
+		return; // closed
+
 	iceTransport->setRemoteDescription(std::move(description));
 
 	// Since we assumed passive role during DataChannel creation, we might need to shift the stream

--- a/src/impl/queue.hpp
+++ b/src/impl/queue.hpp
@@ -138,12 +138,13 @@ template <typename T> optional<T> Queue<T>::exchange(T element) {
 
 template <typename T> bool Queue<T>::wait(const optional<std::chrono::milliseconds> &duration) {
 	std::unique_lock lock(mMutex);
-	if (duration)
-		mPopCondition.wait_for(lock, *duration, [this]() { return !mQueue.empty() || mStopping; });
-	else
+	if (duration) {
+		return mPopCondition.wait_for(lock, *duration,
+		                              [this]() { return !mQueue.empty() || mStopping; });
+	} else {
 		mPopCondition.wait(lock, [this]() { return !mQueue.empty() || mStopping; });
-
-	return !mQueue.empty();
+		return true;
+	}
 }
 
 template <typename T> void Queue<T>::pushImpl(T element) {

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -267,9 +267,9 @@ ssize_t TlsTransport::ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_
 int TlsTransport::TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms) {
 	TlsTransport *t = static_cast<TlsTransport *>(ptr);
 	try {
-		bool notEmpty = t->mIncomingQueue.wait(
+		bool isReadable = t->mIncomingQueue.wait(
 		    ms != GNUTLS_INDEFINITE_TIMEOUT ? std::make_optional(milliseconds(ms)) : nullopt);
-		return notEmpty ? 1 : 0;
+		return isReadable ? 1 : 0;
 
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -183,7 +183,7 @@ shared_ptr<T> emplaceTransport(WebSocket *ws, shared_ptr<T> *member, shared_ptr<
 	if (ws->state.load() == WebSocket::State::Closed) {
 		std::atomic_store(member, decltype(transport)(nullptr));
 		transport->stop();
-		throw std::runtime_error("Connection is closed");
+		return nullptr;
 	}
 	return transport;
 }

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -137,6 +137,8 @@ void PeerConnection::setLocalDescription(Description::Type type) {
 	}
 
 	auto iceTransport = impl()->initIceTransport();
+	if (!iceTransport)
+		return; // closed
 
 	Description local = iceTransport->getLocalDescription(type);
 	impl()->processLocalDescription(std::move(local));


### PR DESCRIPTION
This PR fixes a possible race condition on early call to `PeerConnection::close()` caused by concurrent calls to `Transport::stop()` and `Transport::start()`.