### PR TITLE
Is it necessary to clear all SSRC attributes when creating reciprocated SDP of Media?

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -690,6 +690,17 @@ Description::Media Description::Media::reciprocate() const {
 		break;
 	}
 
+	// Clear all ssrc attributes as them are individual
+	auto it = mAttributes.begin();
+	while (it != mAttributes.end()) {
+		if (match_prefix(*it, "ssrc:"))
+			it = reciprocated.mAttributes.erase(it);
+		else
+			++it;
+	}
+	reciprocated.mSsrcs.clear();
+	reciprocated.mCNameMap.clear();
+
 	return reciprocated;
 }
 

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -690,9 +690,9 @@ Description::Media Description::Media::reciprocate() const {
 		break;
 	}
 
-	// Clear all ssrc attributes as them are individual
-	auto it = mAttributes.begin();
-	while (it != mAttributes.end()) {
+	// Clear all ssrc attributes as they are individual
+	auto it = reciprocated.mAttributes.begin();
+	while (it != reciprocated.mAttributes.end()) {
 		if (match_prefix(*it, "ssrc:"))
 			it = reciprocated.mAttributes.erase(it);
 		else


### PR DESCRIPTION
In my options, all the SSRC attributes are individual, so we should reset them when creating reciprocated SDP.