### PR TITLE
Support usage of openssl as static library files in ios.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,8 +312,16 @@ else()
 		# This is a bug in CMake that causes it to prefer the system version over
 		# the one in the specified ROOT folder
 		if(EXISTS ${OPENSSL_ROOT_DIR})
-			set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib" CACHE FILEPATH "" FORCE)
-			set(OPENSSL_SSL_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libssl.dylib" CACHE FILEPATH "" FORCE)
+            # Use static files when OPENSSL_USE_STATIC_LIBS is set.
+            # OPENSSL_USE_STATIC_LIBS is what CMake's FindOpenSSL looks at
+            # to decide whether to use static libraries.
+            if(OPENSSL_USE_STATIC_LIBS)
+                set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libcrypto.a" CACHE FILEPATH "" FORCE)
+                set(OPENSSL_SSL_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libssl.a" CACHE FILEPATH "" FORCE)
+            else()
+                set(OPENSSL_CRYPTO_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libcrypto.dylib" CACHE FILEPATH "" FORCE)
+                set(OPENSSL_SSL_LIBRARY "${OPENSSL_ROOT_DIR}/lib/libssl.dylib" CACHE FILEPATH "" FORCE)
+            endif()
 		endif()
 	endif()
 	find_package(OpenSSL REQUIRED)


### PR DESCRIPTION
Thanks a lot for the recent update supporting iOS! As the update allows me to directly use the upstream version again, which I am very happy about, I wanted to suggest this PR.

The current CMakeLists.txt assumes using .dylib files in its APPLE support, while some people (e.g., me) prefer using .a files. This PR adds a way to support the use of .a files.
OPENSSL_USE_STATIC_LIBS as a flag comes from CMake's find_package.
https://cmake.org/cmake/help/v3.6/module/FindOpenSSL.html
Using CMake's flag here, so one day the whole detour with OPENSSL_ROOT_DIR can be gone without causing additional changes.