### PR TITLE
Add rtcIsClosed to the C API.

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -196,6 +196,7 @@ RTC_EXPORT int rtcSetErrorCallback(int id, rtcErrorCallbackFunc cb);
 RTC_EXPORT int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb);
 RTC_EXPORT int rtcSendMessage(int id, const char *data, int size);
 RTC_EXPORT bool rtcIsOpen(int id);
+RTC_EXPORT bool rtcIsClosed(int id);
 
 RTC_EXPORT int rtcGetBufferedAmount(int id); // total size buffered to send
 RTC_EXPORT int rtcSetBufferedAmountLowThreshold(int id, int amount);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -679,6 +679,10 @@ bool rtcIsOpen(int id) {
 	return wrap([id] { return getChannel(id)->isOpen(); });
 }
 
+bool rtcIsClosed(int id) {
+	return wrap([id] { return getChannel(id)->isClosed(); });
+}
+
 int rtcGetBufferedAmount(int id) {
 	return wrap([id] {
 		auto channel = getChannel(id);


### PR DESCRIPTION
Exposing Channel::isClosed() via the C API.