### PR TITLE
Fix rtcIsOpen and rtcIsClosed on invalid channel

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -413,6 +413,18 @@ Arguments:
 
 Return value: `true` if the channel exists and is open, `false` otherwise
 
+#### rtcIsClosed
+
+```
+bool rtcIsClosed(int id)
+```
+
+Arguments:
+
+- `id`: the channel identifier
+
+Return value: `true` if the channel exists and is closed (not open and not connecting), `false` otherwise
+
 #### rtcSendMessage
 
 ```

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -416,6 +416,18 @@ Arguments:
 
 Return value: `true` if the channel exists and is open, `false` otherwise
 
+#### rtcIsClosed
+
+```
+bool rtcIsClosed(int id)
+```
+
+Arguments:
+
+- `id`: the channel identifier
+
+Return value: `true` if the channel exists and is closed (not open and not connecting), `false` otherwise
+
 #### rtcSendMessage
 
 ```

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -676,11 +676,11 @@ int rtcSendMessage(int id, const char *data, int size) {
 }
 
 bool rtcIsOpen(int id) {
-	return wrap([id] { return getChannel(id)->isOpen(); });
+	return wrap([id] { return getChannel(id)->isOpen() ? 0 : 1; }) == 0 ? true : false;
 }
 
 bool rtcIsClosed(int id) {
-	return wrap([id] { return getChannel(id)->isClosed(); });
+	return wrap([id] { return getChannel(id)->isClosed() ? 0 : 1; }) == 0 ? true : false ;
 }
 
 int rtcGetBufferedAmount(int id) {

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -80,6 +80,16 @@ static void RTC_API openCallback(int id, void *ptr) {
 	peer->connected = true;
 	printf("DataChannel %d: Open\n", peer == peer1 ? 1 : 2);
 
+	if (!rtcIsOpen(id)) {
+		fprintf(stderr, "rtcIsOpen failed\n");
+		return;
+	}
+
+	if (rtcIsClosed(id)) {
+		fprintf(stderr, "rtcIsClosed failed\n");
+		return;
+	}
+
 	const char *message = peer == peer1 ? "Hello from 1" : "Hello from 2";
 	rtcSendMessage(peer->dc, message, -1); // negative size indicates a null-terminated string
 }
@@ -180,6 +190,16 @@ int test_capi_connectivity_main() {
 	int attempts;
 
 	rtcInitLogger(RTC_LOG_DEBUG, nullptr);
+
+	if (rtcIsOpen(666)) {
+		fprintf(stderr, "rtcIsOpen for invalid channel id failed\n");
+		return -1;
+	}
+
+	if (rtcIsClosed(666)) {
+		fprintf(stderr, "rtcIsOpen for invalid channel id failed\n");
+		return -1;
+	}
 
 	// STUN server example (not necessary to connect locally)
 	// Please do not use outside of libdatachannel tests


### PR DESCRIPTION
This PR fixes the return value of C API functions `rtcIsOpen` and `rtcIsClosed` to return `false` on invalid channel id. It also adds `rtcIsClosed` to the reference.