### PR TITLE
Fix buffered amount callback causing hang on close

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -351,6 +351,7 @@ bool SctpTransport::stop() {
 	flush();
 	shutdown();
 	onRecv(nullptr);
+	mBufferedAmountCallback = nullptr;
 	return true;
 }
 
@@ -435,7 +436,9 @@ bool SctpTransport::flush() {
 }
 
 void SctpTransport::closeStream(unsigned int stream) {
-	send(make_message(0, Message::Reset, to_uint16(stream)));
+	// This method must not call the buffered callback synchronously, so call send() from processor
+	mProcessor.enqueue(&SctpTransport::send, this,
+	                   make_message(0, Message::Reset, to_uint16(stream)));
 }
 
 void SctpTransport::incoming(message_ptr message) {
@@ -631,7 +634,7 @@ bool SctpTransport::trySendMessage(message_ptr message) {
 void SctpTransport::updateBufferedAmount(uint16_t streamId, ptrdiff_t delta) {
 	// Requires mSendMutex to be locked
 
-	if(delta == 0)
+	if (delta == 0)
 		return;
 
 	auto it = mBufferedAmount.insert(std::make_pair(streamId, 0)).first;
@@ -901,7 +904,7 @@ int SctpTransport::WriteCallback(void *ptr, void *data, size_t len, uint8_t tos,
 	auto *transport = static_cast<SctpTransport *>(ptr);
 
 	// Set the CRC32 ourselves as we have enabled CRC32 offloading
-	if(len >= 12) {
+	if (len >= 12) {
 		uint32_t *checksum = reinterpret_cast<uint32_t *>(data) + 2;
 		*checksum = 0;
 		*checksum = usrsctp_crc32c(data, len);


### PR DESCRIPTION
This PR fixes a situation where the `PeerConnection` processor wait on itself because the buffered amount callback is synchronously called when closing a `DataChannel` with `SctpTransport::closeStream()`.