### PR TITLE
Fix WebSocketServer listening address

### DIFF
--- a/src/impl/tcpserver.cpp
+++ b/src/impl/tcpserver.cpp
@@ -103,7 +103,7 @@ void TcpServer::listen(uint16_t port) {
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
-	hints.ai_flags = AI_ADDRCONFIG;
+	hints.ai_flags = AI_PASSIVE | AI_NUMERICSERV;
 
 	struct addrinfo *result = nullptr;
 	if (::getaddrinfo(nullptr, std::to_string(port).c_str(), &hints, &result))


### PR DESCRIPTION
This PR fixes `WebSocketServer` not listening on any IPv4 and IPv6 address as it should, as the flag `AI_PASSIVE` was missing when calling `getaddrinfo`.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/454