### PR TITLE
Expose NAL unit separator in C API

### DIFF
--- a/include/rtc/h264rtppacketizer.hpp
+++ b/include/rtc/h264rtppacketizer.hpp
@@ -37,12 +37,12 @@ public:
 	/// Default clock rate for H264 in RTP
 	inline static const uint32_t defaultClockRate = 90 * 1000;
 
-	/// Nalunit separator
+	/// NAL unit separator
 	enum class Separator {
-		LongStartSequence,  // 0x00, 0x00, 0x00, 0x01
-		ShortStartSequence, // 0x00, 0x00, 0x01
-		StartSequence,      // LongStartSequence or ShortStartSequence
-		Length              // first 4 bytes is nal unit length
+		Length = RTC_NAL_SEPARATOR_LENGTH, // first 4 bytes are NAL unit length
+		LongStartSequence = RTC_NAL_SEPARATOR_LONG_START_SEQUENCE,   // 0x00, 0x00, 0x00, 0x01
+		ShortStartSequence = RTC_NAL_SEPARATOR_SHORT_START_SEQUENCE, // 0x00, 0x00, 0x01
+		StartSequence = RTC_NAL_SEPARATOR_START_SEQUENCE, // LongStartSequence or ShortStartSequence
 	};
 
 	H264RtpPacketizer(H264RtpPacketizer::Separator separator,

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -260,14 +260,26 @@ RTC_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
 
 // Media
 
+// Define how NAL units are separated in a H264 sample
+typedef enum {
+	RTC_NAL_SEPARATOR_LENGTH = 0,               // first 4 bytes are NAL unit length
+	RTC_NAL_SEPARATOR_LONG_START_SEQUENCE = 1,  // 0x00, 0x00, 0x00, 0x01
+	RTC_NAL_SEPARATOR_SHORT_START_SEQUENCE = 2, // 0x00, 0x00, 0x01
+	RTC_NAL_SEPARATOR_START_SEQUENCE = 3,       // long or short start sequence
+} rtcNalUnitSeparator;
+
 typedef struct {
 	uint32_t ssrc;
 	const char *cname;
 	uint8_t payloadType;
 	uint32_t clockRate;
-	uint16_t maxFragmentSize; // Maximum NALU fragment size
 	uint16_t sequenceNumber;
 	uint32_t timestamp;
+
+	// H264
+	rtcNalUnitSeparator nalSeparator; // NAL unit separator
+	uint16_t maxFragmentSize;         // Maximum NAL unit fragment size
+
 } rtcPacketizationHandlerInit;
 
 typedef struct {

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -680,7 +680,7 @@ bool rtcIsOpen(int id) {
 }
 
 bool rtcIsClosed(int id) {
-	return wrap([id] { return getChannel(id)->isClosed() ? 0 : 1; }) == 0 ? true : false ;
+	return wrap([id] { return getChannel(id)->isClosed() ? 0 : 1; }) == 0 ? true : false;
 }
 
 int rtcGetBufferedAmount(int id) {
@@ -1019,9 +1019,12 @@ int rtcSetH264PacketizationHandler(int tr, const rtcPacketizationHandlerInit *in
 		// create RTP configuration
 		auto rtpConfig = createRtpPacketizationConfig(init);
 		// create packetizer
+		auto nalSeparator = init ? init->nalSeparator : RTC_NAL_SEPARATOR_LENGTH;
 		auto maxFragmentSize = init && init->maxFragmentSize ? init->maxFragmentSize
 		                                                     : RTC_DEFAULT_MAXIMUM_FRAGMENT_SIZE;
-		auto packetizer = std::make_shared<H264RtpPacketizer>(rtpConfig, maxFragmentSize);
+		auto packetizer = std::make_shared<H264RtpPacketizer>(
+		    static_cast<rtc::H264RtpPacketizer::Separator>(nalSeparator), rtpConfig,
+		    maxFragmentSize);
 		// create H264 handler
 		auto h264Handler = std::make_shared<H264PacketizationHandler>(packetizer);
 		emplaceMediaChainableHandler(h264Handler, tr);


### PR DESCRIPTION
This PR exposes the H264 NAL unit separator in the C media API.

Related to: https://github.com/paullouisageneau/libdatachannel/issues/502