### PR TITLE
Synchronize signaling on PeerConnection interface

### DIFF
--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -89,7 +89,6 @@ public:
 	bool getSelectedCandidatePair(Candidate *local, Candidate *remote);
 
 	void setLocalDescription(Description::Type type = Description::Type::Unspec);
-
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -106,6 +106,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	std::atomic<GatheringState> gatheringState = GatheringState::New;
 	std::atomic<SignalingState> signalingState = SignalingState::Stable;
 	std::atomic<bool> negotiationNeeded = false;
+	std::mutex signalingMutex;
 
 	synchronized_callback<shared_ptr<rtc::DataChannel>> dataChannelCallback;
 	synchronized_callback<Description> localDescriptionCallback;


### PR DESCRIPTION
This PR introduces a signaling mutex on PeerConnection interface to enforce synchronization on methods `setLocalDescription`, `setRemoteDescription`, and `addRemoteCandidate`.