### PR TITLE
Refactor PeerConnection::iterateDataChannels()

### DIFF
--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -69,6 +69,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	shared_ptr<DataChannel> findDataChannel(uint16_t stream);
 	void shiftDataChannels();
 	void iterateDataChannels(std::function<void(shared_ptr<DataChannel> channel)> func);
+	void cleanupDataChannels();
 	void openDataChannels();
 	void closeDataChannels();
 	void remoteCloseDataChannels();


### PR DESCRIPTION
This PR refactors `impl::PeerConnection::iterateDataChannels()` to prevent running the cleanup routine each time. It also prevents a false positive in the thread sanitizer.