### PR TITLE
Make rtc::Message private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,6 @@ set(LIBDATACHANNEL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/datachannel.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/description.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/global.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/src/message.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/peerconnection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/rtcpreceivingsession.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/track.cpp
@@ -78,7 +77,6 @@ set(LIBDATACHANNEL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/rtcpreceivingsession.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/common.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/global.hpp
-	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/message.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/peerconnection.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/reliability.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/rtc.h
@@ -110,6 +108,7 @@ set(LIBDATACHANNEL_IMPL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/dtlstransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/icetransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/init.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/message.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/peerconnection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/logcounter.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sctptransport.cpp
@@ -139,6 +138,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/icetransport.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/init.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/internals.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/message.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/peerconnection.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/queue.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/logcounter.hpp

--- a/examples/streamer/main.cpp
+++ b/examples/streamer/main.cpp
@@ -362,7 +362,6 @@ shared_ptr<Stream> createStream(const string h264Samples, const unsigned fps, co
             }
         }
         if (!tracks.empty()) {
-            auto message = make_message(move(sample));
             for (auto clientTrack: tracks) {
                 auto client = clientTrack.id;
                 auto trackData = clientTrack.trackData;
@@ -381,11 +380,11 @@ shared_ptr<Stream> createStream(const string h264Samples, const unsigned fps, co
                 if (rtpConfig->timestampToSeconds(reportElapsedTimestamp) > 1) {
                     trackData->sender->setNeedsToReport();
                 }
-                cout << "Sending " << streamType << " sample with size: " << to_string(message->size()) << " to " << client << endl;
+                cout << "Sending " << streamType << " sample with size: " << to_string(sample.size()) << " to " << client << endl;
                 bool send = false;
                 try {
                     // send sample
-                    send = trackData->track->send(*message);
+                    send = trackData->track->send(sample);
                 } catch (...) {
                     send = false;
                 }

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -20,7 +20,6 @@
 #define RTC_CHANNEL_H
 
 #include "common.hpp"
-#include "message.hpp"
 
 #include <atomic>
 #include <functional>

--- a/include/rtc/common.hpp
+++ b/include/rtc/common.hpp
@@ -75,6 +75,17 @@ using std::uint32_t;
 using std::uint64_t;
 using std::uint8_t;
 
+using message_variant = variant<binary, string>;
+
+namespace impl {
+
+struct Message;
+
+}
+
+using message_ptr = shared_ptr<impl::Message>;
+using message_callback = std::function<void(message_ptr message)>;
+
 } // namespace rtc
 
 #endif

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -20,7 +20,6 @@
 #define RTC_ICE_CONFIGURATION_H
 
 #include "common.hpp"
-#include "message.hpp"
 
 #include <vector>
 

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -21,7 +21,6 @@
 
 #include "channel.hpp"
 #include "common.hpp"
-#include "message.hpp"
 #include "reliability.hpp"
 
 #include <type_traits>

--- a/include/rtc/mediahandler.hpp
+++ b/include/rtc/mediahandler.hpp
@@ -21,7 +21,6 @@
 #define RTC_MEDIA_HANDLER_H
 
 #include "common.hpp"
-#include "message.hpp"
 
 namespace rtc {
 

--- a/include/rtc/mediahandlerelement.hpp
+++ b/include/rtc/mediahandlerelement.hpp
@@ -22,7 +22,6 @@
 #if RTC_ENABLE_MEDIA
 
 #include "common.hpp"
-#include "message.hpp"
 #include "rtp.hpp"
 
 namespace rtc {

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -24,7 +24,6 @@
 #include "configuration.hpp"
 #include "datachannel.hpp"
 #include "description.hpp"
-#include "message.hpp"
 #include "reliability.hpp"
 #include "track.hpp"
 

--- a/include/rtc/rtcpreceivingsession.hpp
+++ b/include/rtc/rtcpreceivingsession.hpp
@@ -24,7 +24,6 @@
 
 #include "common.hpp"
 #include "mediahandler.hpp"
-#include "message.hpp"
 #include "rtp.hpp"
 
 namespace rtc {

--- a/include/rtc/rtcpsrreporter.hpp
+++ b/include/rtc/rtcpsrreporter.hpp
@@ -22,7 +22,6 @@
 #if RTC_ENABLE_MEDIA
 
 #include "mediahandlerelement.hpp"
-#include "message.hpp"
 #include "rtppacketizationconfig.hpp"
 
 namespace rtc {

--- a/include/rtc/rtppacketizer.hpp
+++ b/include/rtc/rtppacketizer.hpp
@@ -21,7 +21,6 @@
 
 #if RTC_ENABLE_MEDIA
 
-#include "message.hpp"
 #include "rtppacketizationconfig.hpp"
 
 namespace rtc {

--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -23,7 +23,6 @@
 #include "common.hpp"
 #include "description.hpp"
 #include "mediahandler.hpp"
-#include "message.hpp"
 
 namespace rtc {
 

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -23,7 +23,6 @@
 
 #include "channel.hpp"
 #include "common.hpp"
-#include "message.hpp"
 
 namespace rtc {
 

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -63,11 +63,11 @@ bool DataChannel::isClosed(void) const { return impl()->isClosed(); }
 size_t DataChannel::maxMessageSize() const { return impl()->maxMessageSize(); }
 
 bool DataChannel::send(message_variant data) {
-	return impl()->outgoing(make_message(std::move(data)));
+	return impl()->outgoing(impl::make_message(std::move(data)));
 }
 
 bool DataChannel::send(const byte *data, size_t size) {
-	return impl()->outgoing(std::make_shared<Message>(data, data + size, Message::Binary));
+	return impl()->outgoing(impl::make_message(data, data + size, impl::Message::Binary));
 }
 
 } // namespace rtc

--- a/src/impl/message.cpp
+++ b/src/impl/message.cpp
@@ -18,7 +18,7 @@
 
 #include "message.hpp"
 
-namespace rtc {
+namespace rtc::impl {
 
 message_ptr make_message(size_t size, Message::Type type, unsigned int stream,
                          shared_ptr<Reliability> reliability) {
@@ -57,4 +57,4 @@ message_variant to_variant(Message &&message) {
 	}
 }
 
-} // namespace rtc
+} // namespace rtc::impl

--- a/src/impl/message.hpp
+++ b/src/impl/message.hpp
@@ -16,17 +16,17 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef RTC_MESSAGE_H
-#define RTC_MESSAGE_H
+#ifndef RTC_IMPL_MESSAGE_H
+#define RTC_IMPL_MESSAGE_H
 
 #include "common.hpp"
 #include "reliability.hpp"
 
 #include <functional>
 
-namespace rtc {
+namespace rtc::impl {
 
-struct RTC_CPP_EXPORT Message : binary {
+struct Message : binary {
 	enum Type { Binary, String, Control, Reset };
 
 	Message(const Message &message) = default;
@@ -44,10 +44,6 @@ struct RTC_CPP_EXPORT Message : binary {
 	shared_ptr<Reliability> reliability;
 };
 
-using message_ptr = shared_ptr<Message>;
-using message_callback = std::function<void(message_ptr message)>;
-using message_variant = variant<binary, string>;
-
 inline size_t message_size_func(const message_ptr &m) {
 	return m->type == Message::Binary || m->type == Message::String ? m->size() : 0;
 }
@@ -61,18 +57,18 @@ message_ptr make_message(Iterator begin, Iterator end, Message::Type type = Mess
 	return message;
 }
 
-RTC_CPP_EXPORT message_ptr make_message(size_t size, Message::Type type = Message::Binary,
+message_ptr make_message(size_t size, Message::Type type = Message::Binary,
                                         unsigned int stream = 0,
                                         shared_ptr<Reliability> reliability = nullptr);
 
-RTC_CPP_EXPORT message_ptr make_message(binary &&data, Message::Type type = Message::Binary,
+message_ptr make_message(binary &&data, Message::Type type = Message::Binary,
                                         unsigned int stream = 0,
                                         shared_ptr<Reliability> reliability = nullptr);
 
-RTC_CPP_EXPORT message_ptr make_message(message_variant data);
+message_ptr make_message(message_variant data);
 
-RTC_CPP_EXPORT message_variant to_variant(Message &&message);
+message_variant to_variant(Message &&message);
 
-} // namespace rtc
+} // namespace rtc::impl
 
 #endif

--- a/src/mediahandlerelement.cpp
+++ b/src/mediahandlerelement.cpp
@@ -21,6 +21,7 @@
 #include "mediahandlerelement.hpp"
 
 #include "impl/internals.hpp"
+#include "impl/message.hpp"
 
 #include <cassert>
 

--- a/src/mediahandlerrootelement.cpp
+++ b/src/mediahandlerrootelement.cpp
@@ -20,13 +20,15 @@
 
 #include "mediahandlerrootelement.hpp"
 
+#include "impl/message.hpp"
+
 namespace rtc {
 
 message_ptr MediaHandlerRootElement::reduce(ChainedMessagesProduct messages) {
 	if (messages && !messages->empty()) {
-		auto msg_ptr = messages->front();
-		if (msg_ptr) {
-			return make_message(*msg_ptr);
+		auto msg = messages->front();
+		if (msg) {
+			return impl::make_message(*msg);
 		} else {
 			return nullptr;
 		}

--- a/src/rtcpnackresponder.cpp
+++ b/src/rtcpnackresponder.cpp
@@ -21,6 +21,7 @@
 #include "rtcpnackresponder.hpp"
 
 #include "impl/internals.hpp"
+#include "impl/message.hpp"
 
 #include <cassert>
 

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -23,6 +23,7 @@
 #include "track.hpp"
 
 #include "impl/logcounter.hpp"
+#include "impl/message.hpp"
 
 #include <cmath>
 #include <utility>
@@ -45,7 +46,7 @@ static impl::LogCounter COUNTER_BAD_SCTP_STATUS(plog::warning,
 message_ptr RtcpReceivingSession::outgoing(message_ptr ptr) { return ptr; }
 
 message_ptr RtcpReceivingSession::incoming(message_ptr ptr) {
-	if (ptr->type == Message::Type::Binary) {
+	if (ptr->type == impl::Message::Type::Binary) {
 		auto rtp = reinterpret_cast<const RTP *>(ptr->data());
 
 		// https://tools.ietf.org/html/rfc3550#appendix-A.1
@@ -69,7 +70,7 @@ message_ptr RtcpReceivingSession::incoming(message_ptr ptr) {
 		return ptr;
 	}
 
-	assert(ptr->type == Message::Type::Control);
+	assert(ptr->type == impl::Message::Type::Control);
 	auto rr = reinterpret_cast<const RTCP_RR *>(ptr->data());
 	if (rr->header.payloadType() == 201) {
 		// RR
@@ -99,7 +100,7 @@ void RtcpReceivingSession::requestBitrate(unsigned int newBitrate) {
 }
 
 void RtcpReceivingSession::pushREMB(unsigned int bitrate) {
-	message_ptr msg = make_message(RTCP_REMB::SizeWithSSRCs(1), Message::Type::Control);
+	message_ptr msg = impl::make_message(RTCP_REMB::SizeWithSSRCs(1), impl::Message::Type::Control);
 	auto remb = reinterpret_cast<RTCP_REMB *>(msg->data());
 	remb->preparePacket(mSsrc, 1, bitrate);
 	remb->setSsrc(0, mSsrc);
@@ -108,7 +109,7 @@ void RtcpReceivingSession::pushREMB(unsigned int bitrate) {
 }
 
 void RtcpReceivingSession::pushRR(unsigned int lastSR_delay) {
-	auto msg = make_message(RTCP_RR::SizeWithReportBlocks(1), Message::Type::Control);
+	auto msg = impl::make_message(RTCP_RR::SizeWithReportBlocks(1), impl::Message::Type::Control);
 	auto rr = reinterpret_cast<RTCP_RR *>(msg->data());
 	rr->preparePacket(mSsrc, 1);
 	rr->getReportBlock(0)->preparePacket(mSsrc, 0, 0, uint16_t(mGreatestSeqNo), 0, 0, mSyncNTPTS,
@@ -134,7 +135,7 @@ bool RtcpReceivingSession::requestKeyframe() {
 }
 
 void RtcpReceivingSession::pushPLI() {
-	auto msg = make_message(RTCP_PLI::Size(), Message::Type::Control);
+	auto msg = impl::make_message(RTCP_PLI::Size(), impl::Message::Type::Control);
 	auto *pli = reinterpret_cast<RTCP_PLI *>(msg->data());
 	pli->preparePacket(mSsrc);
 	send(msg);

--- a/src/rtcpsrreporter.cpp
+++ b/src/rtcpsrreporter.cpp
@@ -20,6 +20,8 @@
 
 #include "rtcpsrreporter.hpp"
 
+#include "impl/message.hpp"
+
 #include <cassert>
 #include <cmath>
 
@@ -66,8 +68,8 @@ void RtcpSrReporter::setNeedsToReport() { needsToReport = true; }
 
 message_ptr RtcpSrReporter::getSenderReport(uint32_t timestamp) {
 	auto srSize = RTCP_SR::Size(0);
-	auto msg = make_message(srSize + RTCP_SDES::Size({{uint8_t(rtpConfig->cname.size())}}),
-	                        Message::Type::Control);
+	auto msg = impl::make_message(srSize + RTCP_SDES::Size({{uint8_t(rtpConfig->cname.size())}}),
+	                        impl::Message::Type::Control);
 	auto sr = reinterpret_cast<RTCP_SR *>(msg->data());
 	auto timestamp_s = rtpConfig->timestampToSeconds(timestamp);
 	auto currentTime = timeOffset + timestamp_s;

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -19,6 +19,7 @@
 #include "track.hpp"
 
 #include "impl/internals.hpp"
+#include "impl/message.hpp"
 #include "impl/track.hpp"
 
 namespace rtc {
@@ -38,9 +39,13 @@ void Track::setDescription(Description::Media description) {
 
 void Track::close() { impl()->close(); }
 
-bool Track::send(message_variant data) { return impl()->outgoing(make_message(std::move(data))); }
+bool Track::send(message_variant data) {
+	return impl()->outgoing(impl::make_message(std::move(data)));
+}
 
-bool Track::send(const byte *data, size_t size) { return send(binary(data, data + size)); }
+bool Track::send(const byte *data, size_t size) {
+	return impl()->outgoing(impl::make_message(data, data + size, impl::Message::Binary));
+}
 
 bool Track::isOpen(void) const { return impl()->isOpen(); }
 

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -21,6 +21,7 @@
 #include "websocket.hpp"
 #include "common.hpp"
 
+#include "impl/message.hpp"
 #include "impl/internals.hpp"
 #include "impl/websocket.hpp"
 
@@ -61,11 +62,11 @@ void WebSocket::open(const string &url) {
 void WebSocket::close() { impl()->close(); }
 
 bool WebSocket::send(message_variant data) {
-	return impl()->outgoing(make_message(std::move(data)));
+	return impl()->outgoing(impl::make_message(std::move(data)));
 }
 
 bool WebSocket::send(const byte *data, size_t size) {
-	return impl()->outgoing(make_message(data, data + size));
+	return impl()->outgoing(impl::make_message(data, data + size));
 }
 
 optional<string> WebSocket::remoteAddress() const {


### PR DESCRIPTION
The library exposed `rtc::Message` while it is a private utility, this PR moves it to `impl` namespace.