### PR TITLE
Fix undefined behavior in getTimestampFromSeconds()

### DIFF
--- a/include/rtc/common.hpp
+++ b/include/rtc/common.hpp
@@ -68,6 +68,10 @@ using std::weak_ptr;
 using binary = std::vector<byte>;
 using binary_ptr = std::shared_ptr<binary>;
 
+using std::int16_t;
+using std::int32_t;
+using std::int64_t;
+using std::int8_t;
 using std::ptrdiff_t;
 using std::size_t;
 using std::uint16_t;

--- a/src/rtppacketizationconfig.cpp
+++ b/src/rtppacketizationconfig.cpp
@@ -64,7 +64,7 @@ double RtpPacketizationConfig::timestampToSeconds(uint32_t timestamp) {
 }
 
 uint32_t RtpPacketizationConfig::getTimestampFromSeconds(double seconds, uint32_t clockRate) {
-	return uint32_t(seconds * clockRate);
+	return uint32_t(int64_t(seconds * double(clockRate))); // convert to integer then cast to u32
 }
 
 uint32_t RtpPacketizationConfig::secondsToTimestamp(double seconds) {


### PR DESCRIPTION
This PR fixes undefined behavior when the resulting timestamp overflows in `RtpPacketizationConfig::getTimestampFromSeconds()`.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/521