### PR TITLE
Blocking cleanup

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -50,7 +50,9 @@ An optional call to `rtcPreload` preloads the global resources used by the libra
 void rtcCleanup(void)
 ```
 
-An optional call to `rtcCleanup` requests unloading of the global resources used by the library. If all created PeerConnections are deleted, unloading will happen immediately and the call will block until unloading is done, otherwise unloading will happen as soon as the last PeerConnection is deleted. If resources are already unloaded, the call has no effect.
+An optional call to `rtcCleanup` unloads the global resources used by the library. The call will block until unloading is done. If Peer Connections, Data Channels, Tracks, or WebSockets created through this API still exist, they will be destroyed. If resources are already unloaded, the call has no effect.
+
+Warning: This function requires all Peer Connections, Data Channels, Tracks, and WebSockets to be destroyed before returning, meaning all callbacks must return before this function returns. Therefore, it must never be called from a callback.
 
 #### rtcSetUserPointer
 

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -23,6 +23,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <future>
 
 namespace rtc {
 
@@ -47,7 +48,7 @@ RTC_CPP_EXPORT void InitLogger(plog::Severity severity, plog::IAppender *appende
 #endif
 
 RTC_CPP_EXPORT void Preload();
-RTC_CPP_EXPORT void Cleanup();
+RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
 struct SctpSettings {
 	// For the following settings, not set means optimized default

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -53,7 +53,10 @@ An optional call to `rtcPreload` preloads the global resources used by the libra
 void rtcCleanup(void)
 ```
 
-An optional call to `rtcCleanup` requests unloading of the global resources used by the library. If all created PeerConnections are deleted, unloading will happen immediately and the call will block until unloading is done, otherwise unloading will happen as soon as the last PeerConnection is deleted. If resources are already unloaded, the call has no effect.
+An optional call to `rtcCleanup` unloads the global resources used by the library. The call will block until unloading is done. If Peer Connections, Data Channels, Tracks, or WebSockets created through this API still exist, they will be destroyed. If resources are already unloaded, the call has no effect.
+
+Warning: This function requires all Peer Connections, Data Channels, Tracks, and WebSockets to be destroyed before returning, meaning all callbacks must return before this function returns. Therefore, it must never be called from a callback.
+
 
 #### rtcSetUserPointer
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1367,7 +1367,7 @@ void rtcCleanup() {
 	try {
 		eraseAll();
 		if(rtc::Cleanup().wait_for(10s) == std::future_status::timeout)
-			throw std::runtime_error("Cleanup timeout");
+			throw std::runtime_error("Cleanup timeout (possible deadlock or undestructible object)");
 
 	} catch (const std::exception &e) {
 		PLOG_ERROR << e.what();

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -103,7 +103,7 @@ void InitLogger(plog::Severity severity, plog::IAppender *appender) {
 }
 
 void Preload() { Init::Instance().preload(); }
-void Cleanup() { Init::Instance().cleanup(); }
+std::shared_future<void> Cleanup() { return Init::Instance().cleanup(); }
 
 void SetSctpSettings(SctpSettings s) { Init::Instance().setSctpSettings(std::move(s)); }
 

--- a/src/impl/init.hpp
+++ b/src/impl/init.hpp
@@ -24,6 +24,7 @@
 
 #include <chrono>
 #include <mutex>
+#include <future>
 
 namespace rtc {
 
@@ -40,7 +41,7 @@ public:
 
 	init_token token();
 	void preload();
-	void cleanup();
+	std::shared_future<void> cleanup();
 	void setSctpSettings(SctpSettings s);
 
 private:
@@ -55,6 +56,7 @@ private:
 	bool mInitialized = false;
 	SctpSettings mCurrentSctpSettings = {};
 	std::mutex mMutex;
+	std::shared_future<void> mCleanupFuture;
 
 	struct TokenPayload;
 };

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -121,7 +121,7 @@ size_t benchmark(milliseconds duration) {
 			}
 		} catch (const std::exception &e) {
 			std::cout << "Send failed: " << e.what() << std::endl;
-		}		
+		}
 	});
 
 	// When sent data is buffered in the DataChannel,
@@ -166,8 +166,6 @@ size_t benchmark(milliseconds duration) {
 
 	pc1.close();
 	pc2.close();
-
-	rtc::Cleanup();
 	this_thread::sleep_for(1s);
 	return goodput;
 }

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -166,7 +166,8 @@ size_t benchmark(milliseconds duration) {
 
 	pc1.close();
 	pc2.close();
-	this_thread::sleep_for(1s);
+
+	rtc::Cleanup();
 	return goodput;
 }
 

--- a/test/capi_websocketserver.cpp
+++ b/test/capi_websocketserver.cpp
@@ -35,6 +35,7 @@ static const char *MESSAGE = "Hello, this is a C API WebSocket test!";
 
 static bool success = false;
 static bool failed = false;
+static int wsclient = -1;
 
 static void RTC_API openCallback(int ws, void *ptr) {
 	printf("WebSocket: Connection open\n");
@@ -86,6 +87,8 @@ static void RTC_API serverMessageCallback(int ws, const char *message, int size,
 }
 
 static void RTC_API serverClientCallback(int wsserver, int ws, void *ptr) {
+	wsclient = ws;
+
 	char address[256];
 	if (rtcGetWebSocketRemoteAddress(ws, address, 256) < 0) {
 		fprintf(stderr, "rtcGetWebSocketRemoteAddress failed\n");
@@ -144,6 +147,9 @@ int test_capi_websocketserver_main() {
 	if (failed)
 		goto error;
 
+	rtcDeleteWebSocket(wsclient);
+	sleep(1);
+
 	rtcDeleteWebSocket(ws);
 	sleep(1);
 
@@ -154,6 +160,9 @@ int test_capi_websocketserver_main() {
 	return 0;
 
 error:
+	if (wsclient >= 0)
+		rtcDeleteWebSocket(wsclient);
+
 	if (ws >= 0)
 		rtcDeleteWebSocket(ws);
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -47,6 +47,7 @@ void test_benchmark() {
 }
 
 int main(int argc, char **argv) {
+	// C++ API tests
 	try {
 		cout << endl << "*** Running WebRTC connectivity test..." << endl;
 		test_connectivity();
@@ -63,14 +64,6 @@ int main(int argc, char **argv) {
 		cerr << "WebRTC TURN connectivity test failed: " << e.what() << endl;
 		return -1;
 	}
-	try {
-		cout << endl << "*** Running WebRTC C API connectivity test..." << endl;
-		test_capi_connectivity();
-		cout << "*** Finished WebRTC C API connectivity test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC C API connectivity test failed: " << e.what() << endl;
-		return -1;
-	}
 #if RTC_ENABLE_MEDIA
 	try {
 		cout << endl << "*** Running WebRTC Track test..." << endl;
@@ -78,14 +71,6 @@ int main(int argc, char **argv) {
 		cout << "*** Finished WebRTC Track test" << endl;
 	} catch (const exception &e) {
 		cerr << "WebRTC Track test failed: " << e.what() << endl;
-		return -1;
-	}
-	try {
-		cout << endl << "*** Running WebRTC C API track test..." << endl;
-		test_capi_track();
-		cout << "*** Finished WebRTC C API track test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC C API track test failed: " << e.what() << endl;
 		return -1;
 	}
 #endif
@@ -109,6 +94,38 @@ int main(int argc, char **argv) {
 		cerr << "WebSocketServer test failed: " << e.what() << endl;
 		return -1;
 	}
+#endif
+	try {
+		// Every created object must have been destroyed, otherwise the wait will block
+		cout << endl << "*** Running cleanup..." << endl;
+		if(rtc::Cleanup().wait_for(10s) == future_status::timeout)
+			throw std::runtime_error("Timeout");
+		cout << "*** Finished cleanup..." << endl;
+	} catch (const exception &e) {
+		cerr << "Cleanup failed: " << e.what() << endl;
+		return -1;
+	}
+
+	// C API tests
+	try {
+		cout << endl << "*** Running WebRTC C API connectivity test..." << endl;
+		test_capi_connectivity();
+		cout << "*** Finished WebRTC C API connectivity test" << endl;
+	} catch (const exception &e) {
+		cerr << "WebRTC C API connectivity test failed: " << e.what() << endl;
+		return -1;
+	}
+#if RTC_ENABLE_MEDIA
+	try {
+		cout << endl << "*** Running WebRTC C API track test..." << endl;
+		test_capi_track();
+		cout << "*** Finished WebRTC C API track test" << endl;
+	} catch (const exception &e) {
+		cerr << "WebRTC C API track test failed: " << e.what() << endl;
+		return -1;
+	}
+#endif
+#if RTC_ENABLE_WEBSOCKET
 	try {
 		cout << endl << "*** Running WebSocketServer C API test..." << endl;
 		test_capi_websocketserver();
@@ -118,7 +135,16 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 #endif
+	try {
+		cout << endl << "*** Running C API cleanup..." << endl;
+		rtcCleanup();
+		cout << "*** Finished C API cleanup..." << endl;
+	} catch (const exception &e) {
+		cerr << "C API cleanup failed: " << e.what() << endl;
+		return -1;
+	}
 /*
+	// Benchmark
 	try {
 		cout << endl << "*** Running WebRTC benchmark..." << endl;
 		test_benchmark();
@@ -129,14 +155,5 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 */
-	try {
-		cout << endl << "*** Running cleanup..." << endl;
-		if(rtc::Cleanup().wait_for(10s) == future_status::timeout)
-			throw std::runtime_error("Timeout");
-
-	} catch (const exception &e) {
-		cerr << "Cleanup failed: " << e.what() << endl;
-		return -1;
-	}
 	return 0;
 }

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -55,7 +55,6 @@ int main(int argc, char **argv) {
 		cerr << "WebRTC connectivity test failed: " << e.what() << endl;
 		return -1;
 	}
-	this_thread::sleep_for(1s);
 	try {
 		cout << endl << "*** Running WebRTC TURN connectivity test..." << endl;
 		test_turn_connectivity();
@@ -64,7 +63,6 @@ int main(int argc, char **argv) {
 		cerr << "WebRTC TURN connectivity test failed: " << e.what() << endl;
 		return -1;
 	}
-	this_thread::sleep_for(1s);
 	try {
 		cout << endl << "*** Running WebRTC C API connectivity test..." << endl;
 		test_capi_connectivity();
@@ -74,7 +72,6 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 #if RTC_ENABLE_MEDIA
-	this_thread::sleep_for(1s);
 	try {
 		cout << endl << "*** Running WebRTC Track test..." << endl;
 		test_track();
@@ -95,7 +92,6 @@ int main(int argc, char **argv) {
 #if RTC_ENABLE_WEBSOCKET
 // TODO: Temporarily disabled as the echo service is unreliable
 /*
-	this_thread::sleep_for(1s);
 	try {
 		cout << endl << "*** Running WebSocket test..." << endl;
 		test_websocket();
@@ -123,7 +119,6 @@ int main(int argc, char **argv) {
 	}
 #endif
 /*
-    this_thread::sleep_for(1s);
 	try {
 		cout << endl << "*** Running WebRTC benchmark..." << endl;
 		test_benchmark();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -20,6 +20,8 @@
 #include <iostream>
 #include <thread>
 
+#include <rtc/rtc.hpp>
+
 using namespace std;
 using namespace chrono_literals;
 
@@ -132,6 +134,14 @@ int main(int argc, char **argv) {
 		return -1;
 	}
 */
-	std::this_thread::sleep_for(1s);
+	try {
+		cout << endl << "*** Running cleanup..." << endl;
+		if(rtc::Cleanup().wait_for(10s) == future_status::timeout)
+			throw std::runtime_error("Timeout");
+
+	} catch (const exception &e) {
+		cerr << "Cleanup failed: " << e.what() << endl;
+		return -1;
+	}
 	return 0;
 }


### PR DESCRIPTION
This PR updates `rtc::Cleanup()` to return a future resolved upon completion, and changes `rtcCleanup()` in the C API to always block until completion.