### PR TITLE
Renaming and cleanup

### DIFF
--- a/examples/sfu-media/main.cpp
+++ b/examples/sfu-media/main.cpp
@@ -67,7 +67,7 @@ int main() {
 		track->onMessage(
 		    [&receivers, targetSSRC](rtc::binary message) {
 			    // This is an RTP packet
-			    auto rtp = (rtc::RTP *)message.data();
+			    auto rtp = reinterpret_cast<rtc::RtpHeader *>(message.data());
 			    rtp->setSsrc(targetSSRC);
 			    for (auto pc : receivers) {
 				    if (pc->track != nullptr && pc->track->isOpen()) {

--- a/examples/streamer/h264fileparser.cpp
+++ b/examples/streamer/h264fileparser.cpp
@@ -34,7 +34,7 @@ H264FileParser::H264FileParser(string directory, uint32_t fps, bool loop): FileP
 void H264FileParser::loadNextSample() {
     FileParser::loadNextSample();
 
-    unsigned long long i = 0;
+    size_t i = 0;
     while (i < sample.size()) {
         assert(i + 4 < sample.size());
         auto lengthPtr = (uint32_t *) (sample.data() + i);

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -91,10 +91,10 @@ public:
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 
-	shared_ptr<DataChannel> createDataChannel(string label, DataChannelInit init = {});
+	[[nodiscard]] shared_ptr<DataChannel> createDataChannel(string label, DataChannelInit init = {});
 	void onDataChannel(std::function<void(std::shared_ptr<DataChannel> dataChannel)> callback);
 
-	shared_ptr<Track> addTrack(Description::Media description);
+	[[nodiscard]] shared_ptr<Track> addTrack(Description::Media description);
 	void onTrack(std::function<void(std::shared_ptr<Track> track)> callback);
 
 	void onLocalDescription(std::function<void(Description description)> callback);

--- a/include/rtc/rtcpsrreporter.hpp
+++ b/include/rtc/rtcpsrreporter.hpp
@@ -28,23 +28,22 @@
 namespace rtc {
 
 class RTC_CPP_EXPORT RtcpSrReporter final : public MediaHandlerElement {
-
 	bool needsToReport = false;
 
 	uint32_t packetCount = 0;
 	uint32_t payloadOctets = 0;
 	double timeOffset = 0;
 
-	uint32_t _previousReportedTimestamp = 0;
+	uint32_t mPreviousReportedTimestamp = 0;
 
-	void addToReport(RTP *rtp, uint32_t rtpSize);
+	void addToReport(RtpHeader *rtp, uint32_t rtpSize);
 	message_ptr getSenderReport(uint32_t timestamp);
 
 public:
 	static uint64_t secondsToNTP(double seconds);
 
 	/// Timestamp of previous sender report
-	const uint32_t &previousReportedTimestamp = _previousReportedTimestamp;
+	const uint32_t &previousReportedTimestamp = mPreviousReportedTimestamp;
 
 	/// RTP configuration
 	const shared_ptr<RtpPacketizationConfig> rtpConfig;
@@ -60,8 +59,7 @@ public:
 
 	/// Set offset to compute NTS for RTCP SR packets. Offset represents relation between real start
 	/// time and timestamp of the stream in RTP packets
-	/// @note `time_offset = rtpConfig->startTime_s -
-	/// rtpConfig->timestampToSeconds(rtpConfig->timestamp)`
+	/// @note `time_offset = rtpConfig->startTime - rtpConfig->timestampToSeconds(rtpConfig->timestamp)`
 	void startRecording();
 };
 

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -31,7 +31,7 @@ typedef uint32_t SSRC;
 
 #pragma pack(push, 1)
 
-struct RTC_CPP_EXPORT RTP_ExtensionHeader {
+struct RTC_CPP_EXPORT RtpExtensionHeader {
 	uint16_t _profileSpecificId;
 	uint16_t _headerLength;
 
@@ -49,7 +49,7 @@ struct RTC_CPP_EXPORT RTP_ExtensionHeader {
 	void writeCurrentVideoOrientation(size_t offset, uint8_t id, uint8_t value);
 };
 
-struct RTC_CPP_EXPORT RTP {
+struct RTC_CPP_EXPORT RtpHeader {
 	uint8_t _first;
 	uint8_t _payloadType;
 	uint16_t _seqNumber;
@@ -69,8 +69,8 @@ struct RTC_CPP_EXPORT RTP {
 
 	[[nodiscard]] size_t getSize() const;
 	[[nodiscard]] size_t getExtensionHeaderSize() const;
-	[[nodiscard]] const RTP_ExtensionHeader *getExtensionHeader() const;
-	[[nodiscard]] RTP_ExtensionHeader *getExtensionHeader();
+	[[nodiscard]] const RtpExtensionHeader *getExtensionHeader() const;
+	[[nodiscard]] RtpExtensionHeader *getExtensionHeader();
 	[[nodiscard]] const char *getBody() const;
 	[[nodiscard]] char *getBody();
 
@@ -85,7 +85,7 @@ struct RTC_CPP_EXPORT RTP {
 	void setExtension(bool extension);
 };
 
-struct RTC_CPP_EXPORT RTCP_ReportBlock {
+struct RTC_CPP_EXPORT RtcpReportBlock {
 	SSRC _ssrc;
 	uint32_t _fractionLostAndPacketsLost; // fraction lost is 8-bit, packets lost is 24-bit
 	uint16_t _seqNoCycles;
@@ -117,7 +117,7 @@ struct RTC_CPP_EXPORT RTCP_ReportBlock {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_HEADER {
+struct RTC_CPP_EXPORT RtcpHeader {
 	uint8_t _first;
 	uint8_t _payloadType;
 	uint16_t _length;
@@ -137,8 +137,8 @@ struct RTC_CPP_EXPORT RTCP_HEADER {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_FB_HEADER {
-	RTCP_HEADER header;
+struct RTC_CPP_EXPORT RtcpFbHeader {
+	RtcpHeader header;
 
 	SSRC _packetSender;
 	SSRC _mediaSource;
@@ -152,8 +152,8 @@ struct RTC_CPP_EXPORT RTCP_FB_HEADER {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_SR {
-	RTCP_HEADER header;
+struct RTC_CPP_EXPORT RtcpSr {
+	RtcpHeader header;
 
 	SSRC _senderSSRC;
 	uint64_t _ntpTimestamp;
@@ -161,7 +161,7 @@ struct RTC_CPP_EXPORT RTCP_SR {
 	uint32_t _packetCount;
 	uint32_t _octetCount;
 
-	RTCP_ReportBlock _reportBlocks;
+	RtcpReportBlock _reportBlocks;
 
 	[[nodiscard]] static unsigned int Size(unsigned int reportCount);
 
@@ -171,8 +171,8 @@ struct RTC_CPP_EXPORT RTCP_SR {
 	[[nodiscard]] uint32_t octetCount() const;
 	[[nodiscard]] uint32_t senderSSRC() const;
 
-	[[nodiscard]] const RTCP_ReportBlock *getReportBlock(int num) const;
-	[[nodiscard]] RTCP_ReportBlock *getReportBlock(int num);
+	[[nodiscard]] const RtcpReportBlock *getReportBlock(int num) const;
+	[[nodiscard]] RtcpReportBlock *getReportBlock(int num);
 	[[nodiscard]] unsigned int size(unsigned int reportCount);
 	[[nodiscard]] size_t getSize() const;
 
@@ -185,7 +185,7 @@ struct RTC_CPP_EXPORT RTCP_SR {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_SDES_ITEM {
+struct RTC_CPP_EXPORT RtcpSdesItem {
 	uint8_t type;
 
 	uint8_t _length;
@@ -199,9 +199,9 @@ struct RTC_CPP_EXPORT RTCP_SDES_ITEM {
 	void setText(string text);
 };
 
-struct RTCP_SDES_CHUNK {
+struct RTC_CPP_EXPORT RtcpSdesChunk {
 	SSRC _ssrc;
-	RTCP_SDES_ITEM _items;
+	RtcpSdesItem _items;
 
 	[[nodiscard]] static unsigned int Size(const std::vector<uint8_t> textLengths);
 
@@ -212,8 +212,8 @@ struct RTCP_SDES_CHUNK {
 	// Get item at given index
 	// All items with index < num must be valid, otherwise this function has undefined behaviour
 	// (use safelyCountChunkSize() to check if chunk is valid).
-	[[nodiscard]] const RTCP_SDES_ITEM *getItem(int num) const;
-	[[nodiscard]] RTCP_SDES_ITEM *getItem(int num);
+	[[nodiscard]] const RtcpSdesItem *getItem(int num) const;
+	[[nodiscard]] RtcpSdesItem *getItem(int num);
 
 	// Get size of chunk
 	// All items must be valid, otherwise this function has undefined behaviour (use
@@ -223,9 +223,9 @@ struct RTCP_SDES_CHUNK {
 	long safelyCountChunkSize(size_t maxChunkSize) const;
 };
 
-struct RTC_CPP_EXPORT RTCP_SDES {
-	RTCP_HEADER header;
-	RTCP_SDES_CHUNK _chunks;
+struct RTC_CPP_EXPORT RtcpSdes {
+	RtcpHeader header;
+	RtcpSdesChunk _chunks;
 
 	[[nodiscard]] static unsigned int Size(const std::vector<std::vector<uint8_t>> lengths);
 
@@ -238,17 +238,17 @@ struct RTC_CPP_EXPORT RTCP_SDES {
 	// Get chunk at given index
 	// All chunks (and their items) with index < `num` must be valid, otherwise this function has
 	// undefined behaviour (use `isValid` to check if chunk is valid).
-	const RTCP_SDES_CHUNK *getChunk(int num) const;
-	RTCP_SDES_CHUNK *getChunk(int num);
+	const RtcpSdesChunk *getChunk(int num) const;
+	RtcpSdesChunk *getChunk(int num);
 
 	void preparePacket(uint8_t chunkCount);
 };
 
-struct RTC_CPP_EXPORT RTCP_RR {
-	RTCP_HEADER header;
+struct RTC_CPP_EXPORT RtcpRr {
+	RtcpHeader header;
 
 	SSRC _senderSSRC;
-	RTCP_ReportBlock _reportBlocks;
+	RtcpReportBlock _reportBlocks;
 
 	[[nodiscard]] static size_t SizeWithReportBlocks(uint8_t reportCount);
 
@@ -256,8 +256,8 @@ struct RTC_CPP_EXPORT RTCP_RR {
 	bool isSenderReport();
 	bool isReceiverReport();
 
-	[[nodiscard]] RTCP_ReportBlock *getReportBlock(int num);
-	[[nodiscard]] const RTCP_ReportBlock *getReportBlock(int num) const;
+	[[nodiscard]] RtcpReportBlock *getReportBlock(int num);
+	[[nodiscard]] const RtcpReportBlock *getReportBlock(int num) const;
 	[[nodiscard]] size_t getSize() const;
 
 	void preparePacket(SSRC senderSSRC, uint8_t reportCount);
@@ -266,8 +266,8 @@ struct RTC_CPP_EXPORT RTCP_RR {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_REMB {
-	RTCP_FB_HEADER header;
+struct RTC_CPP_EXPORT RtcpRemb {
+	RtcpFbHeader header;
 
 	char _id[4];       // Unique identifier ('R' 'E' 'M' 'B')
 	uint32_t _bitrate; // Num SSRC, Br Exp, Br Mantissa (bit mask)
@@ -282,8 +282,8 @@ struct RTC_CPP_EXPORT RTCP_REMB {
 	void setSsrc(int iterator, SSRC newSssrc);
 };
 
-struct RTC_CPP_EXPORT RTCP_PLI {
-	RTCP_FB_HEADER header;
+struct RTC_CPP_EXPORT RtcpPli {
+	RtcpFbHeader header;
 
 	[[nodiscard]] static unsigned int Size();
 
@@ -292,16 +292,16 @@ struct RTC_CPP_EXPORT RTCP_PLI {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_FIR_PART {
+struct RTC_CPP_EXPORT RtcpFirPart {
 	uint32_t ssrc;
 	uint8_t seqNo;
 	uint8_t dummy1;
 	uint16_t dummy2;
 };
 
-struct RTC_CPP_EXPORT RTCP_FIR {
-	RTCP_FB_HEADER header;
-	RTCP_FIR_PART parts[1];
+struct RTC_CPP_EXPORT RtcpFir {
+	RtcpFbHeader header;
+	RtcpFirPart parts[1];
 
 	static unsigned int Size();
 
@@ -310,7 +310,7 @@ struct RTC_CPP_EXPORT RTCP_FIR {
 	void log() const;
 };
 
-struct RTC_CPP_EXPORT RTCP_NACK_PART {
+struct RTC_CPP_EXPORT RtcpNackPart {
 	uint16_t _pid;
 	uint16_t _blp;
 
@@ -323,9 +323,9 @@ struct RTC_CPP_EXPORT RTCP_NACK_PART {
 	std::vector<uint16_t> getSequenceNumbers();
 };
 
-struct RTC_CPP_EXPORT RTCP_NACK {
-	RTCP_FB_HEADER header;
-	RTCP_NACK_PART parts[1];
+struct RTC_CPP_EXPORT RtcpNack {
+	RtcpFbHeader header;
+	RtcpNackPart parts[1];
 
 	[[nodiscard]] static unsigned int Size(unsigned int discreteSeqNoCount);
 
@@ -345,8 +345,8 @@ struct RTC_CPP_EXPORT RTCP_NACK {
 	bool addMissingPacket(unsigned int *fciCount, uint16_t *fciPID, uint16_t missingPacket);
 };
 
-struct RTC_CPP_EXPORT RTP_RTX {
-	RTP header;
+struct RTC_CPP_EXPORT RtpRtx {
+	RtpHeader header;
 
 	[[nodiscard]] const char *getBody() const;
 	[[nodiscard]] char *getBody();
@@ -357,8 +357,27 @@ struct RTC_CPP_EXPORT RTP_RTX {
 	// Returns the new size of the packet
 	size_t normalizePacket(size_t totalSize, SSRC originalSSRC, uint8_t originalPayloadType);
 
-	size_t copyTo(RTP *dest, size_t totalSize, uint8_t originalPayloadType);
+	size_t copyTo(RtpHeader *dest, size_t totalSize, uint8_t originalPayloadType);
 };
+
+// For backward compatibility, do not use
+using RTP_ExtensionHeader = RtpExtensionHeader;
+using RTP = RtpHeader;
+using RTCP_ReportBlock = RtcpReportBlock;
+using RTCP_HEADER = RtcpHeader;
+using RTCP_FB_HEADER = RtcpFbHeader;
+using RTCP_SR = RtcpSr;
+using RTCP_SDES_ITEM = RtcpSdesItem;
+using RTCP_SDES_CHUNK = RtcpSdesChunk;
+using RTCP_SDES = RtcpSdes;
+using RTCP_RR = RtcpRr;
+using RTCP_REMB = RtcpRemb;
+using RTCP_PLI = RtcpPli;
+using RTCP_FIR_PART = RtcpFirPart;
+using RTCP_FIR = RtcpFir;
+using RTCP_NACK_PART = RtcpNackPart;
+using RTCP_NACK = RtcpNack;
+using RTP_RTX = RtpRtx;
 
 #pragma pack(pop)
 

--- a/include/rtc/rtppacketizationconfig.hpp
+++ b/include/rtc/rtppacketizationconfig.hpp
@@ -27,8 +27,8 @@ namespace rtc {
 
 /// RTP configuration used in packetization process
 class RTC_CPP_EXPORT RtpPacketizationConfig {
-	uint32_t _startTimestamp = 0;
-	double _startTime_s = 0;
+	uint32_t mStartTimestamp = 0;
+	double mStartTime = 0;
 	RtpPacketizationConfig(const RtpPacketizationConfig &) = delete;
 
 public:
@@ -36,14 +36,16 @@ public:
 	const std::string cname;
 	const uint8_t payloadType;
 	const uint32_t clockRate;
-	const double &startTime_s = _startTime_s;
-	const uint32_t &startTimestamp = _startTimestamp;
+	const double &startTime = mStartTime;
+	const uint32_t &startTimestamp = mStartTimestamp;
 	const uint8_t videoOrientationId;
 
 	/// current sequence number
 	uint16_t sequenceNumber;
+
 	/// current timestamp
 	uint32_t timestamp;
+
 	/// Current video orientation
 	///
 	/// Bit#       7  6  5  4  3  2  1  0
@@ -64,17 +66,20 @@ public:
 	///   3 - 270 degrees
 	uint8_t videoOrientation = 0;
 
-	enum class EpochStart : unsigned long long {
+	// For backward compatibility, do not use
+	const double &startTime_s = mStartTime;
+
+	enum class EpochStart : uint64_t {
 		T1970 = 2208988800, // number of seconds between 1970 and 1900
 		T1900 = 0
 	};
 
 	/// Creates relation between time and timestamp mapping given start time and start timestamp
-	/// @param startTime_s Start time of the stream
+	/// @param startTime Start time of the stream
 	/// @param epochStart Type of used epoch
 	/// @param startTimestamp Corresponding timestamp for given start time (current timestamp will
 	/// be used if value is nullopt)
-	void setStartTime(double startTime_s, EpochStart epochStart,
+	void setStartTime(double startTime, EpochStart epochStart,
 	                  optional<uint32_t> startTimestamp = std::nullopt);
 
 	/// Construct RTP configuration used in packetization process

--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -83,7 +83,7 @@ NalUnitStartSequenceMatch StartSequenceMatchSucc(NalUnitStartSequenceMatch match
 shared_ptr<NalUnits> H264RtpPacketizer::splitMessage(binary_ptr message) {
 	auto nalus = std::make_shared<NalUnits>();
 	if (separator == Separator::Length) {
-		unsigned long long index = 0;
+		size_t index = 0;
 		while (index < message->size()) {
 			assert(index + 4 < message->size());
 			if (index + 4 >= message->size()) {
@@ -107,7 +107,7 @@ shared_ptr<NalUnits> H264RtpPacketizer::splitMessage(binary_ptr message) {
 		}
 	} else {
 		NalUnitStartSequenceMatch match = NUSM_noMatch;
-		unsigned long long index = 0;
+		size_t index = 0;
 		while (index < message->size()) {
 			match = StartSequenceMatchSucc(match, (*message)[index++], separator);
 			if (match == NUSM_longMatch || match == NUSM_shortMatch) {
@@ -116,13 +116,13 @@ shared_ptr<NalUnits> H264RtpPacketizer::splitMessage(binary_ptr message) {
 			}
 		}
 
-		unsigned long long naluStartIndex = index;
+		size_t naluStartIndex = index;
 
 		while (index < message->size()) {
 			match = StartSequenceMatchSucc(match, (*message)[index], separator);
 			if (match == NUSM_longMatch || match == NUSM_shortMatch) {
 				auto sequenceLength = match == NUSM_longMatch ? 4 : 3;
-				unsigned long long naluEndIndex = index - sequenceLength;
+				size_t naluEndIndex = index - sequenceLength;
 				match = NUSM_noMatch;
 				auto begin = message->begin() + naluStartIndex;
 				auto end = message->begin() + naluEndIndex + 1;

--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -67,11 +67,11 @@ DtlsSrtpTransport::DtlsSrtpTransport(shared_ptr<IceTransport> lower,
 	PLOG_DEBUG << "Initializing DTLS-SRTP transport";
 
 	if (srtp_err_status_t err = srtp_create(&mSrtpIn, nullptr)) {
-		throw std::runtime_error("SRTP create failed, status=" + to_string(static_cast<int>(err)));
+		throw std::runtime_error("srtp_create failed, status=" + to_string(static_cast<int>(err)));
 	}
 	if (srtp_err_status_t err = srtp_create(&mSrtpOut, nullptr)) {
 		srtp_dealloc(mSrtpIn);
-		throw std::runtime_error("SRTP create failed, status=" + to_string(static_cast<int>(err)));
+		throw std::runtime_error("srtp_create failed, status=" + to_string(static_cast<int>(err)));
 	}
 }
 
@@ -202,7 +202,7 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 			}
 			PLOG_VERBOSE << "Unprotected SRTCP packet, size=" << size;
 			message->type = Message::Control;
-			message->stream = reinterpret_cast<RTCP_SR *>(message->data())->senderSSRC();
+			message->stream = reinterpret_cast<RtcpSr *>(message->data())->senderSSRC();
 
 		} else {
 			PLOG_VERBOSE << "Incoming SRTP packet, size=" << size;
@@ -221,7 +221,7 @@ void DtlsSrtpTransport::incoming(message_ptr message) {
 			}
 			PLOG_VERBOSE << "Unprotected SRTP packet, size=" << size;
 			message->type = Message::Binary;
-			message->stream = reinterpret_cast<RTP *>(message->data())->ssrc();
+			message->stream = reinterpret_cast<RtpHeader *>(message->data())->ssrc();
 		}
 
 		message->resize(size);

--- a/src/rtcpnackresponder.cpp
+++ b/src/rtcpnackresponder.cpp
@@ -47,7 +47,7 @@ void RtcpNackResponder::Storage::store(binary_ptr packet) {
 	if (!packet || packet->size() < 12) {
 		return;
 	}
-	auto rtp = reinterpret_cast<RTP *>(packet->data());
+	auto rtp = reinterpret_cast<RtpHeader *>(packet->data());
 	auto sequenceNumber = rtp->seqNumber();
 
 	assert((storage.empty() && !oldest && !newest) || (!storage.empty() && oldest && newest));
@@ -82,7 +82,7 @@ RtcpNackResponder::processIncomingControlMessage(message_ptr message) {
 
 	size_t p = 0;
 	while (p < message->size()) {
-		auto nack = reinterpret_cast<RTCP_NACK *>(message->data() + p);
+		auto nack = reinterpret_cast<RtcpNack *>(message->data() + p);
 		p += nack->header.header.lengthInBytes();
 		// check if rtcp is nack
 		if (nack->header.header.payloadType() != 205 || nack->header.header.reportCount() != 1) {

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -41,108 +41,113 @@
 
 namespace rtc {
 
-uint8_t RTP::version() const { return _first >> 6; }
-bool RTP::padding() const { return (_first >> 5) & 0x01; }
-bool RTP::extension() const { return (_first >> 4) & 0x01; }
-uint8_t RTP::csrcCount() const { return _first & 0x0F; }
-uint8_t RTP::marker() const { return _payloadType & 0b10000000; }
-uint8_t RTP::payloadType() const { return _payloadType & 0b01111111; }
-uint16_t RTP::seqNumber() const { return ntohs(_seqNumber); }
-uint32_t RTP::timestamp() const { return ntohl(_timestamp); }
-uint32_t RTP::ssrc() const { return ntohl(_ssrc); }
+uint8_t RtpHeader::version() const { return _first >> 6; }
+bool RtpHeader::padding() const { return (_first >> 5) & 0x01; }
+bool RtpHeader::extension() const { return (_first >> 4) & 0x01; }
+uint8_t RtpHeader::csrcCount() const { return _first & 0x0F; }
+uint8_t RtpHeader::marker() const { return _payloadType & 0b10000000; }
+uint8_t RtpHeader::payloadType() const { return _payloadType & 0b01111111; }
+uint16_t RtpHeader::seqNumber() const { return ntohs(_seqNumber); }
+uint32_t RtpHeader::timestamp() const { return ntohl(_timestamp); }
+uint32_t RtpHeader::ssrc() const { return ntohl(_ssrc); }
 
-size_t RTP::getSize() const {
+size_t RtpHeader::getSize() const {
 	return reinterpret_cast<const char *>(&_csrc) - reinterpret_cast<const char *>(this) +
 	       sizeof(SSRC) * csrcCount();
 }
 
-size_t RTP::getExtensionHeaderSize() const {
-	auto header = reinterpret_cast<const RTP_ExtensionHeader *>(getExtensionHeader());
+size_t RtpHeader::getExtensionHeaderSize() const {
+	auto header = reinterpret_cast<const RtpExtensionHeader *>(getExtensionHeader());
 	if (header) {
-		return header->getSize() + sizeof(RTP_ExtensionHeader);
+		return header->getSize() + sizeof(RtpExtensionHeader);
 	}
 	return 0;
 }
 
-const RTP_ExtensionHeader *RTP::getExtensionHeader() const {
+const RtpExtensionHeader *RtpHeader::getExtensionHeader() const {
 	if (extension()) {
 		auto header = reinterpret_cast<const char *>(&_csrc) + sizeof(SSRC) * csrcCount();
-		return reinterpret_cast<const RTP_ExtensionHeader *>(header);
+		return reinterpret_cast<const RtpExtensionHeader *>(header);
 	}
 	return nullptr;
 }
 
-RTP_ExtensionHeader *RTP::getExtensionHeader() {
+RtpExtensionHeader *RtpHeader::getExtensionHeader() {
 	if (extension()) {
 		auto header = reinterpret_cast<char *>(&_csrc) + sizeof(SSRC) * csrcCount();
-		return reinterpret_cast<RTP_ExtensionHeader *>(header);
+		return reinterpret_cast<RtpExtensionHeader *>(header);
 	}
 	return nullptr;
 }
 
-const char *RTP::getBody() const {
-	return reinterpret_cast<const char *>(&_csrc) + sizeof(SSRC) * csrcCount() + getExtensionHeaderSize();
+const char *RtpHeader::getBody() const {
+	return reinterpret_cast<const char *>(&_csrc) + sizeof(SSRC) * csrcCount() +
+	       getExtensionHeaderSize();
 }
 
-char *RTP::getBody() { return reinterpret_cast<char *>(&_csrc) + sizeof(SSRC) * csrcCount() + getExtensionHeaderSize(); }
+char *RtpHeader::getBody() {
+	return reinterpret_cast<char *>(&_csrc) + sizeof(SSRC) * csrcCount() + getExtensionHeaderSize();
+}
 
-void RTP::preparePacket() { _first |= (1 << 7); }
+void RtpHeader::preparePacket() { _first |= (1 << 7); }
 
-void RTP::setSeqNumber(uint16_t newSeqNo) { _seqNumber = htons(newSeqNo); }
+void RtpHeader::setSeqNumber(uint16_t newSeqNo) { _seqNumber = htons(newSeqNo); }
 
-void RTP::setPayloadType(uint8_t newPayloadType) {
+void RtpHeader::setPayloadType(uint8_t newPayloadType) {
 	_payloadType = (_payloadType & 0b10000000u) | (0b01111111u & newPayloadType);
 }
 
-void RTP::setSsrc(uint32_t in_ssrc) { _ssrc = htonl(in_ssrc); }
+void RtpHeader::setSsrc(uint32_t in_ssrc) { _ssrc = htonl(in_ssrc); }
 
-void RTP::setMarker(bool marker) { _payloadType = (_payloadType & 0x7F) | (marker << 7); };
+void RtpHeader::setMarker(bool marker) { _payloadType = (_payloadType & 0x7F) | (marker << 7); };
 
-void RTP::setTimestamp(uint32_t i) { _timestamp = htonl(i); }
+void RtpHeader::setTimestamp(uint32_t i) { _timestamp = htonl(i); }
 
-void RTP::setExtension(bool extension) { _first = (_first & ~0x10) | ((extension & 1) << 4); }
+void RtpHeader::setExtension(bool extension) { _first = (_first & ~0x10) | ((extension & 1) << 4); }
 
-void RTP::log() const {
-	PLOG_VERBOSE << "RTP V: " << (int)version() << " P: " << (padding() ? "P" : " ")
+void RtpHeader::log() const {
+	PLOG_VERBOSE << "RtpHeader V: " << (int)version() << " P: " << (padding() ? "P" : " ")
 	             << " X: " << (extension() ? "X" : " ") << " CC: " << (int)csrcCount()
 	             << " M: " << (marker() ? "M" : " ") << " PT: " << (int)payloadType()
 	             << " SEQNO: " << seqNumber() << " TS: " << timestamp();
 }
 
-uint16_t RTP_ExtensionHeader::profileSpecificId() const { return ntohs(_profileSpecificId); }
+uint16_t RtpExtensionHeader::profileSpecificId() const { return ntohs(_profileSpecificId); }
 
-uint16_t RTP_ExtensionHeader::headerLength() const { return ntohs(_headerLength); }
+uint16_t RtpExtensionHeader::headerLength() const { return ntohs(_headerLength); }
 
-size_t RTP_ExtensionHeader::getSize() const { return headerLength() * 4; }
+size_t RtpExtensionHeader::getSize() const { return headerLength() * 4; }
 
-const char *RTP_ExtensionHeader::getBody() const { return reinterpret_cast<const char *>((&_headerLength) + 1); }
+const char *RtpExtensionHeader::getBody() const {
+	return reinterpret_cast<const char *>((&_headerLength) + 1);
+}
 
-char *RTP_ExtensionHeader::getBody() { return reinterpret_cast<char *>((&_headerLength) + 1); }
+char *RtpExtensionHeader::getBody() { return reinterpret_cast<char *>((&_headerLength) + 1); }
 
-void RTP_ExtensionHeader::setProfileSpecificId(uint16_t profileSpecificId) {
+void RtpExtensionHeader::setProfileSpecificId(uint16_t profileSpecificId) {
 	_profileSpecificId = htons(profileSpecificId);
 }
 
-void RTP_ExtensionHeader::setHeaderLength(uint16_t headerLength) {
+void RtpExtensionHeader::setHeaderLength(uint16_t headerLength) {
 	_headerLength = htons(headerLength);
 }
 
-void RTP_ExtensionHeader::clearBody() { std::memset(getBody(), 0, getSize()); }
+void RtpExtensionHeader::clearBody() { std::memset(getBody(), 0, getSize()); }
 
-void RTP_ExtensionHeader::writeCurrentVideoOrientation(size_t offset, uint8_t id, uint8_t value)
-{
-	if ((id == 0) || (id > 14) || ((offset + 2) > getSize())) return;
+void RtpExtensionHeader::writeCurrentVideoOrientation(size_t offset, uint8_t id, uint8_t value) {
+	if ((id == 0) || (id > 14) || ((offset + 2) > getSize()))
+		return;
 	auto buf = getBody() + offset;
 	buf[0] = id << 4;
 	buf[1] = value;
 }
 
-SSRC RTCP_ReportBlock::getSSRC() const { return ntohl(_ssrc); }
+SSRC RtcpReportBlock::getSSRC() const { return ntohl(_ssrc); }
 
-void RTCP_ReportBlock::preparePacket(SSRC in_ssrc, [[maybe_unused]] unsigned int packetsLost,
-                                     [[maybe_unused]] unsigned int totalPackets,
-                                     uint16_t highestSeqNo, uint16_t seqNoCycles, uint32_t jitter,
-                                     uint64_t lastSR_NTP, uint64_t lastSR_DELAY) {
+void RtcpReportBlock::preparePacket(SSRC in_ssrc, [[maybe_unused]] unsigned int packetsLost,
+                                    [[maybe_unused]] unsigned int totalPackets,
+                                    uint16_t highestSeqNo, uint16_t seqNoCycles, uint32_t jitter,
+                                    uint64_t lastSR_NTP, uint64_t lastSR_DELAY) {
 	setSeqNo(highestSeqNo, seqNoCycles);
 	setJitter(jitter);
 	setSSRC(in_ssrc);
@@ -156,49 +161,49 @@ void RTCP_ReportBlock::preparePacket(SSRC in_ssrc, [[maybe_unused]] unsigned int
 	// _delaySinceLastReport = lastSR_DELAY;
 }
 
-void RTCP_ReportBlock::setSSRC(SSRC in_ssrc) { _ssrc = htonl(in_ssrc); }
+void RtcpReportBlock::setSSRC(SSRC in_ssrc) { _ssrc = htonl(in_ssrc); }
 
-void RTCP_ReportBlock::setPacketsLost([[maybe_unused]] unsigned int packetsLost,
-                                      [[maybe_unused]] unsigned int totalPackets) {
+void RtcpReportBlock::setPacketsLost([[maybe_unused]] unsigned int packetsLost,
+                                     [[maybe_unused]] unsigned int totalPackets) {
 	// TODO Implement loss percentages.
 	_fractionLostAndPacketsLost = 0;
 }
 
-unsigned int RTCP_ReportBlock::getLossPercentage() const {
+unsigned int RtcpReportBlock::getLossPercentage() const {
 	// TODO Implement loss percentages.
 	return 0;
 }
 
-unsigned int RTCP_ReportBlock::getPacketLostCount() const {
+unsigned int RtcpReportBlock::getPacketLostCount() const {
 	// TODO Implement total packets lost.
 	return 0;
 }
 
-uint16_t RTCP_ReportBlock::seqNoCycles() const { return ntohs(_seqNoCycles); }
+uint16_t RtcpReportBlock::seqNoCycles() const { return ntohs(_seqNoCycles); }
 
-uint16_t RTCP_ReportBlock::highestSeqNo() const { return ntohs(_highestSeqNo); }
+uint16_t RtcpReportBlock::highestSeqNo() const { return ntohs(_highestSeqNo); }
 
-uint32_t RTCP_ReportBlock::jitter() const { return ntohl(_jitter); }
+uint32_t RtcpReportBlock::jitter() const { return ntohl(_jitter); }
 
-uint32_t RTCP_ReportBlock::delaySinceSR() const { return ntohl(_delaySinceLastReport); }
+uint32_t RtcpReportBlock::delaySinceSR() const { return ntohl(_delaySinceLastReport); }
 
-void RTCP_ReportBlock::setSeqNo(uint16_t highestSeqNo, uint16_t seqNoCycles) {
+void RtcpReportBlock::setSeqNo(uint16_t highestSeqNo, uint16_t seqNoCycles) {
 	_highestSeqNo = htons(highestSeqNo);
 	_seqNoCycles = htons(seqNoCycles);
 }
 
-void RTCP_ReportBlock::setJitter(uint32_t jitter) { _jitter = htonl(jitter); }
+void RtcpReportBlock::setJitter(uint32_t jitter) { _jitter = htonl(jitter); }
 
-void RTCP_ReportBlock::setNTPOfSR(uint64_t ntp) { _lastReport = htonll(ntp >> 16u); }
+void RtcpReportBlock::setNTPOfSR(uint64_t ntp) { _lastReport = htonll(ntp >> 16u); }
 
-uint32_t RTCP_ReportBlock::getNTPOfSR() const { return ntohl(_lastReport) << 16u; }
+uint32_t RtcpReportBlock::getNTPOfSR() const { return ntohl(_lastReport) << 16u; }
 
-void RTCP_ReportBlock::setDelaySinceSR(uint32_t sr) {
+void RtcpReportBlock::setDelaySinceSR(uint32_t sr) {
 	// The delay, expressed in units of 1/65536 seconds
 	_delaySinceLastReport = htonl(sr);
 }
 
-void RTCP_ReportBlock::log() const {
+void RtcpReportBlock::log() const {
 	PLOG_VERBOSE << "RTCP report block: "
 	             << "ssrc="
 	             << ntohl(_ssrc)
@@ -210,90 +215,90 @@ void RTCP_ReportBlock::log() const {
 	             << ", lastSRDelay=" << delaySinceSR();
 }
 
-uint8_t RTCP_HEADER::version() const { return _first >> 6; }
+uint8_t RtcpHeader::version() const { return _first >> 6; }
 
-bool RTCP_HEADER::padding() const { return (_first >> 5) & 0x01; }
+bool RtcpHeader::padding() const { return (_first >> 5) & 0x01; }
 
-uint8_t RTCP_HEADER::reportCount() const { return _first & 0x1F; }
+uint8_t RtcpHeader::reportCount() const { return _first & 0x1F; }
 
-uint8_t RTCP_HEADER::payloadType() const { return _payloadType; }
+uint8_t RtcpHeader::payloadType() const { return _payloadType; }
 
-uint16_t RTCP_HEADER::length() const { return ntohs(_length); }
+uint16_t RtcpHeader::length() const { return ntohs(_length); }
 
-size_t RTCP_HEADER::lengthInBytes() const { return (1 + length()) * 4; }
+size_t RtcpHeader::lengthInBytes() const { return (1 + length()) * 4; }
 
-void RTCP_HEADER::setPayloadType(uint8_t type) { _payloadType = type; }
+void RtcpHeader::setPayloadType(uint8_t type) { _payloadType = type; }
 
-void RTCP_HEADER::setReportCount(uint8_t count) {
+void RtcpHeader::setReportCount(uint8_t count) {
 	_first = (_first & 0b11100000u) | (count & 0b00011111u);
 }
 
-void RTCP_HEADER::setLength(uint16_t length) { _length = htons(length); }
+void RtcpHeader::setLength(uint16_t length) { _length = htons(length); }
 
-void RTCP_HEADER::prepareHeader(uint8_t payloadType, uint8_t reportCount, uint16_t length) {
+void RtcpHeader::prepareHeader(uint8_t payloadType, uint8_t reportCount, uint16_t length) {
 	_first = 0b10000000; // version 2, no padding
 	setReportCount(reportCount);
 	setPayloadType(payloadType);
 	setLength(length);
 }
 
-void RTCP_HEADER::log() const {
+void RtcpHeader::log() const {
 	PLOG_VERBOSE << "RTCP header: "
 	             << "version=" << unsigned(version()) << ", padding=" << padding()
 	             << ", reportCount=" << unsigned(reportCount())
 	             << ", payloadType=" << unsigned(payloadType()) << ", length=" << length();
 }
 
-SSRC RTCP_FB_HEADER::packetSenderSSRC() const { return ntohl(_packetSender); }
+SSRC RtcpFbHeader::packetSenderSSRC() const { return ntohl(_packetSender); }
 
-SSRC RTCP_FB_HEADER::mediaSourceSSRC() const { return ntohl(_mediaSource); }
+SSRC RtcpFbHeader::mediaSourceSSRC() const { return ntohl(_mediaSource); }
 
-void RTCP_FB_HEADER::setPacketSenderSSRC(SSRC ssrc) { _packetSender = htonl(ssrc); }
+void RtcpFbHeader::setPacketSenderSSRC(SSRC ssrc) { _packetSender = htonl(ssrc); }
 
-void RTCP_FB_HEADER::setMediaSourceSSRC(SSRC ssrc) { _mediaSource = htonl(ssrc); }
+void RtcpFbHeader::setMediaSourceSSRC(SSRC ssrc) { _mediaSource = htonl(ssrc); }
 
-void RTCP_FB_HEADER::log() const {
+void RtcpFbHeader::log() const {
 	header.log();
 	PLOG_VERBOSE << "FB: "
 	             << " packet sender: " << packetSenderSSRC()
 	             << " media source: " << mediaSourceSSRC();
 }
 
-unsigned int RTCP_SR::Size(unsigned int reportCount) {
-	return sizeof(RTCP_HEADER) + 24 + reportCount * sizeof(RTCP_ReportBlock);
+unsigned int RtcpSr::Size(unsigned int reportCount) {
+	return sizeof(RtcpHeader) + 24 + reportCount * sizeof(RtcpReportBlock);
 }
 
-void RTCP_SR::preparePacket(SSRC senderSSRC, uint8_t reportCount) {
-	unsigned int length = ((sizeof(header) + 24 + reportCount * sizeof(RTCP_ReportBlock)) / 4) - 1;
+void RtcpSr::preparePacket(SSRC senderSSRC, uint8_t reportCount) {
+	unsigned int length = ((sizeof(header) + 24 + reportCount * sizeof(RtcpReportBlock)) / 4) - 1;
 	header.prepareHeader(200, reportCount, uint16_t(length));
 	this->_senderSSRC = htonl(senderSSRC);
 }
 
-const RTCP_ReportBlock *RTCP_SR::getReportBlock(int num) const { return &_reportBlocks + num; }
+const RtcpReportBlock *RtcpSr::getReportBlock(int num) const { return &_reportBlocks + num; }
 
-RTCP_ReportBlock *RTCP_SR::getReportBlock(int num) { return &_reportBlocks + num; }
+RtcpReportBlock *RtcpSr::getReportBlock(int num) { return &_reportBlocks + num; }
 
-size_t RTCP_SR::getSize() const {
+size_t RtcpSr::getSize() const {
 	// "length" in packet is one less than the number of 32 bit words in the packet.
 	return sizeof(uint32_t) * (1 + size_t(header.length()));
 }
 
-uint64_t RTCP_SR::ntpTimestamp() const { return ntohll(_ntpTimestamp); }
-uint32_t RTCP_SR::rtpTimestamp() const { return ntohl(_rtpTimestamp); }
-uint32_t RTCP_SR::packetCount() const { return ntohl(_packetCount); }
-uint32_t RTCP_SR::octetCount() const { return ntohl(_octetCount); }
-uint32_t RTCP_SR::senderSSRC() const { return ntohl(_senderSSRC); }
+uint64_t RtcpSr::ntpTimestamp() const { return ntohll(_ntpTimestamp); }
+uint32_t RtcpSr::rtpTimestamp() const { return ntohl(_rtpTimestamp); }
+uint32_t RtcpSr::packetCount() const { return ntohl(_packetCount); }
+uint32_t RtcpSr::octetCount() const { return ntohl(_octetCount); }
+uint32_t RtcpSr::senderSSRC() const { return ntohl(_senderSSRC); }
 
-void RTCP_SR::setNtpTimestamp(uint64_t ts) { _ntpTimestamp = htonll(ts); }
-void RTCP_SR::setRtpTimestamp(uint32_t ts) { _rtpTimestamp = htonl(ts); }
-void RTCP_SR::setOctetCount(uint32_t ts) { _octetCount = htonl(ts); }
-void RTCP_SR::setPacketCount(uint32_t ts) { _packetCount = htonl(ts); }
+void RtcpSr::setNtpTimestamp(uint64_t ts) { _ntpTimestamp = htonll(ts); }
+void RtcpSr::setRtpTimestamp(uint32_t ts) { _rtpTimestamp = htonl(ts); }
+void RtcpSr::setOctetCount(uint32_t ts) { _octetCount = htonl(ts); }
+void RtcpSr::setPacketCount(uint32_t ts) { _packetCount = htonl(ts); }
 
-void RTCP_SR::log() const {
+void RtcpSr::log() const {
 	header.log();
 	PLOG_VERBOSE << "RTCP SR: "
 	             << " SSRC=" << senderSSRC() << ", NTP_TS=" << ntpTimestamp()
-	             << ", RTP_TS=" << rtpTimestamp() << ", packetCount=" << packetCount()
+	             << ", RtpTS=" << rtpTimestamp() << ", packetCount=" << packetCount()
 	             << ", octetCount=" << octetCount();
 
 	for (unsigned i = 0; i < unsigned(header.reportCount()); i++) {
@@ -301,11 +306,11 @@ void RTCP_SR::log() const {
 	}
 }
 
-unsigned int RTCP_SDES_ITEM::Size(uint8_t textLength) { return textLength + 2; }
+unsigned int RtcpSdesItem::Size(uint8_t textLength) { return textLength + 2; }
 
-std::string RTCP_SDES_ITEM::text() const { return std::string(_text, _length); }
+std::string RtcpSdesItem::text() const { return std::string(_text, _length); }
 
-void RTCP_SDES_ITEM::setText(std::string text) {
+void RtcpSdesItem::setText(std::string text) {
 	if (text.size() > 0xFF)
 		throw std::invalid_argument("text is too long");
 
@@ -313,42 +318,42 @@ void RTCP_SDES_ITEM::setText(std::string text) {
 	memcpy(_text, text.data(), text.size());
 }
 
-uint8_t RTCP_SDES_ITEM::length() const { return _length; }
+uint8_t RtcpSdesItem::length() const { return _length; }
 
-unsigned int RTCP_SDES_CHUNK::Size(const std::vector<uint8_t> textLengths) {
+unsigned int RtcpSdesChunk::Size(const std::vector<uint8_t> textLengths) {
 	unsigned int itemsSize = 0;
 	for (auto length : textLengths) {
-		itemsSize += RTCP_SDES_ITEM::Size(length);
+		itemsSize += RtcpSdesItem::Size(length);
 	}
 	auto nullTerminatedItemsSize = itemsSize + 1;
 	auto words = uint8_t(std::ceil(double(nullTerminatedItemsSize) / 4)) + 1;
 	return words * 4;
 }
 
-SSRC RTCP_SDES_CHUNK::ssrc() const { return ntohl(_ssrc); }
+SSRC RtcpSdesChunk::ssrc() const { return ntohl(_ssrc); }
 
-void RTCP_SDES_CHUNK::setSSRC(SSRC ssrc) { _ssrc = htonl(ssrc); }
+void RtcpSdesChunk::setSSRC(SSRC ssrc) { _ssrc = htonl(ssrc); }
 
-const RTCP_SDES_ITEM *RTCP_SDES_CHUNK::getItem(int num) const {
+const RtcpSdesItem *RtcpSdesChunk::getItem(int num) const {
 	auto base = &_items;
 	while (num-- > 0) {
-		auto itemSize = RTCP_SDES_ITEM::Size(base->length());
-		base = reinterpret_cast<const RTCP_SDES_ITEM *>(reinterpret_cast<const uint8_t *>(base) +
-		                                                itemSize);
+		auto itemSize = RtcpSdesItem::Size(base->length());
+		base = reinterpret_cast<const RtcpSdesItem *>(reinterpret_cast<const uint8_t *>(base) +
+		                                              itemSize);
 	}
-	return reinterpret_cast<const RTCP_SDES_ITEM *>(base);
+	return reinterpret_cast<const RtcpSdesItem *>(base);
 }
 
-RTCP_SDES_ITEM *RTCP_SDES_CHUNK::getItem(int num) {
+RtcpSdesItem *RtcpSdesChunk::getItem(int num) {
 	auto base = &_items;
 	while (num-- > 0) {
-		auto itemSize = RTCP_SDES_ITEM::Size(base->length());
-		base = reinterpret_cast<RTCP_SDES_ITEM *>(reinterpret_cast<uint8_t *>(base) + itemSize);
+		auto itemSize = RtcpSdesItem::Size(base->length());
+		base = reinterpret_cast<RtcpSdesItem *>(reinterpret_cast<uint8_t *>(base) + itemSize);
 	}
-	return reinterpret_cast<RTCP_SDES_ITEM *>(base);
+	return reinterpret_cast<RtcpSdesItem *>(base);
 }
 
-unsigned int RTCP_SDES_CHUNK::getSize() const {
+unsigned int RtcpSdesChunk::getSize() const {
 	std::vector<uint8_t> textLengths{};
 	unsigned int i = 0;
 	auto item = getItem(i);
@@ -359,8 +364,8 @@ unsigned int RTCP_SDES_CHUNK::getSize() const {
 	return Size(textLengths);
 }
 
-long RTCP_SDES_CHUNK::safelyCountChunkSize(size_t maxChunkSize) const {
-	if (maxChunkSize < RTCP_SDES_CHUNK::Size({})) {
+long RtcpSdesChunk::safelyCountChunkSize(size_t maxChunkSize) const {
+	if (maxChunkSize < RtcpSdesChunk::Size({})) {
 		// chunk is truncated
 		return -1;
 	}
@@ -372,12 +377,12 @@ long RTCP_SDES_CHUNK::safelyCountChunkSize(size_t maxChunkSize) const {
 	auto item = getItem(i);
 	std::vector<uint8_t> textsLength{};
 	while (item->type != 0) {
-		if (size + RTCP_SDES_ITEM::Size(0) > maxChunkSize) {
+		if (size + RtcpSdesItem::Size(0) > maxChunkSize) {
 			// item is too short
 			return -1;
 		}
 		auto itemLength = item->length();
-		if (size + RTCP_SDES_ITEM::Size(itemLength) >= maxChunkSize) {
+		if (size + RtcpSdesItem::Size(itemLength) >= maxChunkSize) {
 			// item is too large (it can't be equal to chunk size because after item there
 			// must be 1-4 null bytes as padding)
 			return -1;
@@ -386,7 +391,7 @@ long RTCP_SDES_CHUNK::safelyCountChunkSize(size_t maxChunkSize) const {
 		// safely to access next item
 		item = getItem(++i);
 	}
-	auto realSize = RTCP_SDES_CHUNK::Size(textsLength);
+	auto realSize = RtcpSdesChunk::Size(textsLength);
 	if (realSize > maxChunkSize) {
 		// Chunk is too large
 		return -1;
@@ -394,15 +399,15 @@ long RTCP_SDES_CHUNK::safelyCountChunkSize(size_t maxChunkSize) const {
 	return realSize;
 }
 
-unsigned int RTCP_SDES::Size(const std::vector<std::vector<uint8_t>> lengths) {
+unsigned int RtcpSdes::Size(const std::vector<std::vector<uint8_t>> lengths) {
 	unsigned int chunks_size = 0;
 	for (auto length : lengths)
-		chunks_size += RTCP_SDES_CHUNK::Size(length);
+		chunks_size += RtcpSdesChunk::Size(length);
 
 	return 4 + chunks_size;
 }
 
-bool RTCP_SDES::isValid() const {
+bool RtcpSdes::isValid() const {
 	auto chunksSize = header.lengthInBytes() - sizeof(header);
 	if (chunksSize == 0) {
 		return true;
@@ -411,7 +416,7 @@ bool RTCP_SDES::isValid() const {
 	unsigned int i = 0;
 	unsigned int size = 0;
 	while (size < chunksSize) {
-		if (chunksSize < size + RTCP_SDES_CHUNK::Size({})) {
+		if (chunksSize < size + RtcpSdesChunk::Size({})) {
 			// chunk is truncated
 			return false;
 		}
@@ -426,7 +431,7 @@ bool RTCP_SDES::isValid() const {
 	return size == chunksSize;
 }
 
-unsigned int RTCP_SDES::chunksCount() const {
+unsigned int RtcpSdes::chunksCount() const {
 	if (!isValid()) {
 		return 0;
 	}
@@ -439,26 +444,26 @@ unsigned int RTCP_SDES::chunksCount() const {
 	return i;
 }
 
-const RTCP_SDES_CHUNK *RTCP_SDES::getChunk(int num) const {
+const RtcpSdesChunk *RtcpSdes::getChunk(int num) const {
 	auto base = &_chunks;
 	while (num-- > 0) {
 		auto chunkSize = base->getSize();
-		base = reinterpret_cast<const RTCP_SDES_CHUNK *>(reinterpret_cast<const uint8_t *>(base) +
-		                                                 chunkSize);
+		base = reinterpret_cast<const RtcpSdesChunk *>(reinterpret_cast<const uint8_t *>(base) +
+		                                               chunkSize);
 	}
-	return reinterpret_cast<const RTCP_SDES_CHUNK *>(base);
+	return reinterpret_cast<const RtcpSdesChunk *>(base);
 }
 
-RTCP_SDES_CHUNK *RTCP_SDES::getChunk(int num) {
+RtcpSdesChunk *RtcpSdes::getChunk(int num) {
 	auto base = &_chunks;
 	while (num-- > 0) {
 		auto chunkSize = base->getSize();
-		base = reinterpret_cast<RTCP_SDES_CHUNK *>(reinterpret_cast<uint8_t *>(base) + chunkSize);
+		base = reinterpret_cast<RtcpSdesChunk *>(reinterpret_cast<uint8_t *>(base) + chunkSize);
 	}
-	return reinterpret_cast<RTCP_SDES_CHUNK *>(base);
+	return reinterpret_cast<RtcpSdesChunk *>(base);
 }
 
-void RTCP_SDES::preparePacket(uint8_t chunkCount) {
+void RtcpSdes::preparePacket(uint8_t chunkCount) {
 	unsigned int chunkSize = 0;
 	for (uint8_t i = 0; i < chunkCount; i++) {
 		auto chunk = getChunk(i);
@@ -468,35 +473,35 @@ void RTCP_SDES::preparePacket(uint8_t chunkCount) {
 	header.prepareHeader(202, chunkCount, length);
 }
 
-const RTCP_ReportBlock *RTCP_RR::getReportBlock(int num) const { return &_reportBlocks + num; }
+const RtcpReportBlock *RtcpRr::getReportBlock(int num) const { return &_reportBlocks + num; }
 
-RTCP_ReportBlock *RTCP_RR::getReportBlock(int num) { return &_reportBlocks + num; }
+RtcpReportBlock *RtcpRr::getReportBlock(int num) { return &_reportBlocks + num; }
 
-size_t RTCP_RR::SizeWithReportBlocks(uint8_t reportCount) {
-	return sizeof(header) + 4 + size_t(reportCount) * sizeof(RTCP_ReportBlock);
+size_t RtcpRr::SizeWithReportBlocks(uint8_t reportCount) {
+	return sizeof(header) + 4 + size_t(reportCount) * sizeof(RtcpReportBlock);
 }
 
-SSRC RTCP_RR::senderSSRC() const { return ntohl(_senderSSRC); }
+SSRC RtcpRr::senderSSRC() const { return ntohl(_senderSSRC); }
 
-bool RTCP_RR::isSenderReport() { return header.payloadType() == 200; }
+bool RtcpRr::isSenderReport() { return header.payloadType() == 200; }
 
-bool RTCP_RR::isReceiverReport() { return header.payloadType() == 201; }
+bool RtcpRr::isReceiverReport() { return header.payloadType() == 201; }
 
-size_t RTCP_RR::getSize() const {
+size_t RtcpRr::getSize() const {
 	// "length" in packet is one less than the number of 32 bit words in the packet.
 	return sizeof(uint32_t) * (1 + size_t(header.length()));
 }
 
-void RTCP_RR::preparePacket(SSRC senderSSRC, uint8_t reportCount) {
+void RtcpRr::preparePacket(SSRC senderSSRC, uint8_t reportCount) {
 	// "length" in packet is one less than the number of 32 bit words in the packet.
 	size_t length = (SizeWithReportBlocks(reportCount) / 4) - 1;
 	header.prepareHeader(201, reportCount, uint16_t(length));
 	this->_senderSSRC = htonl(senderSSRC);
 }
 
-void RTCP_RR::setSenderSSRC(SSRC ssrc) { this->_senderSSRC = htonl(ssrc); }
+void RtcpRr::setSenderSSRC(SSRC ssrc) { this->_senderSSRC = htonl(ssrc); }
 
-void RTCP_RR::log() const {
+void RtcpRr::log() const {
 	header.log();
 	PLOG_VERBOSE << "RTCP RR: "
 	             << " SSRC=" << ntohl(_senderSSRC);
@@ -506,16 +511,14 @@ void RTCP_RR::log() const {
 	}
 }
 
-size_t RTCP_REMB::SizeWithSSRCs(int count) {
-	return sizeof(RTCP_REMB) + (count - 1) * sizeof(SSRC);
-}
+size_t RtcpRemb::SizeWithSSRCs(int count) { return sizeof(RtcpRemb) + (count - 1) * sizeof(SSRC); }
 
-unsigned int RTCP_REMB::getSize() const {
+unsigned int RtcpRemb::getSize() const {
 	// "length" in packet is one less than the number of 32 bit words in the packet.
 	return sizeof(uint32_t) * (1 + header.header.length());
 }
 
-void RTCP_REMB::preparePacket(SSRC senderSSRC, unsigned int numSSRC, unsigned int in_bitrate) {
+void RtcpRemb::preparePacket(SSRC senderSSRC, unsigned int numSSRC, unsigned int in_bitrate) {
 
 	// Report Count becomes the format here.
 	header.header.prepareHeader(206, 15, 0);
@@ -533,7 +536,7 @@ void RTCP_REMB::preparePacket(SSRC senderSSRC, unsigned int numSSRC, unsigned in
 	setBitrate(numSSRC, in_bitrate);
 }
 
-void RTCP_REMB::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
+void RtcpRemb::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
 	unsigned int exp = 0;
 	while (in_bitrate > pow(2, 18) - 1) {
 		exp++;
@@ -541,27 +544,26 @@ void RTCP_REMB::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
 	}
 
 	// "length" in packet is one less than the number of 32 bit words in the packet.
-	header.header.setLength(
-	    uint16_t((offsetof(RTCP_REMB, _ssrc) / sizeof(uint32_t)) - 1 + numSSRC));
+	header.header.setLength(uint16_t((offsetof(RtcpRemb, _ssrc) / sizeof(uint32_t)) - 1 + numSSRC));
 
 	_bitrate = htonl((numSSRC << (32u - 8u)) | (exp << (32u - 8u - 6u)) | in_bitrate);
 }
 
-void RTCP_REMB::setSsrc(int iterator, SSRC newSssrc) { _ssrc[iterator] = htonl(newSssrc); }
+void RtcpRemb::setSsrc(int iterator, SSRC newSssrc) { _ssrc[iterator] = htonl(newSssrc); }
 
-unsigned int RTCP_PLI::Size() { return sizeof(RTCP_FB_HEADER); }
+unsigned int RtcpPli::Size() { return sizeof(RtcpFbHeader); }
 
-void RTCP_PLI::preparePacket(SSRC messageSSRC) {
+void RtcpPli::preparePacket(SSRC messageSSRC) {
 	header.header.prepareHeader(206, 1, 2);
 	header.setPacketSenderSSRC(messageSSRC);
 	header.setMediaSourceSSRC(messageSSRC);
 }
 
-void RTCP_PLI::log() const { header.log(); }
+void RtcpPli::log() const { header.log(); }
 
-unsigned int RTCP_FIR::Size() { return sizeof(RTCP_FB_HEADER) + sizeof(RTCP_FIR_PART); }
+unsigned int RtcpFir::Size() { return sizeof(RtcpFbHeader) + sizeof(RtcpFirPart); }
 
-void RTCP_FIR::preparePacket(SSRC messageSSRC, uint8_t seqNo) {
+void RtcpFir::preparePacket(SSRC messageSSRC, uint8_t seqNo) {
 	header.header.prepareHeader(206, 4, 2 + 2 * 1);
 	header.setPacketSenderSSRC(messageSSRC);
 	header.setMediaSourceSSRC(messageSSRC);
@@ -569,15 +571,15 @@ void RTCP_FIR::preparePacket(SSRC messageSSRC, uint8_t seqNo) {
 	parts[0].seqNo = seqNo;
 }
 
-void RTCP_FIR::log() const { header.log(); }
+void RtcpFir::log() const { header.log(); }
 
-uint16_t RTCP_NACK_PART::pid() { return ntohs(_pid); }
-uint16_t RTCP_NACK_PART::blp() { return ntohs(_blp); }
+uint16_t RtcpNackPart::pid() { return ntohs(_pid); }
+uint16_t RtcpNackPart::blp() { return ntohs(_blp); }
 
-void RTCP_NACK_PART::setPid(uint16_t pid) { _pid = htons(pid); }
-void RTCP_NACK_PART::setBlp(uint16_t blp) { _blp = htons(blp); }
+void RtcpNackPart::setPid(uint16_t pid) { _pid = htons(pid); }
+void RtcpNackPart::setBlp(uint16_t blp) { _blp = htons(blp); }
 
-std::vector<uint16_t> RTCP_NACK_PART::getSequenceNumbers() {
+std::vector<uint16_t> RtcpNackPart::getSequenceNumbers() {
 	std::vector<uint16_t> result{};
 	result.reserve(17);
 	uint16_t p = pid();
@@ -594,19 +596,19 @@ std::vector<uint16_t> RTCP_NACK_PART::getSequenceNumbers() {
 	return result;
 }
 
-unsigned int RTCP_NACK::Size(unsigned int discreteSeqNoCount) {
-	return offsetof(RTCP_NACK, parts) + sizeof(RTCP_NACK_PART) * discreteSeqNoCount;
+unsigned int RtcpNack::Size(unsigned int discreteSeqNoCount) {
+	return offsetof(RtcpNack, parts) + sizeof(RtcpNackPart) * discreteSeqNoCount;
 }
 
-unsigned int RTCP_NACK::getSeqNoCount() { return header.header.length() - 2; }
+unsigned int RtcpNack::getSeqNoCount() { return header.header.length() - 2; }
 
-void RTCP_NACK::preparePacket(SSRC ssrc, unsigned int discreteSeqNoCount) {
+void RtcpNack::preparePacket(SSRC ssrc, unsigned int discreteSeqNoCount) {
 	header.header.prepareHeader(205, 1, 2 + uint16_t(discreteSeqNoCount));
 	header.setMediaSourceSSRC(ssrc);
 	header.setPacketSenderSSRC(ssrc);
 }
 
-bool RTCP_NACK::addMissingPacket(unsigned int *fciCount, uint16_t *fciPID, uint16_t missingPacket) {
+bool RtcpNack::addMissingPacket(unsigned int *fciCount, uint16_t *fciPID, uint16_t missingPacket) {
 	if (*fciCount == 0 || missingPacket < *fciPID || missingPacket > (*fciPID + 16)) {
 		parts[*fciCount].setPid(missingPacket);
 		parts[*fciCount].setBlp(0);
@@ -622,19 +624,19 @@ bool RTCP_NACK::addMissingPacket(unsigned int *fciCount, uint16_t *fciPID, uint1
 	}
 }
 
-uint16_t RTP_RTX::getOriginalSeqNo() const { return ntohs(*(uint16_t *)(header.getBody())); }
+uint16_t RtpRtx::getOriginalSeqNo() const { return ntohs(*(uint16_t *)(header.getBody())); }
 
-const char *RTP_RTX::getBody() const { return header.getBody() + sizeof(uint16_t); }
+const char *RtpRtx::getBody() const { return header.getBody() + sizeof(uint16_t); }
 
-char *RTP_RTX::getBody() { return header.getBody() + sizeof(uint16_t); }
+char *RtpRtx::getBody() { return header.getBody() + sizeof(uint16_t); }
 
-size_t RTP_RTX::getBodySize(size_t totalSize) const {
+size_t RtpRtx::getBodySize(size_t totalSize) const {
 	return totalSize - (getBody() - reinterpret_cast<const char *>(this));
 }
 
-size_t RTP_RTX::getSize() const { return header.getSize() + sizeof(uint16_t); }
+size_t RtpRtx::getSize() const { return header.getSize() + sizeof(uint16_t); }
 
-size_t RTP_RTX::normalizePacket(size_t totalSize, SSRC originalSSRC, uint8_t originalPayloadType) {
+size_t RtpRtx::normalizePacket(size_t totalSize, SSRC originalSSRC, uint8_t originalPayloadType) {
 	header.setSeqNumber(getOriginalSeqNo());
 	header.setSsrc(originalSSRC);
 	header.setPayloadType(originalPayloadType);
@@ -643,7 +645,7 @@ size_t RTP_RTX::normalizePacket(size_t totalSize, SSRC originalSSRC, uint8_t ori
 	return totalSize - 2;
 }
 
-size_t RTP_RTX::copyTo(RTP *dest, size_t totalSize, uint8_t originalPayloadType) {
+size_t RtpRtx::copyTo(RtpHeader *dest, size_t totalSize, uint8_t originalPayloadType) {
 	memmove((char *)dest, (char *)this, header.getSize());
 	dest->setSeqNumber(getOriginalSeqNo());
 	dest->setPayloadType(originalPayloadType);

--- a/src/rtppacketizationconfig.cpp
+++ b/src/rtppacketizationconfig.cpp
@@ -42,17 +42,17 @@ RtpPacketizationConfig::RtpPacketizationConfig(SSRC ssrc, string cname, uint8_t 
 	} else {
 		this->timestamp = rand();
 	}
-	this->_startTimestamp = this->timestamp;
+	this->mStartTimestamp = this->timestamp;
 }
 
-void RtpPacketizationConfig::setStartTime(double startTime_s, EpochStart epochStart,
+void RtpPacketizationConfig::setStartTime(double startTime, EpochStart epochStart,
                                           optional<uint32_t> startTimestamp) {
-	this->_startTime_s = startTime_s + static_cast<unsigned long long>(epochStart);
+	this->mStartTime = startTime + double(static_cast<uint64_t>(epochStart));
 	if (startTimestamp.has_value()) {
-		this->_startTimestamp = startTimestamp.value();
+		this->mStartTimestamp = startTimestamp.value();
 		timestamp = this->startTimestamp;
 	} else {
-		this->_startTimestamp = timestamp;
+		this->mStartTimestamp = timestamp;
 	}
 }
 

--- a/src/rtppacketizer.cpp
+++ b/src/rtppacketizer.cpp
@@ -37,7 +37,7 @@ binary_ptr RtpPacketizer::packetize(shared_ptr<binary> payload, bool setMark) {
 		rtpExtHeaderSize = rtpExtHeaderCvoSize;
 	}
 	auto msg = std::make_shared<binary>(rtpHeaderSize + rtpExtHeaderSize + payload->size());
-	auto *rtp = (RTP *)msg->data();
+	auto *rtp = (RtpHeader *)msg->data();
 	rtp->setPayloadType(rtpConfig->payloadType);
 	// increase sequence number
 	rtp->setSeqNumber(rtpConfig->sequenceNumber++);


### PR DESCRIPTION
This PR renames RTP and RTCP structures for the sake of consistency and cleans up other cosmetic things on the public API. It introduces aliases for backward compatibility.