### PR TITLE
Handle different local and remote SCTP ports

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -178,11 +178,10 @@ void SctpTransport::Cleanup() {
 		std::this_thread::sleep_for(100ms);
 }
 
-SctpTransport::SctpTransport(shared_ptr<Transport> lower, const Configuration &config,
-                             uint16_t port, message_callback recvCallback,
-                             amount_callback bufferedAmountCallback,
+SctpTransport::SctpTransport(shared_ptr<Transport> lower, const Configuration &config, Ports ports,
+                             message_callback recvCallback, amount_callback bufferedAmountCallback,
                              state_callback stateChangeCallback)
-    : Transport(lower, std::move(stateChangeCallback)), mPort(port),
+    : Transport(lower, std::move(stateChangeCallback)), mPorts(std::move(ports)),
       mSendQueue(0, message_size_func), mBufferedAmountCallback(std::move(bufferedAmountCallback)) {
 	onRecv(std::move(recvCallback));
 
@@ -361,28 +360,34 @@ void SctpTransport::close() {
 	}
 }
 
-void SctpTransport::connect() {
-	if (!mSock)
-		throw std::logic_error("Attempted SCTP connect with closed socket");
-
-	PLOG_DEBUG << "SCTP connecting";
-	changeState(State::Connecting);
-
+struct sockaddr_conn SctpTransport::getSockAddrConn(uint16_t port) {
 	struct sockaddr_conn sconn = {};
 	sconn.sconn_family = AF_CONN;
-	sconn.sconn_port = htons(mPort);
+	sconn.sconn_port = htons(port);
 	sconn.sconn_addr = this;
 #ifdef HAVE_SCONN_LEN
 	sconn.sconn_len = sizeof(sconn);
 #endif
+	return sconn;
+}
 
-	if (usrsctp_bind(mSock, reinterpret_cast<struct sockaddr *>(&sconn), sizeof(sconn)))
+void SctpTransport::connect() {
+	if (!mSock)
+		throw std::logic_error("Attempted SCTP connect with closed socket");
+
+	PLOG_DEBUG << "SCTP connecting (local port=" << mPorts.local
+	           << ", remote port=" << mPorts.remote << ")";
+	changeState(State::Connecting);
+
+	auto local = getSockAddrConn(mPorts.local);
+	if (usrsctp_bind(mSock, reinterpret_cast<struct sockaddr *>(&local), sizeof(local)))
 		throw std::runtime_error("Could not bind usrsctp socket, errno=" + std::to_string(errno));
 
 	// According to RFC 8841, both endpoints must initiate the SCTP association, in a
 	// simultaneous-open manner, irrelevent to the SDP setup role.
 	// See https://tools.ietf.org/html/rfc8841#section-9.3
-	int ret = usrsctp_connect(mSock, reinterpret_cast<struct sockaddr *>(&sconn), sizeof(sconn));
+	auto remote = getSockAddrConn(mPorts.remote);
+	int ret = usrsctp_connect(mSock, reinterpret_cast<struct sockaddr *>(&remote), sizeof(remote));
 	if (ret && errno != EINPROGRESS)
 		throw std::runtime_error("Connection attempt failed, errno=" + std::to_string(errno));
 }

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -42,7 +42,12 @@ public:
 
 	using amount_callback = std::function<void(uint16_t streamId, size_t amount)>;
 
-	SctpTransport(shared_ptr<Transport> lower, const Configuration &config, uint16_t port,
+	struct Ports {
+		uint16_t local = DEFAULT_SCTP_PORT;
+		uint16_t remote = DEFAULT_SCTP_PORT;
+	};
+
+	SctpTransport(shared_ptr<Transport> lower, const Configuration &config, Ports ports,
 	              message_callback recvCallback, amount_callback bufferedAmountCallback,
 	              state_callback stateChangeCallback);
 	~SctpTransport();
@@ -76,6 +81,8 @@ private:
 		PPID_BINARY_EMPTY = 57
 	};
 
+	struct sockaddr_conn getSockAddrConn(uint16_t port);
+
 	void connect();
 	void shutdown();
 	void close();
@@ -96,7 +103,7 @@ private:
 	void processData(binary &&data, uint16_t streamId, PayloadId ppid);
 	void processNotification(const union sctp_notification *notify, size_t len);
 
-	const uint16_t mPort;
+	const Ports mPorts;
 	struct socket *mSock;
 
 	Processor mProcessor;


### PR DESCRIPTION
This PR makes `SctpTransport` handle different local and remote ports. It fixes the case where the remote peer chooses another non-default SCTP port when answering.

Fixes: https://github.com/paullouisageneau/libdatachannel/issues/534