### PR TITLE
Poll service for TCP sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(LIBDATACHANNEL_IMPL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollinterrupter.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollservice.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcpserver.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcptransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tlstransport.cpp
@@ -150,6 +151,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollinterrupter.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/pollservice.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcpserver.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tcptransport.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tlstransport.hpp

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -125,7 +125,9 @@ void Init::doInit() {
 #endif
 
 	ThreadPool::Instance().spawn(THREADPOOL_SIZE);
+#if RTC_ENABLE_WEBSOCKET
 	PollService::Instance().start();
+#endif
 
 #if USE_GNUTLS
 	// Nothing to do
@@ -154,8 +156,10 @@ void Init::doCleanup() {
 
 	PLOG_DEBUG << "Global cleanup";
 
-	PollService::Instance().join();
 	ThreadPool::Instance().join();
+#if RTC_ENABLE_WEBSOCKET
+	PollService::Instance().join();
+#endif
 
 	SctpTransport::Cleanup();
 	DtlsTransport::Cleanup();

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Paul-Louis Ageneau
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -21,6 +21,7 @@
 
 #include "certificate.hpp"
 #include "dtlstransport.hpp"
+#include "pollservice.hpp"
 #include "sctptransport.hpp"
 #include "threadpool.hpp"
 #include "tls.hpp"
@@ -124,6 +125,7 @@ void Init::doInit() {
 #endif
 
 	ThreadPool::Instance().spawn(THREADPOOL_SIZE);
+	PollService::Instance().start();
 
 #if USE_GNUTLS
 	// Nothing to do
@@ -152,6 +154,7 @@ void Init::doCleanup() {
 
 	PLOG_DEBUG << "Global cleanup";
 
+	PollService::Instance().join();
 	ThreadPool::Instance().join();
 
 	SctpTransport::Cleanup();

--- a/src/impl/init.hpp
+++ b/src/impl/init.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 Paul-Louis Ageneau
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/src/impl/pollservice.cpp
+++ b/src/impl/pollservice.cpp
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "pollservice.hpp"
+#include "internals.hpp"
+
+#if RTC_ENABLE_WEBSOCKET
+
+#include <cassert>
+
+namespace rtc::impl {
+
+using namespace std::chrono_literals;
+using std::chrono::duration_cast;
+using std::chrono::milliseconds;
+
+PollService &PollService::Instance() {
+	static PollService *instance = new PollService;
+	return *instance;
+}
+
+PollService::PollService() : mStopped(true) {}
+
+PollService::~PollService() {}
+
+void PollService::start() {
+	mSocks = std::make_unique<SocketMap>();
+	mStopped = false;
+	mThread = std::thread(&PollService::runLoop, this);
+}
+
+void PollService::join() {
+	std::unique_lock lock(mMutex);
+	if(std::exchange(mStopped, true))
+		return;
+
+	lock.unlock();
+
+	mInterrupter.interrupt();
+	mThread.join();
+	mSocks.reset();
+}
+
+void PollService::add(socket_t sock, Params params) {
+	std::unique_lock lock(mMutex);
+	assert(mSocks);
+
+	if (!params.callback)
+		throw std::invalid_argument("poll callback is null");
+
+	mSocks->erase(sock);
+
+	PLOG_VERBOSE << "Registering socket in poll service, direction=" << params.direction;
+	auto until = params.timeout ? std::make_optional(clock::now() + *params.timeout) : nullopt;
+	mSocks->emplace(sock, SocketEntry{std::move(params), std::move(until)});
+
+	mInterrupter.interrupt();
+}
+
+void PollService::remove(socket_t sock) {
+	std::unique_lock lock(mMutex);
+	assert(mSocks);
+
+	PLOG_VERBOSE << "Unregistering socket in poll service";
+	mSocks->erase(sock);
+
+	mInterrupter.interrupt();
+}
+
+void PollService::prepare(std::vector<struct pollfd> &pfds, optional<clock::time_point> &next) {
+	std::unique_lock lock(mMutex);
+	pfds.resize(1 + mSocks->size());
+	next.reset();
+
+	auto it = pfds.begin();
+	mInterrupter.prepare(*it++);
+	for (const auto &[sock, entry] : *mSocks) {
+		it->fd = sock;
+		switch (entry.params.direction) {
+		case Direction::In:
+			it->events = POLLIN;
+			break;
+		case Direction::Out:
+			it->events = POLLOUT;
+			break;
+		default:
+			it->events = POLLIN | POLLOUT;
+			break;
+		}
+		if (entry.until)
+			next = next ? std::min(*next, *entry.until) : *entry.until;
+
+		++it;
+	}
+}
+
+void PollService::process(std::vector<struct pollfd> &pfds) {
+	std::unique_lock lock(mMutex);
+	for (auto it = pfds.begin(); it != pfds.end(); ++it) {
+		socket_t sock = it->fd;
+		auto jt = mSocks->find(sock);
+		if (jt == mSocks->end())
+			continue; // removed
+
+		auto &entry = jt->second;
+		const auto &params = entry.params;
+
+		if (it->revents & POLLNVAL || it->revents & POLLERR) {
+			PLOG_VERBOSE << "Poll error event";
+			auto callback = std::move(params.callback);
+			mSocks->erase(sock);
+			callback(Event::Error);
+			continue;
+		}
+
+		if (it->revents & POLLIN || it->revents & POLLOUT) {
+			entry.until =
+			    params.timeout ? std::make_optional(clock::now() + *params.timeout) : nullopt;
+
+			auto callback = params.callback;
+
+			if (it->revents & POLLIN) {
+				PLOG_VERBOSE << "Poll in event";
+				params.callback(Event::In);
+			}
+
+			if (it->revents & POLLOUT) {
+				PLOG_VERBOSE << "Poll out event";
+				params.callback(Event::Out);
+			}
+
+			continue;
+		}
+
+		if (entry.until && clock::now() >= *entry.until) {
+			PLOG_VERBOSE << "Poll timeout event";
+			auto callback = std::move(params.callback);
+			mSocks->erase(sock);
+			callback(Event::Timeout);
+			continue;
+		}
+	}
+}
+
+void PollService::runLoop() {
+	try {
+		PLOG_DEBUG << "Poll service started";
+		assert(mSocks);
+
+		std::vector<struct pollfd> pfds;
+		optional<clock::time_point> next;
+		while (!mStopped) {
+			prepare(pfds, next);
+
+			PLOG_VERBOSE << "Entering poll";
+			int ret;
+			do {
+				int timeout = next ? duration_cast<milliseconds>(
+				                         std::max(clock::duration::zero(), *next - clock::now()))
+				                         .count()
+				                   : -1;
+				ret = ::poll(pfds.data(), pfds.size(), timeout);
+
+			} while (ret < 0 && (sockerrno == SEINTR || sockerrno == SEAGAIN));
+
+			PLOG_VERBOSE << "Exiting poll";
+
+			if (ret < 0)
+				throw std::runtime_error("Failed to wait for socket connection");
+
+			process(pfds);
+		}
+	} catch (const std::exception &e) {
+		PLOG_FATAL << "Poll service failed: " << e.what();
+	}
+
+	PLOG_DEBUG << "Poll service stopped";
+}
+
+std::ostream &operator<<(std::ostream &out, PollService::Direction direction) {
+	const char *str;
+	switch (direction) {
+	case PollService::Direction::In:
+		str = "in";
+		break;
+	case PollService::Direction::Out:
+		str = "out";
+		break;
+	case PollService::Direction::Both:
+		str = "both";
+		break;
+	default:
+		str = "unknown";
+		break;
+	}
+	return out << str;
+}
+
+} // namespace rtc::impl
+
+#endif

--- a/src/impl/pollservice.hpp
+++ b/src/impl/pollservice.hpp
@@ -19,18 +19,19 @@
 #ifndef RTC_IMPL_POLL_SERVICE_H
 #define RTC_IMPL_POLL_SERVICE_H
 
-#include "pollinterrupter.hpp"
-#include "socket.hpp"
 #include "common.hpp"
 #include "internals.hpp"
+#include "pollinterrupter.hpp"
+#include "socket.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 
 #include <chrono>
+#include <functional>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
-#include <functional>
+#include <vector>
 
 namespace rtc::impl {
 

--- a/src/impl/pollservice.hpp
+++ b/src/impl/pollservice.hpp
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) 2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef RTC_IMPL_POLL_SERVICE_H
+#define RTC_IMPL_POLL_SERVICE_H
+
+#include "pollinterrupter.hpp"
+#include "socket.hpp"
+#include "common.hpp"
+#include "internals.hpp"
+
+#if RTC_ENABLE_WEBSOCKET
+
+#include <chrono>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <functional>
+
+namespace rtc::impl {
+
+class PollService {
+public:
+	using clock = std::chrono::steady_clock;
+
+	static PollService &Instance();
+
+	PollService(const PollService &) = delete;
+	PollService &operator=(const PollService &) = delete;
+	PollService(PollService &&) = delete;
+	PollService &operator=(PollService &&) = delete;
+
+	void start();
+	void join();
+
+	enum class Direction { Both, In, Out };
+	enum class Event { None, Error, Timeout, In, Out };
+
+	struct Params {
+		Direction direction;
+		optional<clock::duration> timeout;
+		std::function<void(Event)> callback;
+	};
+
+	void add(socket_t sock, Params params);
+	void remove(socket_t sock);
+
+private:
+	PollService();
+	~PollService();
+
+	void prepare(std::vector<struct pollfd> &pfds, optional<clock::time_point> &next);
+	void process(std::vector<struct pollfd> &pfds);
+	void runLoop();
+
+	struct SocketEntry {
+		Params params;
+		optional<clock::time_point> until;
+	};
+
+	using SocketMap = std::unordered_map<socket_t, SocketEntry>;
+	unique_ptr<SocketMap> mSocks;
+
+	std::recursive_mutex mMutex;
+	std::thread mThread;
+	bool mStopped;
+	PollInterrupter mInterrupter;
+};
+
+std::ostream &operator<<(std::ostream &out, PollService::Direction direction);
+
+} // namespace rtc::impl
+
+#endif
+
+#endif

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -155,10 +155,10 @@ void TcpTransport::connect() {
 			auto callback = [this, result, ai, recurse](PollService::Event event) mutable {
 				try {
 					if (event == PollService::Event::Error)
-						throw std::runtime_error("Connection interrupted");
+						throw std::runtime_error("TCP connection failed");
 
 					if (event == PollService::Event::Timeout)
-						throw std::runtime_error("Connection timed out");
+						throw std::runtime_error("TCP connection timed out");
 
 					if (event != PollService::Event::Out)
 						return;

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -37,7 +37,7 @@ using std::chrono::milliseconds;
 
 TcpTransport::TcpTransport(string hostname, string service, state_callback callback)
     : Transport(nullptr, std::move(callback)), mIsActive(true), mHostname(std::move(hostname)),
-      mService(std::move(service)) {
+      mService(std::move(service)), mSock(INVALID_SOCKET) {
 
 	PLOG_DEBUG << "Initializing TCP transport";
 }
@@ -174,7 +174,7 @@ void TcpTransport::connect() {
 						throw std::runtime_error(msg.str());
 					}
 
-					PLOG_DEBUG << "TCP connection succeeded";
+					PLOG_INFO << "TCP connected";
 					freeaddrinfo(result);
 					changeState(State::Connected);
 

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -63,7 +63,7 @@ private:
 	const bool mIsActive;
 	string mHostname, mService;
 
-	socket_t mSock = INVALID_SOCKET;
+	socket_t mSock;
 	Queue<message_ptr> mSendQueue;
 	std::mutex mSendMutex;
 };

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -28,7 +28,6 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include <mutex>
-#include <future>
 
 namespace rtc::impl {
 

--- a/src/impl/wshandshake.cpp
+++ b/src/impl/wshandshake.cpp
@@ -183,7 +183,7 @@ size_t WsHandshake::parseHttpRequest(const byte *buffer, size_t size) {
 
 	string method, path, protocol;
 	requestLine >> method >> path >> protocol;
-	PLOG_DEBUG << "WebSocket request method \"" << method << "\" for path: " << path;
+	PLOG_DEBUG << "WebSocket request method=\"" << method << "\", path=\"" << path << "\"";
 	if (method != "GET")
 		throw RequestError("Invalid request method \"" + method + "\" for WebSocket", 405);
 
@@ -205,7 +205,7 @@ size_t WsHandshake::parseHttpRequest(const byte *buffer, size_t size) {
 	std::transform(h->second.begin(), h->second.end(), std::back_inserter(upgrade),
 	               [](char c) { return std::tolower(c); });
 	if (upgrade != "websocket")
-		throw RequestError("WebSocket upgrade header mismatching: " + h->second, 426);
+		throw RequestError("WebSocket upgrade header mismatching", 426);
 
 	h = headers.find("sec-websocket-key");
 	if (h == headers.end())
@@ -236,7 +236,7 @@ size_t WsHandshake::parseHttpResponse(const byte *buffer, size_t size) {
 	string protocol;
 	unsigned int code = 0;
 	status >> protocol >> code;
-	PLOG_DEBUG << "WebSocket response code: " << code;
+	PLOG_DEBUG << "WebSocket response code=" << code;
 	if (code != 101)
 		throw std::runtime_error("Unexpected response code " + to_string(code) + " for WebSocket");
 
@@ -250,7 +250,7 @@ size_t WsHandshake::parseHttpResponse(const byte *buffer, size_t size) {
 	std::transform(h->second.begin(), h->second.end(), std::back_inserter(upgrade),
 	               [](char c) { return std::tolower(c); });
 	if (upgrade != "websocket")
-		throw Error("WebSocket update header mismatching: " + h->second);
+		throw Error("WebSocket update header mismatching");
 
 	h = headers.find("sec-websocket-accept");
 	if (h == headers.end())


### PR DESCRIPTION
This PR replaces TCP polling threads by a shared poll service to allow applications with a lot of WebSockets to scale better. This is in particularly useful with the newly-introduced `WebSocketServer`.