### PR TITLE
Add ice-options attribute handling in description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ set(LIBDATACHANNEL_IMPL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/threadpool.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tls.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/track.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/utils.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/processor.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.cpp
@@ -147,6 +148,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/threadpool.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/tls.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/track.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/utils.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/processor.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/base64.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/sha.hpp

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -58,6 +58,7 @@ public:
 	string typeString() const;
 	Role role() const;
 	string bundleMid() const;
+	std::vector<string> iceOptions() const;
 	optional<string> iceUfrag() const;
 	optional<string> icePwd() const;
 	optional<string> fingerprint() const;
@@ -65,6 +66,7 @@ public:
 
 	void hintType(Type type);
 	void setFingerprint(string fingerprint);
+	void addIceOption(string option);
 
 	bool hasCandidate(const Candidate &candidate) const;
 	void addCandidate(Candidate candidate);
@@ -274,6 +276,7 @@ private:
 	Role mRole;
 	string mUsername;
 	string mSessionId;
+	std::vector<string> mIceOptions;
 	optional<string> mIceUfrag, mIcePwd;
 	optional<string> mFingerprint;
 

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -166,8 +166,10 @@ Description IceTransport::getLocalDescription(Description::Type type) const {
 	// RFC 5763: The endpoint that is the offerer MUST use the setup attribute value of
 	// setup:actpass.
 	// See https://tools.ietf.org/html/rfc5763#section-5
-	return Description(string(sdp), type,
+	Description desc(string(sdp), type,
 	                   type == Description::Type::Offer ? Description::Role::ActPass : mRole);
+	desc.addIceOption("trickle");
+	return desc;
 }
 
 void IceTransport::setRemoteDescription(const Description &description) {
@@ -573,8 +575,10 @@ Description IceTransport::getLocalDescription(Description::Type type) const {
 	// RFC 5763: The endpoint that is the offerer MUST use the setup attribute value of
 	// setup:actpass.
 	// See https://tools.ietf.org/html/rfc5763#section-5
-	return Description(string(sdp.get()), type,
+	Description desc(string(sdp.get()), type,
 	                   type == Description::Type::Offer ? Description::Role::ActPass : mRole);
+	desc.addIceOption("trickle");
+	return desc;
 }
 
 void IceTransport::setRemoteDescription(const Description &description) {

--- a/src/impl/utils.cpp
+++ b/src/impl/utils.cpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include "utils.hpp"
+
+#include <iterator>
+#include <sstream>
+
+namespace rtc::impl::utils {
+
+std::vector<string> explode(const string &str, char delim) {
+	std::vector<std::string> result;
+	std::istringstream ss(str);
+	string token;
+	while (std::getline(ss, token, delim))
+		result.push_back(token);
+
+	return result;
+}
+
+string implode(const std::vector<string> &tokens, char delim) {
+	string sdelim(1, delim);
+	std::ostringstream ss;
+	std::copy(tokens.begin(), tokens.end(), std::ostream_iterator<string>(ss, sdelim.c_str()));
+	string result = ss.str();
+	if (result.size() > 0)
+		result.resize(result.size() - 1);
+
+	return result;
+}
+
+} // namespace rtc::impl::utils

--- a/src/impl/utils.hpp
+++ b/src/impl/utils.hpp
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2020-2022 Paul-Louis Ageneau
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef RTC_IMPL_UTILS_H
+#define RTC_IMPL_UTILS_H
+
+#include "common.hpp"
+
+#include <vector>
+
+namespace rtc::impl::utils {
+
+std::vector<string> explode(const string &str, char delim);
+string implode(const std::vector<string> &tokens, char delim);
+
+} // namespace rtc::impl
+
+#endif

--- a/src/impl/wshandshake.cpp
+++ b/src/impl/wshandshake.cpp
@@ -20,6 +20,7 @@
 #include "base64.hpp"
 #include "internals.hpp"
 #include "sha.hpp"
+#include "utils.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -27,36 +28,10 @@
 #include <chrono>
 #include <climits>
 #include <iostream>
-#include <iterator>
 #include <random>
 #include <sstream>
 
 using std::string;
-
-namespace {
-
-std::vector<string> explode(const string &str, char delim) {
-	std::vector<std::string> result;
-	std::istringstream ss(str);
-	string token;
-	while (std::getline(ss, token, delim))
-		result.push_back(token);
-
-	return result;
-}
-
-string implode(const std::vector<string> &tokens, char delim) {
-	string sdelim(1, delim);
-	std::ostringstream ss;
-	std::copy(tokens.begin(), tokens.end(), std::ostream_iterator<string>(ss, sdelim.c_str()));
-	string result = ss.str();
-	if (result.size() > 0)
-		result.resize(result.size() - 1);
-
-	return result;
-}
-
-} // namespace
 
 namespace rtc::impl {
 
@@ -108,7 +83,7 @@ string WsHandshake::generateHttpRequest() {
 	             mKey + "\r\n";
 
 	if (!mProtocols.empty())
-		out += "Sec-WebSocket-Protocol: " + implode(mProtocols, ',') + "\r\n";
+		out += "Sec-WebSocket-Protocol: " + utils::implode(mProtocols, ',') + "\r\n";
 
 	out += "\r\n";
 
@@ -215,7 +190,7 @@ size_t WsHandshake::parseHttpRequest(const byte *buffer, size_t size) {
 
 	h = headers.find("sec-websocket-protocol");
 	if (h != headers.end())
-		mProtocols = explode(h->second, ',');
+		mProtocols = utils::explode(h->second, ',');
 
 	return length;
 }

--- a/src/impl/wshandshake.hpp
+++ b/src/impl/wshandshake.hpp
@@ -25,6 +25,7 @@
 
 #include <list>
 #include <map>
+#include <vector>
 
 namespace rtc::impl {
 


### PR DESCRIPTION
This PR implements actual handling for `ice-options` attribute in `Description` to replace the hardcoded value. This allows exposing the "ice2" attribute emitted by libjuice.