### PR TITLE
Fixed WebSocket transports not reset after connection failure

### DIFF
--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -113,7 +113,7 @@ void WebSocket::close() {
 		if (auto transport = std::atomic_load(&mWsTransport))
 			transport->close();
 		else
-			changeState(State::Closed);
+			remoteClose();
 	}
 }
 


### PR DESCRIPTION
This PR fixes `WebSocket::close()` which changed the state to `State::Closed` without resetting transports.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/568