### PR TITLE
ICE UDP multiplexing support

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -81,6 +81,7 @@ typedef struct {
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;
 	bool enableIceTcp;
+	bool enableIceUdpMux;
 	bool disableAutoNegotiation;
 	uint16_t portRangeBegin;
 	uint16_t portRangeEnd;
@@ -100,6 +101,7 @@ Arguments:
   - `certificateType` (optional): certificate type, either `RTC_CERTIFICATE_ECDSA` or `RTC_CERTIFICATE_RSA` (0 or `RTC_CERTIFICATE_DEFAULT` if default)
   - `iceTransportPolicy` (optional): ICE transport policy, if set to `RTC_TRANSPORT_POLICY_RELAY`, the PeerConnection will emit only relayed candidates (0 or `RTC_TRANSPORT_POLICY_ALL` if default)
   - `enableIceTcp`: if true, generate TCP candidates for ICE (ignored with libjuice as ICE backend)
+  - `enableIceUdpMux`: if true, connections are multiplexed on the same UDP port (should be combined with `portRangeBegin` and `portRangeEnd`, ignored with libnice as ICE backend)
   - `disableAutoNegotiation`: if true, the user is responsible for calling `rtcSetLocalDescription` after creating a Data Channel and after setting the remote description
   - `portRangeBegin` (optional): first port (included) of the allowed local port range (0 if unused)
   - `portRangeEnd` (optional): last port (included) of the allowed local port (0 if unused)

--- a/examples/client/main.cpp
+++ b/examples/client/main.cpp
@@ -72,6 +72,11 @@ int main(int argc, char **argv) try {
 		config.iceServers.emplace_back(stunServer);
 	}
 
+	if (params.udpMux()) {
+		cout << "ICE UDP mux enabled" << endl;
+		config.enableIceUdpMux = true;
+	}
+
 	localId = randomId(4);
 	cout << "The local ID is: " << localId << endl;
 

--- a/examples/client/parse_cl.cpp
+++ b/examples/client/parse_cl.cpp
@@ -44,6 +44,7 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
   static struct option long_options[] =
   {
     {"noStun", no_argument, NULL, 'n'},
+    {"udpMux", no_argument, NULL, 'm'},
     {"stunServer", required_argument, NULL, 's'},
     {"stunPort", required_argument, NULL, 't'},
     {"webSocketServer", required_argument, NULL, 'w'},
@@ -56,6 +57,7 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
 
   /* default values */
   _n = false;
+  _m = false;
   _s = "stun.l.google.com";
   _t = 19302;
   _w = "localhost";
@@ -63,13 +65,17 @@ Cmdline::Cmdline (int argc, char *argv[]) // ISO C++17 not allowed: throw (std::
   _h = false;
 
   optind = 0;
-  while ((c = getopt_long (argc, argv, "s:t:w:x:enhv", long_options, &optind)) != - 1)
+  while ((c = getopt_long (argc, argv, "s:t:w:x:enmhv", long_options, &optind)) != - 1)
     {
       switch (c)
         {
         case 'n':
           _n = true;
           break;
+
+		case 'm':
+		  _m = true;
+		  break;
 
         case 's':
           _s = optarg;

--- a/examples/client/parse_cl.h
+++ b/examples/client/parse_cl.h
@@ -35,6 +35,7 @@ class Cmdline
 private:
   /* parameters */
   bool _n;
+  bool _m;
   std::string _s;
   int _t;
   std::string _w;
@@ -57,6 +58,7 @@ public:
   int next_param () { return _optind; }
 
   bool noStun () const { return _n; }
+  bool udpMux () const { return _m; }
   std::string stunServer () const { return _s; }
   int stunPort () const { return _t; }
   std::string webSocketServer () const { return _w; }

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -80,7 +80,8 @@ struct RTC_CPP_EXPORT Configuration {
 	// Options
 	CertificateType certificateType = CertificateType::Default;
 	TransportPolicy iceTransportPolicy = TransportPolicy::All;
-	bool enableIceTcp = false;
+	bool enableIceTcp = false;    // libnice only
+	bool enableIceUdpMux = false; // libjuice only
 	bool disableAutoNegotiation = false;
 
 	// Port range

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -155,7 +155,8 @@ typedef struct {
 	const char *bindAddress; // libjuice only, NULL means any
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;
-	bool enableIceTcp;
+	bool enableIceTcp;    // libnice only
+	bool enableIceUdpMux; // libjuice only
 	bool disableAutoNegotiation;
 	uint16_t portRangeBegin; // 0 means automatic
 	uint16_t portRangeEnd;   // 0 means automatic

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -84,6 +84,7 @@ typedef struct {
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;
 	bool enableIceTcp;
+	bool enableIceUdpMux;
 	bool disableAutoNegotiation;
 	uint16_t portRangeBegin;
 	uint16_t portRangeEnd;
@@ -103,6 +104,7 @@ Arguments:
   - `certificateType` (optional): certificate type, either `RTC_CERTIFICATE_ECDSA` or `RTC_CERTIFICATE_RSA` (0 or `RTC_CERTIFICATE_DEFAULT` if default)
   - `iceTransportPolicy` (optional): ICE transport policy, if set to `RTC_TRANSPORT_POLICY_RELAY`, the PeerConnection will emit only relayed candidates (0 or `RTC_TRANSPORT_POLICY_ALL` if default)
   - `enableIceTcp`: if true, generate TCP candidates for ICE (ignored with libjuice as ICE backend)
+  - `enableIceUdpMux`: if true, connections are multiplexed on the same UDP port (should be combined with `portRangeBegin` and `portRangeEnd`, ignored with libnice as ICE backend)
   - `disableAutoNegotiation`: if true, the user is responsible for calling `rtcSetLocalDescription` after creating a Data Channel and after setting the remote description
   - `portRangeBegin` (optional): first port (included) of the allowed local port range (0 if unused)
   - `portRangeEnd` (optional): last port (included) of the allowed local port (0 if unused)

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -365,6 +365,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 		c.certificateType = static_cast<CertificateType>(config->certificateType);
 		c.iceTransportPolicy = static_cast<TransportPolicy>(config->iceTransportPolicy);
 		c.enableIceTcp = config->enableIceTcp;
+		c.enableIceUdpMux = config->enableIceUdpMux;
 		c.disableAutoNegotiation = config->disableAutoNegotiation;
 
 		if (config->mtu > 0)
@@ -1431,3 +1432,4 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 		return RTC_ERR_SUCCESS;
 	});
 }
+

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -23,6 +23,7 @@
 #include "common.hpp"
 #include "configuration.hpp"
 #include "description.hpp"
+#include "global.hpp"
 #include "peerconnection.hpp"
 #include "transport.hpp"
 

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -23,6 +23,7 @@
 #include "dtlstransport.hpp"
 #include "pollservice.hpp"
 #include "sctptransport.hpp"
+#include "icetransport.hpp"
 #include "threadpool.hpp"
 #include "tls.hpp"
 

--- a/src/impl/pollinterrupter.hpp
+++ b/src/impl/pollinterrupter.hpp
@@ -24,8 +24,6 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
-#include <mutex>
-
 namespace rtc::impl {
 
 // Utility class to interrupt poll()
@@ -34,13 +32,16 @@ public:
 	PollInterrupter();
 	~PollInterrupter();
 
+	PollInterrupter(const PollInterrupter &other) = delete;
+	void operator=(const PollInterrupter &other) = delete;
+
 	void prepare(struct pollfd &pfd);
+	void process(struct pollfd &pfd);
 	void interrupt();
 
 private:
-	std::mutex mMutex;
 #ifdef _WIN32
-	socket_t mDummySock = INVALID_SOCKET;
+	socket_t mSock;
 #else // assume POSIX
 	int mPipeIn, mPipeOut;
 #endif

--- a/src/impl/pollservice.hpp
+++ b/src/impl/pollservice.hpp
@@ -76,11 +76,11 @@ private:
 
 	using SocketMap = std::unordered_map<socket_t, SocketEntry>;
 	unique_ptr<SocketMap> mSocks;
+	unique_ptr<PollInterrupter> mInterrupter;
 
 	std::recursive_mutex mMutex;
 	std::thread mThread;
 	bool mStopped;
-	PollInterrupter mInterrupter;
 };
 
 std::ostream &operator<<(std::ostream &out, PollService::Direction direction);

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -21,6 +21,7 @@
 
 #include "common.hpp"
 #include "configuration.hpp"
+#include "global.hpp"
 #include "processor.hpp"
 #include "queue.hpp"
 #include "transport.hpp"

--- a/src/impl/tcpserver.hpp
+++ b/src/impl/tcpserver.hpp
@@ -29,10 +29,13 @@
 
 namespace rtc::impl {
 
-class TcpServer {
+class TcpServer final {
 public:
 	TcpServer(uint16_t port);
 	~TcpServer();
+
+	TcpServer(const TcpServer &other) = delete;
+	void operator=(const TcpServer &other) = delete;
 
 	shared_ptr<TcpTransport> accept();
 	void close();

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -48,8 +48,8 @@ TcpTransport::TcpTransport(socket_t sock, state_callback callback)
 	PLOG_DEBUG << "Initializing TCP transport with socket";
 
 	// Set non-blocking
-	ctl_t b = 1;
-	if (::ioctlsocket(mSock, FIONBIO, &b) < 0)
+	ctl_t nbio = 1;
+	if (::ioctlsocket(mSock, FIONBIO, &nbio) < 0)
 		throw std::runtime_error("Failed to set socket non-blocking mode");
 
 	// Retrieve hostname and service
@@ -221,8 +221,8 @@ void TcpTransport::prepare(const sockaddr *addr, socklen_t addrlen) {
 			throw std::runtime_error("TCP socket creation failed");
 
 		// Set non-blocking
-		ctl_t b = 1;
-		if (::ioctlsocket(mSock, FIONBIO, &b) < 0)
+		ctl_t nbio = 1;
+		if (::ioctlsocket(mSock, FIONBIO, &nbio) < 0)
 			throw std::runtime_error("Failed to set socket non-blocking mode");
 
 #ifdef __APPLE__

--- a/test/capi_websocketserver.cpp
+++ b/test/capi_websocketserver.cpp
@@ -144,7 +144,7 @@ int test_capi_websocketserver_main() {
 	while (!success && !failed && attempts--)
 		sleep(1);
 
-	if (failed)
+	if (!success || failed)
 		goto error;
 
 	rtcDeleteWebSocket(wsclient);


### PR DESCRIPTION
This PR introduces ICE UDP multiplexing support with libjuice. The behavior is disabled by default and may be enabled with the new `enableIceUdpMux` config option.

Requires https://github.com/paullouisageneau/libjuice/pull/148

Implements https://github.com/paullouisageneau/libdatachannel/issues/555