### PR TITLE
Call onClose callback synchonously when close() is called

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -405,6 +405,44 @@ int rtcSetAvailableCallback(int id, rtcAvailableCallbackFunc cb)
 
 It is called when messages are now available to be received with `rtcReceiveMessage`.
 
+#### rtcSendMessage
+
+```
+int rtcSendMessage(int id, const char *data, int size)
+```
+
+Sends a message in the channel.
+
+Arguments:
+
+- `id`: the channel identifier
+- `data`: the message data
+- `size`: if size >= 0, `data` is interpreted as a binary message of length `size`, otherwise it is interpreted as a null-terminated UTF-8 string.
+
+Return value: `RTC_ERR_SUCCESS` or a negative error code
+
+The message is sent immediately if possible, otherwise it is buffered to be sent later.
+
+Data Channel and WebSocket: If the message may not be sent immediately due to flow control or congestion control, it is buffered until it can actually be sent. You can retrieve the current buffered data size with `rtcGetBufferedAmount`.
+
+Track: There is no flow or congestion control, messages are never buffered and `rtcGetBufferedAmount` always returns 0.
+
+#### rtcClose
+
+```
+int rtcClose(int id)
+```
+
+Close the channel.
+
+Arguments:
+
+- `id`: the channel identifier
+
+Return value: `RTC_ERR_SUCCESS` or a negative error code
+
+WebSocket: Like with the JavaScript API, the state will first change to closing, then closed only after the connection has been actually closed.
+
 #### rtcIsOpen
 
 ```
@@ -428,27 +466,6 @@ Arguments:
 - `id`: the channel identifier
 
 Return value: `true` if the channel exists and is closed (not open and not connecting), `false` otherwise
-
-#### rtcSendMessage
-
-```
-int rtcSendMessage(int id, const char *data, int size)
-```
-
-Sends a message in the channel.
-
-Arguments:
-
-- `id`: the channel identifier
-- `data`: the message data
-- `size`: if size >= 0, `data` is interpreted as a binary message of length `size`, otherwise it is interpreted as a null-terminated UTF-8 string.
-
-Return value: `RTC_ERR_SUCCESS` or a negative error code
-
-The message is sent immediately if possible, otherwise it is buffered to be sent later.
-
-Data Channel and WebSocket: If the message may not be sent immediately due to flow control or congestion control, it is buffered until it can actually be sent. You can retrieve the current buffered data size with `rtcGetBufferedAmount`.
-Tracks are an exception: There is no flow or congestion control, messages are never buffered and `rtcGetBufferedAmount` always returns 0.
 
 #### rtcGetBufferedAmount
 

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -54,6 +54,8 @@ public:
 	void onBufferedAmountLow(std::function<void()> callback);
 	void setBufferedAmountLowThreshold(size_t amount);
 
+	void resetCallbacks();
+
 	// Extended API
 	optional<message_variant> receive(); // only if onMessage unset
 	optional<message_variant> peek();    // only if onMessage unset

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -103,6 +103,8 @@ public:
 	void onGatheringStateChange(std::function<void(GatheringState state)> callback);
 	void onSignalingStateChange(std::function<void(SignalingState state)> callback);
 
+	void resetCallbacks();
+
 	// Stats
 	void clearStats();
 	size_t bytesSent();

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -196,6 +196,7 @@ RTC_EXPORT int rtcSetClosedCallback(int id, rtcClosedCallbackFunc cb);
 RTC_EXPORT int rtcSetErrorCallback(int id, rtcErrorCallbackFunc cb);
 RTC_EXPORT int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb);
 RTC_EXPORT int rtcSendMessage(int id, const char *data, int size);
+RTC_EXPORT int rtcClose(int id);
 RTC_EXPORT bool rtcIsOpen(int id);
 RTC_EXPORT bool rtcIsClosed(int id);
 

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -59,6 +59,7 @@ public:
 
 	void open(const string &url);
 	void close() override;
+	void forceClose();
 	bool send(const message_variant data) override;
 	bool send(const byte *data, size_t size) override;
 

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -408,6 +408,44 @@ int rtcSetAvailableCallback(int id, rtcAvailableCallbackFunc cb)
 
 It is called when messages are now available to be received with `rtcReceiveMessage`.
 
+#### rtcSendMessage
+
+```
+int rtcSendMessage(int id, const char *data, int size)
+```
+
+Sends a message in the channel.
+
+Arguments:
+
+- `id`: the channel identifier
+- `data`: the message data
+- `size`: if size >= 0, `data` is interpreted as a binary message of length `size`, otherwise it is interpreted as a null-terminated UTF-8 string.
+
+Return value: `RTC_ERR_SUCCESS` or a negative error code
+
+The message is sent immediately if possible, otherwise it is buffered to be sent later.
+
+Data Channel and WebSocket: If the message may not be sent immediately due to flow control or congestion control, it is buffered until it can actually be sent. You can retrieve the current buffered data size with `rtcGetBufferedAmount`.
+
+Track: There is no flow or congestion control, messages are never buffered and `rtcGetBufferedAmount` always returns 0.
+
+#### rtcClose
+
+```
+int rtcClose(int id)
+```
+
+Close the channel.
+
+Arguments:
+
+- `id`: the channel identifier
+
+Return value: `RTC_ERR_SUCCESS` or a negative error code
+
+WebSocket: Like with the JavaScript API, the state will first change to closing, then closed only after the connection has been actually closed.
+
 #### rtcIsOpen
 
 ```
@@ -431,27 +469,6 @@ Arguments:
 - `id`: the channel identifier
 
 Return value: `true` if the channel exists and is closed (not open and not connecting), `false` otherwise
-
-#### rtcSendMessage
-
-```
-int rtcSendMessage(int id, const char *data, int size)
-```
-
-Sends a message in the channel.
-
-Arguments:
-
-- `id`: the channel identifier
-- `data`: the message data
-- `size`: if size >= 0, `data` is interpreted as a binary message of length `size`, otherwise it is interpreted as a null-terminated UTF-8 string.
-
-Return value: `RTC_ERR_SUCCESS` or a negative error code
-
-The message is sent immediately if possible, otherwise it is buffered to be sent later.
-
-Data Channel and WebSocket: If the message may not be sent immediately due to flow control or congestion control, it is buffered until it can actually be sent. You can retrieve the current buffered data size with `rtcGetBufferedAmount`.
-Tracks are an exception: There is no flow or congestion control, messages are never buffered and `rtcGetBufferedAmount` always returns 0.
 
 #### rtcGetBufferedAmount
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -381,13 +381,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 int rtcDeletePeerConnection(int pc) {
 	return wrap([pc] {
 		auto peerConnection = getPeerConnection(pc);
-		peerConnection->onDataChannel(nullptr);
-		peerConnection->onTrack(nullptr);
-		peerConnection->onLocalDescription(nullptr);
-		peerConnection->onLocalCandidate(nullptr);
-		peerConnection->onStateChange(nullptr);
-		peerConnection->onGatheringStateChange(nullptr);
-
+		peerConnection->close();
 		erasePeerConnection(pc);
 		return RTC_ERR_SUCCESS;
 	});
@@ -836,13 +830,7 @@ int rtcCreateDataChannelEx(int pc, const char *label, const rtcDataChannelInit *
 int rtcDeleteDataChannel(int dc) {
 	return wrap([dc] {
 		auto dataChannel = getDataChannel(dc);
-		dataChannel->onOpen(nullptr);
-		dataChannel->onClosed(nullptr);
-		dataChannel->onError(nullptr);
-		dataChannel->onMessage(nullptr);
-		dataChannel->onBufferedAmountLow(nullptr);
-		dataChannel->onAvailable(nullptr);
-
+		dataChannel->close();
 		eraseDataChannel(dc);
 		return RTC_ERR_SUCCESS;
 	});
@@ -994,13 +982,7 @@ int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
 int rtcDeleteTrack(int tr) {
 	return wrap([&] {
 		auto track = getTrack(tr);
-		track->onOpen(nullptr);
-		track->onClosed(nullptr);
-		track->onError(nullptr);
-		track->onMessage(nullptr);
-		track->onBufferedAmountLow(nullptr);
-		track->onAvailable(nullptr);
-
+		track->close();
 		eraseTrack(tr);
 		return RTC_ERR_SUCCESS;
 	});
@@ -1276,13 +1258,7 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 int rtcDeleteWebSocket(int ws) {
 	return wrap([&] {
 		auto webSocket = getWebSocket(ws);
-		webSocket->onOpen(nullptr);
-		webSocket->onClosed(nullptr);
-		webSocket->onError(nullptr);
-		webSocket->onMessage(nullptr);
-		webSocket->onBufferedAmountLow(nullptr);
-		webSocket->onAvailable(nullptr);
-
+		webSocket->close();
 		eraseWebSocket(ws);
 		return RTC_ERR_SUCCESS;
 	});

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1266,7 +1266,8 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 int rtcDeleteWebSocket(int ws) {
 	return wrap([&] {
 		auto webSocket = getWebSocket(ws);
-		webSocket->close();
+		webSocket->forceClose();
+		webSocket->resetCallbacks(); // not done on close by WebSocket
 		eraseWebSocket(ws);
 		return RTC_ERR_SUCCESS;
 	});
@@ -1329,7 +1330,6 @@ RTC_EXPORT int rtcDeleteWebSocketServer(int wsserver) {
 		auto webSocketServer = getWebSocketServer(wsserver);
 		webSocketServer->onClient(nullptr);
 		webSocketServer->stop();
-
 		eraseWebSocketServer(wsserver);
 		return RTC_ERR_SUCCESS;
 	});

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -692,6 +692,14 @@ int rtcSendMessage(int id, const char *data, int size) {
 	});
 }
 
+int rtcClose(int id) {
+	return wrap([&] {
+		auto channel = getChannel(id);
+		channel->close();
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 bool rtcIsOpen(int id) {
 	return wrap([id] { return getChannel(id)->isOpen() ? 0 : 1; }) == 0 ? true : false;
 }
@@ -1157,7 +1165,7 @@ int rtcGetTrackPayloadTypesForCodec(int tr, const char *ccodec, int *buffer, int
 		auto codec = lowercased(string(ccodec));
 		auto description = track->description();
 		std::vector<int> payloadTypes;
-		for(int pt : description.payloadTypes())
+		for (int pt : description.payloadTypes())
 			if (lowercased(description.rtpMap(pt)->format) == codec)
 				payloadTypes.push_back(pt);
 
@@ -1347,12 +1355,13 @@ void rtcPreload() {
 void rtcCleanup() {
 	try {
 		size_t count = eraseAll();
-		if(count != 0) {
+		if (count != 0) {
 			PLOG_INFO << count << " objects were not properly destroyed before cleanup";
 		}
 
-		if(rtc::Cleanup().wait_for(10s) == std::future_status::timeout)
-			throw std::runtime_error("Cleanup timeout (possible deadlock or undestructible object)");
+		if (rtc::Cleanup().wait_for(10s) == std::future_status::timeout)
+			throw std::runtime_error(
+			    "Cleanup timeout (possible deadlock or undestructible object)");
 
 	} catch (const std::exception &e) {
 		PLOG_ERROR << e.what();
@@ -1408,4 +1417,3 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 		return RTC_ERR_SUCCESS;
 	});
 }
-

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -59,6 +59,10 @@ void Channel::setBufferedAmountLowThreshold(size_t amount) {
 	impl()->bufferedAmountLowThreshold = amount;
 }
 
+void Channel::resetCallbacks() {
+	impl()->resetCallbacks();
+}
+
 optional<message_variant> Channel::receive() { return impl()->receive(); }
 
 optional<message_variant> Channel::peek() { return impl()->peek(); }

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -64,7 +64,8 @@ void Track::setDescription(Description::Media description) {
 void Track::close() {
 	PLOG_VERBOSE << "Closing Track";
 
-	mIsClosed = true;
+	if (!mIsClosed.exchange(true))
+		triggerClosed();
 
 	setMediaHandler(nullptr);
 	resetCallbacks();
@@ -112,7 +113,8 @@ void Track::open(shared_ptr<DtlsSrtpTransport> transport) {
 		mDtlsSrtpTransport = transport;
 	}
 
-	triggerOpen();
+	if (!mIsClosed)
+		triggerOpen();
 }
 #endif
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -320,6 +320,10 @@ void PeerConnection::onSignalingStateChange(std::function<void(SignalingState st
 	impl()->signalingStateChangeCallback = callback;
 }
 
+void PeerConnection::resetCallbacks() {
+	impl()->resetCallbacks();
+}
+
 bool PeerConnection::getSelectedCandidatePair(Candidate *local, Candidate *remote) {
 	auto iceTransport = impl()->getIceTransport();
 	return iceTransport ? iceTransport->getSelectedCandidatePair(local, remote) : false;

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -60,6 +60,8 @@ void WebSocket::open(const string &url) {
 
 void WebSocket::close() { impl()->close(); }
 
+void WebSocket::forceClose() { impl()->remoteClose(); }
+
 bool WebSocket::send(message_variant data) {
 	return impl()->outgoing(make_message(std::move(data)));
 }

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -112,6 +112,10 @@ void test_connectivity() {
 				dc->send("Hello from 2");
 		});
 
+		dc->onClosed([]() {
+			cout << "DataChannel 2: Closed" << endl;
+		});
+
 		dc->onMessage([](variant<binary, string> message) {
 			if (holds_alternative<string>(message)) {
 				cout << "Message 2: " << get<string>(message) << endl;
@@ -128,6 +132,10 @@ void test_connectivity() {
 			cout << "DataChannel 1: Open" << endl;
 			dc1->send("Hello from 1");
 		}
+	});
+
+	dc1->onClosed([]() {
+		cout << "DataChannel 1: Closed" << endl;
 	});
 
 	dc1->onMessage([](const variant<binary, string> &message) {
@@ -195,12 +203,18 @@ void test_connectivity() {
 	});
 
 	auto second1 = pc1.createDataChannel("second");
+
 	second1->onOpen([wsecond1 = make_weak_ptr(second1)]() {
 		if (auto second1 = wsecond1.lock()) {
 			cout << "Second DataChannel 1: Open" << endl;
 			second1->send("Second hello from 1");
 		}
 	});
+
+	second1->onClosed([]() {
+		cout << "Second DataChannel 1: Closed" << endl;
+	});
+
 	second1->onMessage([](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {
 			cout << "Second Message 1: " << get<string>(message) << endl;

--- a/test/turn_connectivity.cpp
+++ b/test/turn_connectivity.cpp
@@ -127,6 +127,12 @@ void test_turn_connectivity() {
 		cout << "DataChannel 1: Open" << endl;
 		dc1->send("Hello from 1");
 	});
+
+
+	dc1->onClosed([]() {
+		cout << "DataChannel 1: Closed" << endl;
+	});
+
 	dc1->onMessage([](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {
 			cout << "Message 1: " << get<string>(message) << endl;
@@ -198,6 +204,7 @@ void test_turn_connectivity() {
 	});
 
 	auto second1 = pc1.createDataChannel("second");
+
 	second1->onOpen([wsecond1 = make_weak_ptr(second1)]() {
 		auto second1 = wsecond1.lock();
 		if (!second1)
@@ -206,6 +213,11 @@ void test_turn_connectivity() {
 		cout << "Second DataChannel 1: Open" << endl;
 		second1->send("Second hello from 1");
 	});
+
+	second1->onClosed([]() {
+		cout << "Second DataChannel 1: Closed" << endl;
+	});
+
 	second1->onMessage([](const variant<binary, string> &message) {
 		if (holds_alternative<string>(message)) {
 			cout << "Second Message 1: " << get<string>(message) << endl;


### PR DESCRIPTION
This PR changes the behavior of `onClose` callbacks to ensure that they are always called. When closing is triggered by the user calling `close()`, `onClose` is now called synchronously, in the same way `rtc::PeerConnection` calls `onStateChange` with state `Closed` synchronously on close.

This is a behavior change, however user code should already handle race conditions where the remote side closes the connection resulting in a call to `onClose` just when the user calls `close()`, since this is a legit sequence of events. The change could however introduce deadlocks if user code assumes that `onClose` will be called from another thread and never synchronously.

Implements https://github.com/paullouisageneau/libdatachannel/issues/574