### PR TITLE
Add getters for track mid and direction to C API

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -682,7 +682,7 @@ Retrieves the SDP media description of a Track.
 
 Arguments:
 
-- `dc`: the Track identifier
+- `tr`: the Track identifier
 - `buffer`: a user-supplied buffer to store the description
 - `size`: the size of `buffer`
 
@@ -690,7 +690,40 @@ Return value: the length of the string copied in buffer (including the terminati
 
 If `buffer` is `NULL`, the description is not copied but the size is still returned.
 
-### Media
+#### rtcGetTrackMid
+
+```
+int rtcGetTrackMid(int tr, char *buffer, int size)
+```
+
+Retrieves the mid (media indentifier) of a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `buffer`: a user-supplied buffer to store the mid
+- `size`: the size of `buffer`
+
+Return value: the length of the string copied in buffer (including the terminating null character) or a negative error code
+
+If `buffer` is `NULL`, the mid is not copied but the size is still returned.
+
+#### rtcGetTrackDirection
+
+```
+int rtcGetTrackDirection(int tr, rtcDirection *direction)
+```
+
+Retrieves the direction of a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `direction`: a pointer to a rtcDescription enum to store the result
+
+On success, the value pointed by `direction` will be set to one of the following: `RTC_DIRECTION_SENDONLY`, `RTC_DIRECTION_RECVONLY`, `RTC_DIRECTION_SENDRECV`, `RTC_DIRECTION_INACTIVE`, or `RTC_DIRECTION_UNKNOWN`.
+
+### Media handling
 
 TODO
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -255,6 +255,8 @@ RTC_EXPORT int rtcAddTrackEx(int pc, const rtcTrackInit *init);      // returns 
 RTC_EXPORT int rtcDeleteTrack(int tr);
 
 RTC_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
+RTC_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
+RTC_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
 
 #if RTC_ENABLE_MEDIA
 

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -685,7 +685,7 @@ Retrieves the SDP media description of a Track.
 
 Arguments:
 
-- `dc`: the Track identifier
+- `tr`: the Track identifier
 - `buffer`: a user-supplied buffer to store the description
 - `size`: the size of `buffer`
 
@@ -693,7 +693,40 @@ Return value: the length of the string copied in buffer (including the terminati
 
 If `buffer` is `NULL`, the description is not copied but the size is still returned.
 
-### Media
+#### rtcGetTrackMid
+
+```
+int rtcGetTrackMid(int tr, char *buffer, int size)
+```
+
+Retrieves the mid (media indentifier) of a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `buffer`: a user-supplied buffer to store the mid
+- `size`: the size of `buffer`
+
+Return value: the length of the string copied in buffer (including the terminating null character) or a negative error code
+
+If `buffer` is `NULL`, the mid is not copied but the size is still returned.
+
+#### rtcGetTrackDirection
+
+```
+int rtcGetTrackDirection(int tr, rtcDirection *direction)
+```
+
+Retrieves the direction of a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `direction`: a pointer to a rtcDescription enum to store the result
+
+On success, the value pointed by `direction` will be set to one of the following: `RTC_DIRECTION_SENDONLY`, `RTC_DIRECTION_RECVONLY`, `RTC_DIRECTION_SENDRECV`, `RTC_DIRECTION_INACTIVE`, or `RTC_DIRECTION_UNKNOWN`.
+
+### Media handling
 
 TODO
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1021,6 +1021,9 @@ int rtcGetTrackMid(int tr, char *buffer, int size) {
 
 int rtcGetTrackDirection(int tr, rtcDirection *direction) {
 	return wrap([&] {
+		if (!direction)
+			throw std::invalid_argument("Unexpected null pointer for track direction");
+
 		auto track = getTrack(tr);
 		*direction = static_cast<rtcDirection>(track->direction());
 		return RTC_ERR_SUCCESS;
@@ -1388,12 +1391,13 @@ void rtcPreload() {
 void rtcCleanup() {
 	try {
 		size_t count = eraseAll();
-		if(count != 0) {
+		if (count != 0) {
 			PLOG_INFO << count << " objects were not properly destroyed before cleanup";
 		}
 
-		if(rtc::Cleanup().wait_for(10s) == std::future_status::timeout)
-			throw std::runtime_error("Cleanup timeout (possible deadlock or undestructible object)");
+		if (rtc::Cleanup().wait_for(10s) == std::future_status::timeout)
+			throw std::runtime_error(
+			    "Cleanup timeout (possible deadlock or undestructible object)");
 
 	} catch (const std::exception &e) {
 		PLOG_ERROR << e.what();

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1012,6 +1012,21 @@ int rtcGetTrackDescription(int tr, char *buffer, int size) {
 	});
 }
 
+int rtcGetTrackMid(int tr, char *buffer, int size) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		return copyAndReturn(track->mid(), buffer, size);
+	});
+}
+
+int rtcGetTrackDirection(int tr, rtcDirection *direction) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		*direction = static_cast<rtcDirection>(track->direction());
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 #if RTC_ENABLE_MEDIA
 
 void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, const char *_msid,


### PR DESCRIPTION
This PR adds `rtcGetTrackMid` and `rtcGetTrackDirection` to C API, so the information can be retrieved without parsing the description.