### PR TITLE
Add support for removed media in SDP description

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -91,8 +91,12 @@ public:
 		virtual string type() const { return mType; }
 		virtual string description() const { return mDescription; }
 		virtual string mid() const { return mMid; }
+
 		Direction direction() const { return mDirection; }
 		void setDirection(Direction dir);
+
+		bool isRemoved() const { return mIsRemoved; }
+		void setRemoved();
 
 		std::vector<string> attributes() const;
 		void addAttribute(string attr);
@@ -117,7 +121,7 @@ public:
 		void removeExtMap(int id);
 
 		operator string() const;
-		string generateSdp(string_view eol, string_view addr, string_view port) const;
+		string generateSdp(string_view eol, string_view addr, uint16_t port) const;
 
 		virtual void parseSdpLine(string_view line);
 
@@ -143,11 +147,13 @@ public:
 		string mDescription;
 		string mMid;
 		Direction mDirection;
+		bool mIsRemoved;
 	};
 
 	struct RTC_CPP_EXPORT Application : public Entry {
 	public:
 		Application(string mid = "data");
+		Application(const string &mline, string mid);
 		virtual ~Application() = default;
 
 		string description() const override;

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -96,7 +96,7 @@ public:
 		void setDirection(Direction dir);
 
 		bool isRemoved() const { return mIsRemoved; }
-		void setRemoved();
+		void markRemoved();
 
 		std::vector<string> attributes() const;
 		void addAttribute(string attr);

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -528,7 +528,7 @@ Description::Entry::Entry(const string &mline, string mid, Direction dir)
 
 void Description::Entry::setDirection(Direction dir) { mDirection = dir; }
 
-void Description::Entry::setRemoved() { mIsRemoved = true; }
+void Description::Entry::markRemoved() { mIsRemoved = true; }
 
 std::vector<string> Description::attributes() const { return mAttributes; }
 

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -710,7 +710,7 @@ shared_ptr<Track> PeerConnection::emplaceTrack(Description::Media description) {
 #if !RTC_ENABLE_MEDIA
 	// No media support, mark as removed
 	PLOG_WARNING << "Tracks are disabled (not compiled with media support)";
-	description.setRemoved();
+	description.markRemoved();
 #endif
 
 	shared_ptr<Track> track;
@@ -849,7 +849,7 @@ void PeerConnection::processLocalDescription(Description description) {
 
 					        } else {
 						        auto reciprocated = remoteMedia->reciprocate();
-						        reciprocated.setRemoved();
+						        reciprocated.markRemoved();
 
 						        PLOG_DEBUG << "Adding media to local description, mid=\""
 						                   << reciprocated.mid()
@@ -866,7 +866,7 @@ void PeerConnection::processLocalDescription(Description description) {
 				        if (!reciprocated.isRemoved()) {
 							// No media support, mark as removed
 							PLOG_WARNING << "Rejecting track (not compiled with media support)";
-							reciprocated.setRemoved();
+							reciprocated.markRemoved();
 						}
 #endif
 				        incomingTrack(reciprocated);

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -707,6 +707,12 @@ void PeerConnection::remoteCloseDataChannels() {
 }
 
 shared_ptr<Track> PeerConnection::emplaceTrack(Description::Media description) {
+#if !RTC_ENABLE_MEDIA
+	// No media support, mark as removed
+	PLOG_WARNING << "Tracks are disabled (not compiled with media support)";
+	description.setRemoved();
+#endif
+
 	shared_ptr<Track> track;
 	if (auto it = mTracks.find(description.mid()); it != mTracks.end())
 		if (track = it->second.lock(); track)
@@ -718,22 +724,27 @@ shared_ptr<Track> PeerConnection::emplaceTrack(Description::Media description) {
 		mTrackLines.emplace_back(track);
 	}
 
+	if (description.isRemoved())
+		track->close();
+
 	return track;
 }
 
 void PeerConnection::incomingTrack(Description::Media description) {
 	std::unique_lock lock(mTracksMutex); // we are going to emplace
-#if !RTC_ENABLE_MEDIA
-	if (mTracks.empty()) {
-		PLOG_WARNING << "Tracks will be inative (not compiled with media support)";
-	}
-#endif
-	if (mTracks.find(description.mid()) == mTracks.end()) {
-		auto track = std::make_shared<Track>(weak_from_this(), std::move(description));
+	shared_ptr<Track> track;
+	if (auto it = mTracks.find(description.mid()); it != mTracks.end()) {
+		if (track = it->second.lock(); track)
+			track->setDescription(std::move(description));
+	} else {
+		track = std::make_shared<Track>(weak_from_this(), std::move(description));
 		mTracks.emplace(std::make_pair(track->mid(), track));
 		mTrackLines.emplace_back(track);
 		triggerTrack(track);
 	}
+
+	if (track && description.isRemoved())
+		track->close();
 }
 
 void PeerConnection::openTracks() {
@@ -764,9 +775,13 @@ void PeerConnection::validateRemoteDescription(const Description &description) {
 
 	int activeMediaCount = 0;
 	for (unsigned int i = 0; i < description.mediaCount(); ++i)
-		std::visit(rtc::overloaded{[&](const Description::Application *) { ++activeMediaCount; },
+		std::visit(rtc::overloaded{[&](const Description::Application *application) {
+			                           if (!application->isRemoved())
+				                           ++activeMediaCount;
+		                           },
 		                           [&](const Description::Media *media) {
-			                           if (media->direction() != Description::Direction::Inactive)
+			                           if (!media->isRemoved() ||
+			                               media->direction() != Description::Direction::Inactive)
 				                           ++activeMediaCount;
 		                           }},
 		           description.media(i));
@@ -825,22 +840,20 @@ void PeerConnection::processLocalDescription(Description description) {
 					        // Prefer local description
 					        if (auto track = it->second.lock()) {
 						        auto media = track->description();
-#if !RTC_ENABLE_MEDIA
-						        // No media support, mark as inactive
-						        media.setDirection(Description::Direction::Inactive);
-#endif
-						        PLOG_DEBUG
-						            << "Adding media to local description, mid=\"" << media.mid()
-						            << "\", active=" << std::boolalpha
-						            << (media.direction() != Description::Direction::Inactive);
+
+						        PLOG_DEBUG << "Adding media to local description, mid=\""
+						                   << media.mid() << "\", removed=" << std::boolalpha
+						                   << media.isRemoved();
 
 						        description.addMedia(std::move(media));
+
 					        } else {
 						        auto reciprocated = remoteMedia->reciprocate();
-						        reciprocated.setDirection(Description::Direction::Inactive);
+						        reciprocated.setRemoved();
 
-						        PLOG_DEBUG << "Adding inactive media to local description, mid=\""
-						                   << reciprocated.mid() << "\"";
+						        PLOG_DEBUG << "Adding media to local description, mid=\""
+						                   << reciprocated.mid()
+						                   << "\", removed=true (track is destroyed)";
 
 						        description.addMedia(std::move(reciprocated));
 					        }
@@ -850,15 +863,17 @@ void PeerConnection::processLocalDescription(Description description) {
 
 				        auto reciprocated = remoteMedia->reciprocate();
 #if !RTC_ENABLE_MEDIA
-				        // No media support, mark as inactive
-				        reciprocated.setDirection(Description::Direction::Inactive);
+				        if (!reciprocated.isRemoved()) {
+							// No media support, mark as removed
+							PLOG_WARNING << "Rejecting track (not compiled with media support)";
+							reciprocated.setRemoved();
+						}
 #endif
 				        incomingTrack(reciprocated);
 
-				        PLOG_DEBUG
-				            << "Reciprocating media in local description, mid=\""
-				            << reciprocated.mid() << "\", active=" << std::boolalpha
-				            << (reciprocated.direction() != Description::Direction::Inactive);
+				        PLOG_DEBUG << "Reciprocating media in local description, mid=\""
+				                   << reciprocated.mid() << "\", removed=" << std::boolalpha
+				                   << reciprocated.isRemoved();
 
 				        description.addMedia(std::move(reciprocated));
 			        },
@@ -876,13 +891,9 @@ void PeerConnection::processLocalDescription(Description description) {
 					continue;
 
 				auto media = track->description();
-#if !RTC_ENABLE_MEDIA
-				// No media support, mark as inactive
-				media.setDirection(Description::Direction::Inactive);
-#endif
+
 				PLOG_DEBUG << "Adding media to local description, mid=\"" << media.mid()
-				           << "\", active=" << std::boolalpha
-				           << (media.direction() != Description::Direction::Inactive);
+				           << "\", removed=" << std::boolalpha << media.isRemoved();
 
 				description.addMedia(std::move(media));
 			}
@@ -991,6 +1002,8 @@ void PeerConnection::processRemoteDescription(Description description) {
 		if (!sctpTransport && dtlsTransport &&
 		    dtlsTransport->state() == Transport::State::Connected)
 			initSctpTransport();
+	} else {
+		mProcessor->enqueue(&PeerConnection::remoteCloseDataChannels, this);
 	}
 }
 

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -92,7 +92,7 @@ bool Track::isOpen(void) const {
 	std::shared_lock lock(mMutex);
 	return !mIsClosed && mDtlsSrtpTransport.lock();
 #else
-	return !mIsClosed;
+	return false;
 #endif
 }
 
@@ -184,8 +184,7 @@ bool Track::transportSend([[maybe_unused]] message_ptr message) {
 
 	return transport->sendMedia(message);
 #else
-	PLOG_WARNING << "Ignoring track send (not compiled with media support)";
-	return false;
+	throw std::runtime_error("Track is disabled (not compiled with media support)");
 #endif
 }
 


### PR DESCRIPTION
This PR implements support for removed media in SDP description (port set to 0). This mechanism allows to reject tracks properly instead of marking them as inactive, in particular when media support is disabled.