### PR TITLE
Fix DataChannel open message routing

### DIFF
--- a/.github/workflows/build-gnutls.yml
+++ b/.github/workflows/build-gnutls.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-    - master
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-nice.yml
+++ b/.github/workflows/build-nice.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-    - master
 jobs:
   build-media:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -4,8 +4,6 @@ on:
     branches:
     - master
   pull_request:
-    branches:
-    - master
 jobs:
   build-linux:
     runs-on: ubuntu-latest

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -84,11 +84,18 @@ protected:
 struct NegotiatedDataChannel final : public DataChannel {
 	NegotiatedDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
 	                      string protocol, Reliability reliability);
-	NegotiatedDataChannel(weak_ptr<PeerConnection> pc, weak_ptr<SctpTransport> transport,
-	                      uint16_t stream);
 	~NegotiatedDataChannel();
 
-	void open(impl_ptr<SctpTransport> transport) override;
+	void open(shared_ptr<SctpTransport> transport) override;
+	void processOpenMessage(message_ptr message) override;
+};
+
+struct IncomingDataChannel final : public DataChannel {
+	IncomingDataChannel(weak_ptr<PeerConnection> pc, weak_ptr<SctpTransport> transport,
+	                    uint16_t stream);
+	~IncomingDataChannel();
+
+	void open(shared_ptr<SctpTransport> transport) override;
 	void processOpenMessage(message_ptr message) override;
 };
 

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -35,6 +35,8 @@ namespace rtc::impl {
 struct PeerConnection;
 
 struct DataChannel : Channel, std::enable_shared_from_this<DataChannel> {
+	static bool IsOpenMessage(message_ptr message);
+
 	DataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label, string protocol,
 	            Reliability reliability);
 	virtual ~DataChannel();

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -442,7 +442,7 @@ void PeerConnection::forwardMessage(message_ptr message) {
 			channel->close();
 		}
 
-		channel = std::make_shared<NegotiatedDataChannel>(weak_from_this(), sctpTransport, stream);
+		channel = std::make_shared<IncomingDataChannel>(weak_from_this(), sctpTransport, stream);
 		channel->openCallback =
 		    weak_bind(&PeerConnection::triggerDataChannel, this, weak_ptr<DataChannel>{channel});
 

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -97,6 +97,7 @@ static void RTC_API openCallback(int id, void *ptr) {
 static void RTC_API closedCallback(int id, void *ptr) {
 	Peer *peer = (Peer *)ptr;
 	peer->connected = false;
+	printf("DataChannel %d: Closed\n", peer == peer1 ? 1 : 2);
 }
 
 static void RTC_API messageCallback(int id, const char *message, int size, void *ptr) {
@@ -152,9 +153,6 @@ static void RTC_API dataChannelCallback(int pc, int dc, void *ptr) {
 	rtcSetMessageCallback(dc, messageCallback);
 
 	peer->dc = dc;
-
-	const char *message = peer == peer1 ? "Hello from 1" : "Hello from 2";
-	rtcSendMessage(peer->dc, message, -1); // negative size indicates a null-terminated string
 }
 
 static Peer *createPeer(const rtcConfiguration *config) {

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -108,8 +108,10 @@ void test_connectivity() {
 		}
 
 		dc->onOpen([wdc = make_weak_ptr(dc)]() {
-			if (auto dc = wdc.lock())
+			if (auto dc = wdc.lock()) {
+				cout << "DataChannel 2: Open" << endl;
 				dc->send("Hello from 2");
+			}
 		});
 
 		dc->onMessage([](variant<binary, string> message) {
@@ -149,7 +151,8 @@ void test_connectivity() {
 	if (!adc2 || !adc2->isOpen() || !dc1->isOpen())
 		throw runtime_error("DataChannel is not open");
 
-	if (dc1->maxMessageSize() != CUSTOM_MAX_MESSAGE_SIZE || dc2->maxMessageSize() != CUSTOM_MAX_MESSAGE_SIZE)
+	if (dc1->maxMessageSize() != CUSTOM_MAX_MESSAGE_SIZE ||
+	    dc2->maxMessageSize() != CUSTOM_MAX_MESSAGE_SIZE)
 		throw runtime_error("DataChannel max message size is incorrect");
 
 	if (auto addr = pc1.localAddress())

--- a/test/turn_connectivity.cpp
+++ b/test/turn_connectivity.cpp
@@ -105,8 +105,10 @@ void test_turn_connectivity() {
 		}
 
 		dc->onOpen([wdc = make_weak_ptr(dc)]() {
-			if (auto dc = wdc.lock())
+			if (auto dc = wdc.lock()) {
+				cout << "DataChannel 2: Open" << endl;
 				dc->send("Hello from 2");
+			}
 		});
 
 		dc->onMessage([](variant<binary, string> message) {
@@ -162,7 +164,7 @@ void test_turn_connectivity() {
 	cout << "Local candidate 1:  " << local << endl;
 	cout << "Remote candidate 1: " << remote << endl;
 
-	if(local.type() != Candidate::Type::Relayed || remote.type() != Candidate::Type::Relayed)
+	if (local.type() != Candidate::Type::Relayed || remote.type() != Candidate::Type::Relayed)
 		throw runtime_error("Connection is not relayed as expected");
 
 	if (!pc2.getSelectedCandidatePair(&local, &remote))
@@ -171,7 +173,7 @@ void test_turn_connectivity() {
 	cout << "Local candidate 2:  " << local << endl;
 	cout << "Remote candidate 2: " << remote << endl;
 
-	if(local.type() != Candidate::Type::Relayed || remote.type() != Candidate::Type::Relayed)
+	if (local.type() != Candidate::Type::Relayed || remote.type() != Candidate::Type::Relayed)
 		throw runtime_error("Connection is not relayed as expected");
 
 	// Try to open a second data channel with another label


### PR DESCRIPTION
This PR fixes DataChannel message forwarding logic wrongly routing open messages to the old channel with the same stream id if it exists instead of opening a new one. It also introduces `IncomingDataChannel` to separate the incoming logic from the outgoing logic of `NegotiatedDataChannel` and prevent conflicts.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/588