### PR TITLE
Refactor ProxyServer and expose missing settings in C API

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -77,6 +77,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config)
 typedef struct {
 	const char **iceServers;
 	int iceServersCount;
+	const char *proxyServer;
 	const char *bindAddress;
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;
@@ -95,8 +96,9 @@ Creates a Peer Connection.
 Arguments:
 
 - `config`: the configuration structure, containing:
-  - `iceServers` (optional): an array of pointers on null-terminated ice server URIs (NULL if unused)
+  - `iceServers` (optional): an array of pointers on null-terminated ICE server URIs (NULL if unused)
   - `iceServersCount` (optional): number of URLs in the array pointed by `iceServers` (0 if unused)
+  - `proxyServer` (optional): if non-NULL, specifies the proxy server URI to use for TURN relaying (ignored with libjuice as ICE backend)
   - `bindAddress` (optional): if non-NULL, bind only to the given local address (ignored with libnice as ICE backend)
   - `certificateType` (optional): certificate type, either `RTC_CERTIFICATE_ECDSA` or `RTC_CERTIFICATE_RSA` (0 or `RTC_CERTIFICATE_DEFAULT` if default)
   - `iceTransportPolicy` (optional): ICE transport policy, if set to `RTC_TRANSPORT_POLICY_RELAY`, the PeerConnection will emit only relayed candidates (0 or `RTC_TRANSPORT_POLICY_ALL` if default)
@@ -112,7 +114,9 @@ Return value: the identifier of the new Peer Connection or a negative error code
 
 The Peer Connection must be deleted with `rtcDeletePeerConnection`.
 
-The format of each entry in `iceServers` must match the format `[("stun"|"turn"|"turns") ":"][login ":" password "@"]hostname[":" port]["?transport=" ("udp"|"tcp"|"tls")]`. The default scheme is STUN, the default port is 3478 (5349 over TLS), and the default transport is UDP.  For instance, a STUN server URI could be `mystunserver.org`, and a TURN server URI could be `turn:myuser:12345678@turnserver.org`. Note transports TCP and TLS are only available for a TURN server with libnice as ICE backend and govern only the TURN control connection, meaning relaying is always performed over UDP.
+Each entry in `iceServers` must match the format `[("stun"|"turn"|"turns") (":"|"://")][username ":" password "@"]hostname[":" port]["?transport=" ("udp"|"tcp"|"tls")]`. The default scheme is STUN, the default port is 3478 (5349 over TLS), and the default transport is UDP.  For instance, a STUN server URI could be `mystunserver.org`, and a TURN server URI could be `turn:myuser:12345678@turnserver.org`. Note transports TCP and TLS are only available for a TURN server with libnice as ICE backend and govern only the TURN control connection, meaning relaying is always performed over UDP.
+
+The `proxyServer` URI, if present, must match the format `[("http"|"socks5") (":"|"://")][username ":" password "@"]hostname["    :" port]`. The default scheme is HTTP, and the default port is 3128 for HTTP or 1080 for SOCKS5.
 
 #### rtcDeletePeerConnection
 
@@ -760,6 +764,8 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config)
 
 typedef struct {
 	bool disableTlsVerification;    // if true, disable TLS certificate verification
+	const char **protocols;
+	int protocolsCount;
 } rtcWsConfiguration;
 ```
 
@@ -770,6 +776,9 @@ Arguments:
 - `url`: a null-terminated string representing the fully-qualified URL to open.
 - `config`: a structure with the following parameters:
   - `bool disableTlsVerification`: if true, don't verify the TLS certificate, else try to verify it if possible
+  - `protocols` (optional): an array of pointers on null-terminated protocol names (NULL if unused)
+  - `protocolsCount` (optional): number of URLs in the array pointed by `protocols` (0 if unused)
+
 
 Return value: the identifier of the new WebSocket or a negative error code
 

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -51,16 +51,18 @@ struct RTC_CPP_EXPORT IceServer {
 };
 
 struct RTC_CPP_EXPORT ProxyServer {
-	enum class Type { None = 0, Socks5, Http, Last = Http };
+	enum class Type { Http, Socks5 };
 
-	ProxyServer(Type type_, string hostname_, uint16_t port_, string username_ = "",
-	            string password_ = "");
+	ProxyServer(const string &url);
+
+	ProxyServer(Type type_, string hostname_, uint16_t port_);
+	ProxyServer(Type type_, string hostname_, uint16_t port_, string username_, string password_);
 
 	Type type;
 	string hostname;
 	uint16_t port;
-	string username;
-	string password;
+	optional<string> username;
+	optional<string> password;
 };
 
 enum class CertificateType {

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -152,6 +152,7 @@ RTC_EXPORT void *rtcGetUserPointer(int i);
 typedef struct {
 	const char **iceServers;
 	int iceServersCount;
+	const char *proxyServer; // libnice only
 	const char *bindAddress; // libjuice only, NULL means any
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -365,6 +365,7 @@ int rtcSetSsrcForType(const char *mediaType, const char *sdp, char *buffer, cons
 
 typedef struct {
 	bool disableTlsVerification; // if true, don't verify the TLS certificate
+	const char *proxyServer;     // unsupported for now
 } rtcWsConfiguration;
 
 RTC_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -366,6 +366,8 @@ int rtcSetSsrcForType(const char *mediaType, const char *sdp, char *buffer, cons
 typedef struct {
 	bool disableTlsVerification; // if true, don't verify the TLS certificate
 	const char *proxyServer;     // unsupported for now
+	const char **protocols;
+	int protocolsCount;
 } rtcWsConfiguration;
 
 RTC_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -23,6 +23,7 @@
 
 #include "channel.hpp"
 #include "common.hpp"
+#include "configuration.hpp"
 
 namespace rtc {
 
@@ -43,6 +44,7 @@ public:
 
 	struct Configuration {
 		bool disableTlsVerification = false; // if true, don't verify the TLS certificate
+		optional<ProxyServer> proxyServer;   // unsupported for now
 		std::vector<string> protocols;
 	};
 

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -80,6 +80,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config)
 typedef struct {
 	const char **iceServers;
 	int iceServersCount;
+	const char *proxyServer;
 	const char *bindAddress;
 	rtcCertificateType certificateType;
 	rtcTransportPolicy iceTransportPolicy;
@@ -98,8 +99,9 @@ Creates a Peer Connection.
 Arguments:
 
 - `config`: the configuration structure, containing:
-  - `iceServers` (optional): an array of pointers on null-terminated ice server URIs (NULL if unused)
+  - `iceServers` (optional): an array of pointers on null-terminated ICE server URIs (NULL if unused)
   - `iceServersCount` (optional): number of URLs in the array pointed by `iceServers` (0 if unused)
+  - `proxyServer` (optional): if non-NULL, specifies the proxy server URI to use for TURN relaying (ignored with libjuice as ICE backend)
   - `bindAddress` (optional): if non-NULL, bind only to the given local address (ignored with libnice as ICE backend)
   - `certificateType` (optional): certificate type, either `RTC_CERTIFICATE_ECDSA` or `RTC_CERTIFICATE_RSA` (0 or `RTC_CERTIFICATE_DEFAULT` if default)
   - `iceTransportPolicy` (optional): ICE transport policy, if set to `RTC_TRANSPORT_POLICY_RELAY`, the PeerConnection will emit only relayed candidates (0 or `RTC_TRANSPORT_POLICY_ALL` if default)
@@ -115,7 +117,10 @@ Return value: the identifier of the new Peer Connection or a negative error code
 
 The Peer Connection must be deleted with `rtcDeletePeerConnection`.
 
-The format of each entry in `iceServers` must match the format `[("stun"|"turn"|"turns") ":"][login ":" password "@"]hostname[":" port]["?transport=" ("udp"|"tcp"|"tls")]`. The default scheme is STUN, the default port is 3478 (5349 over TLS), and the default transport is UDP.  For instance, a STUN server URI could be `mystunserver.org`, and a TURN server URI could be `turn:myuser:12345678@turnserver.org`. Note transports TCP and TLS are only available for a TURN server with libnice as ICE backend and govern only the TURN control connection, meaning relaying is always performed over UDP.
+Each entry in `iceServers` must match the format `[("stun"|"turn"|"turns") (":"|"://")][username ":" password "@"]hostname[":" port]["?transport=" ("udp"|"tcp"|"tls")]`. The default scheme is STUN, the default port is 3478 (5349 over TLS), and the default transport is UDP.  For instance, a STUN server URI could be `mystunserver.org`, and a TURN server URI could be `turn:myuser:12345678@turnserver.org`. Note transports TCP and TLS are only available for a TURN server with libnice as ICE backend and govern only the TURN control connection, meaning relaying is always performed over UDP.
+
+The `proxyServer` URI, if present, must match the format `[("http"|"socks5") (":"|"://")][username ":" password "@"]hostname["    :" port]`. The default scheme is HTTP, and the default port is 3128 for HTTP or 1080 for SOCKS5.
+
 
 #### rtcDeletePeerConnection
 
@@ -763,6 +768,8 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config)
 
 typedef struct {
 	bool disableTlsVerification;    // if true, disable TLS certificate verification
+	const char **protocols;
+	int protocolsCount;
 } rtcWsConfiguration;
 ```
 
@@ -773,6 +780,9 @@ Arguments:
 - `url`: a null-terminated string representing the fully-qualified URL to open.
 - `config`: a structure with the following parameters:
   - `bool disableTlsVerification`: if true, don't verify the TLS certificate, else try to verify it if possible
+  - `protocols` (optional): an array of pointers on null-terminated protocol names (NULL if unused)
+  - `protocolsCount` (optional): number of URLs in the array pointed by `protocols` (0 if unused)
+
 
 Return value: the identifier of the new WebSocket or a negative error code
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1284,6 +1284,10 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 
 		WebSocket::Configuration c;
 		c.disableTlsVerification = config->disableTlsVerification;
+
+		if (config->proxyServer)
+			c.proxyServer.emplace(config->proxyServer);
+
 		auto webSocket = std::make_shared<WebSocket>(std::move(c));
 		webSocket->open(url);
 		return emplaceWebSocket(webSocket);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -354,6 +354,9 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 		for (int i = 0; i < config->iceServersCount; ++i)
 			c.iceServers.emplace_back(string(config->iceServers[i]));
 
+		if (config->proxyServer)
+			c.proxyServer.emplace(config->proxyServer);
+
 		if (config->bindAddress)
 			c.bindAddress = string(config->bindAddress);
 
@@ -769,37 +772,37 @@ int rtcReceiveMessage(int id, char *buffer, int *size) {
 			return RTC_ERR_NOT_AVAIL;
 
 		return std::visit( //
-		overloaded{
-			[&](binary b) {
-				int ret = copyAndReturn(std::move(b), buffer, *size);
-				if (ret >= 0) {
-					*size = ret;
-					if (buffer) {
-						channel->receive(); // discard
-					}
-					
-					return RTC_ERR_SUCCESS;
-				} else {
-					*size = int(b.size());
-					return ret;
-				}
-			},
-			[&](string s) {
-				int ret = copyAndReturn(std::move(s), buffer, *size);
-				if (ret >= 0) {
-					*size = -ret;
-					if (buffer) {
-						channel->receive(); // discard
-					}
-					
-					return RTC_ERR_SUCCESS;
-				} else {
-					*size = -int(s.size() + 1);
-					return ret;
-				}
-			},
-		},
-		*message);
+		    overloaded{
+		        [&](binary b) {
+			        int ret = copyAndReturn(std::move(b), buffer, *size);
+			        if (ret >= 0) {
+				        *size = ret;
+				        if (buffer) {
+					        channel->receive(); // discard
+				        }
+
+				        return RTC_ERR_SUCCESS;
+			        } else {
+				        *size = int(b.size());
+				        return ret;
+			        }
+		        },
+		        [&](string s) {
+			        int ret = copyAndReturn(std::move(s), buffer, *size);
+			        if (ret >= 0) {
+				        *size = -ret;
+				        if (buffer) {
+					        channel->receive(); // discard
+				        }
+
+				        return RTC_ERR_SUCCESS;
+			        } else {
+				        *size = -int(s.size() + 1);
+				        return ret;
+			        }
+		        },
+		    },
+		    *message);
 	});
 }
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1288,6 +1288,9 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 		if (config->proxyServer)
 			c.proxyServer.emplace(config->proxyServer);
 
+		for (int i = 0; i < config->protocolsCount; ++i)
+			c.protocols.emplace_back(string(config->protocols[i]));
+
 		auto webSocket = std::make_shared<WebSocket>(std::move(c));
 		webSocket->open(url);
 		return emplaceWebSocket(webSocket);

--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -18,11 +18,14 @@
 
 #include "configuration.hpp"
 
+#include <cassert>
 #include <regex>
 
-namespace rtc {
+#include <iostream>
 
-IceServer::IceServer(const string &url) {
+namespace {
+
+bool parse_url(const std::string &url, std::vector<std::optional<std::string>> &result) {
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B
 	static const char *rs =
 	    R"(^(([^:.@/?#]+):)?(/{0,2}((([^:@]*)(:([^@]*))?)@)?(([^:/?#]*)(:([^/?#]*))?))?([^?#]*)(\?([^#]*))?(#(.*))?)";
@@ -30,12 +33,25 @@ IceServer::IceServer(const string &url) {
 
 	std::smatch m;
 	if (!std::regex_match(url, m, r) || m[10].length() == 0)
-		throw std::invalid_argument("Invalid ICE server URL: " + url);
+		return false;
 
-	std::vector<optional<string>> opt(m.size());
-	std::transform(m.begin(), m.end(), opt.begin(), [](const auto &sm) {
-		return sm.length() > 0 ? std::make_optional(string(sm)) : nullopt;
+	result.resize(m.size());
+	std::transform(m.begin(), m.end(), result.begin(), [](const auto &sm) {
+		return sm.length() > 0 ? std::make_optional(std::string(sm)) : std::nullopt;
 	});
+
+	assert(result.size() == 18);
+	return true;
+}
+
+} // namespace
+
+namespace rtc {
+
+IceServer::IceServer(const string &url) {
+	std::vector<optional<string>> opt;
+	if (!parse_url(url, opt))
+		throw std::invalid_argument("Invalid ICE server URL: " + url);
 
 	string scheme = opt[2].value_or("stun");
 	relayType = RelayType::TurnUdp;
@@ -103,8 +119,42 @@ IceServer::IceServer(string hostname_, string service_, string username_, string
 	}
 }
 
+ProxyServer::ProxyServer(const string &url) {
+	std::vector<optional<string>> opt;
+	if (!parse_url(url, opt))
+		throw std::invalid_argument("Invalid proxy server URL: " + url);
+
+	string scheme = opt[2].value_or("http");
+	if (scheme == "http" || scheme == "HTTP")
+		type = Type::Http;
+	else if (scheme == "socks5" || scheme == "SOCKS5")
+		type = Type::Socks5;
+	else
+		throw std::invalid_argument("Unknown proxy server protocol: " + scheme);
+
+	username = opt[6];
+	password = opt[8];
+
+	hostname = opt[10].value();
+	while (!hostname.empty() && hostname.front() == '[')
+		hostname.erase(hostname.begin());
+	while (!hostname.empty() && hostname.back() == ']')
+		hostname.pop_back();
+
+	string service = opt[12].value_or(type == Type::Socks5 ? "1080" : "3128");
+	try {
+		port = uint16_t(std::stoul(service));
+	} catch (...) {
+		throw std::invalid_argument("Invalid proxy server port in URL: " + service);
+	}
+}
+
+ProxyServer::ProxyServer(Type type_, string hostname_, uint16_t port_)
+    : type(type_), hostname(std::move(hostname_)), port(port_) {}
+
 ProxyServer::ProxyServer(Type type_, string hostname_, uint16_t port_, string username_,
                          string password_)
-    : type(type_), hostname(hostname_), port(port_), username(username_), password(password_) {}
+    : type(type_), hostname(std::move(hostname_)), port(port_), username(std::move(username_)),
+      password(std::move(password_)) {}
 
 } // namespace rtc

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -57,6 +57,10 @@ void WebSocket::open(const string &url) {
 	if (state != State::Closed)
 		throw std::logic_error("WebSocket must be closed before opening");
 
+	if (config.proxyServer) {
+		PLOG_WARNING << "Proxy server support for WebSocket is not implemented";
+	}
+
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B
 	static const char *rs =
 	    R"(^(([^:.@/?#]+):)?(/{0,2}((([^:@]*)(:([^@]*))?)@)?(([^:/?#]*)(:([^/?#]*))?))?([^?#]*)(\?([^#]*))?(#(.*))?)";
@@ -75,6 +79,12 @@ void WebSocket::open(const string &url) {
 		throw std::invalid_argument("Invalid WebSocket scheme: " + scheme);
 
 	mIsSecure = (scheme != "ws");
+
+	string username = m[6];
+	string password = m[8];
+	if (!username.empty() || !password.empty()) {
+		PLOG_WARNING << "HTTP authentication support for WebSocket is not implemented";
+	}
 
 	string host;
 	string hostname = m[10];

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -53,10 +53,7 @@ bool WebSocket::isClosed() const { return impl()->state.load() == State::Closed;
 
 size_t WebSocket::maxMessageSize() const { return DEFAULT_MAX_MESSAGE_SIZE; }
 
-void WebSocket::open(const string &url) {
-	PLOG_VERBOSE << "Opening WebSocket to URL: " << url;
-	impl()->open(url);
-}
+void WebSocket::open(const string &url) { impl()->open(url); }
 
 void WebSocket::close() { impl()->close(); }
 


### PR DESCRIPTION
This PR refactors `ProxyServer` and exposes missing WebSocket configuration settings `proxyServer` and `protocols` in the C API.