### PR TITLE
Fix deadlock on deletion from state callback in C API

### DIFF
--- a/include/rtc/utils.hpp
+++ b/include/rtc/utils.hpp
@@ -96,10 +96,6 @@ public:
 		return callback ? true : false;
 	}
 
-	std::function<void(Args...)> wrap() const {
-		return [this](Args... args) { (*this)(std::move(args)...); };
-	}
-
 protected:
 	virtual void set(std::function<void(Args...)> func) { callback = std::move(func); }
 	virtual bool call(Args... args) const {

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -23,6 +23,7 @@
 #include "datachannel.hpp"
 #include "dtlstransport.hpp"
 #include "icetransport.hpp"
+#include "processor.hpp"
 #include "sctptransport.hpp"
 #include "track.hpp"
 
@@ -101,7 +102,10 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	void resetCallbacks();
 
-	void outgoingMedia(message_ptr message);
+	// Helper method for asynchronous callback invocation
+	template <typename... Args> void trigger(synchronized_callback<Args...> &cb, Args... args) {
+		cb(std::move(args...));
+	}
 
 	const Configuration config;
 	std::atomic<State> state = State::New;
@@ -121,8 +125,8 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 private:
 	const init_token mInitToken = Init::Instance().token();
 	const future_certificate_ptr mCertificate;
-	const unique_ptr<Processor> mProcessor;
 
+	Processor mProcessor;
 	optional<Description> mLocalDescription, mRemoteDescription;
 	optional<Description> mCurrentLocalDescription;
 	mutable std::mutex mLocalDescriptionMutex, mRemoteDescriptionMutex;

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -447,7 +447,7 @@ void SctpTransport::closeStream(unsigned int stream) {
 	mSendQueue.push(make_message(0, Message::Reset, to_uint16(stream)));
 
 	// This method must not call the buffered callback synchronously
-	mProcessor.enqueue(&SctpTransport::flush, this);
+	mProcessor.enqueue(&SctpTransport::flush, shared_from_this());
 }
 
 void SctpTransport::incoming(message_ptr message) {
@@ -702,12 +702,12 @@ void SctpTransport::handleUpcall() {
 
 	if (events & SCTP_EVENT_READ && mPendingRecvCount == 0) {
 		++mPendingRecvCount;
-		mProcessor.enqueue(&SctpTransport::doRecv, this);
+		mProcessor.enqueue(&SctpTransport::doRecv, shared_from_this());
 	}
 
 	if (events & SCTP_EVENT_WRITE && mPendingFlushCount == 0) {
 		++mPendingFlushCount;
-		mProcessor.enqueue(&SctpTransport::doFlush, this);
+		mProcessor.enqueue(&SctpTransport::doFlush, shared_from_this());
 	}
 }
 

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -35,7 +35,7 @@
 
 namespace rtc::impl {
 
-class SctpTransport final : public Transport {
+class SctpTransport final : public Transport, public std::enable_shared_from_this<SctpTransport> {
 public:
 	static void Init();
 	static void SetSettings(const SctpSettings &s);

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -48,7 +48,6 @@ WebSocket::WebSocket(optional<Configuration> optConfig, certificate_ptr certific
 
 WebSocket::~WebSocket() {
 	PLOG_VERBOSE << "Destroying WebSocket";
-	remoteClose();
 }
 
 void WebSocket::open(const string &url) {


### PR DESCRIPTION
This PR fixes a possible deadlock on `Processor::join()`, for instance in the C API when a `PeerConnection` is destroyed from its own state callback.

It ensures tasks enqueued in the processor keep a shared pointer on the object, to prevent its destruction while tasks are left in the processor which would lead the thread waiting for the processor while blocking it. It takes the opportunity to remove the useless `unique_ptr` for `PeerConnection::mProcessor`.