### PR TITLE
Rename NegotiatedDataChannel to OutgoingDataChannel

### DIFF
--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -259,19 +259,19 @@ void DataChannel::incoming(message_ptr message) {
 	}
 }
 
-NegotiatedDataChannel::NegotiatedDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream,
+OutgoingDataChannel::OutgoingDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream,
                                              string label, string protocol, Reliability reliability)
     : DataChannel(pc, stream, std::move(label), std::move(protocol), std::move(reliability)) {}
 
-NegotiatedDataChannel::~NegotiatedDataChannel() {}
+OutgoingDataChannel::~OutgoingDataChannel() {}
 
-void NegotiatedDataChannel::shiftStream() {
+void OutgoingDataChannel::shiftStream() {
 	std::shared_lock lock(mMutex);
 	if (mStream % 2 == 1)
 		mStream -= 1;
 }
 
-void NegotiatedDataChannel::open(shared_ptr<SctpTransport> transport) {
+void OutgoingDataChannel::open(shared_ptr<SctpTransport> transport) {
 	std::unique_lock lock(mMutex);
 	mSctpTransport = transport;
 
@@ -316,7 +316,7 @@ void NegotiatedDataChannel::open(shared_ptr<SctpTransport> transport) {
 	transport->send(make_message(buffer.begin(), buffer.end(), Message::Control, mStream));
 }
 
-void NegotiatedDataChannel::processOpenMessage(message_ptr) {
+void OutgoingDataChannel::processOpenMessage(message_ptr) {
 	PLOG_WARNING << "Received an open message for a locally-created DataChannel, ignoring";
 }
 

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -80,10 +80,10 @@ protected:
 	std::atomic<bool> mIsClosed = false;
 };
 
-struct NegotiatedDataChannel final : public DataChannel {
-	NegotiatedDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
+struct OutgoingDataChannel final : public DataChannel {
+	OutgoingDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
 	                      string protocol, Reliability reliability);
-	~NegotiatedDataChannel();
+	~OutgoingDataChannel();
 
 	void shiftStream() override;
 	void open(shared_ptr<SctpTransport> transport) override;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -630,14 +630,14 @@ shared_ptr<DataChannel> PeerConnection::emplaceDataChannel(string label, DataCha
 			stream += 2;
 		}
 	}
-	// If the DataChannel is user-negotiated, do not negotiate it here
+	// If the DataChannel is user-negotiated, do not negotiate it in-band
 	auto channel =
 	    init.negotiated
 	        ? std::make_shared<DataChannel>(weak_from_this(), stream, std::move(label),
 	                                        std::move(init.protocol), std::move(init.reliability))
-	        : std::make_shared<NegotiatedDataChannel>(weak_from_this(), stream, std::move(label),
-	                                                  std::move(init.protocol),
-	                                                  std::move(init.reliability));
+	        : std::make_shared<OutgoingDataChannel>(weak_from_this(), stream, std::move(label),
+	                                                std::move(init.protocol),
+	                                                std::move(init.reliability));
 	mDataChannels.emplace(std::make_pair(stream, channel));
 	return channel;
 }


### PR DESCRIPTION
This PR renames `NegotiatedDataChannel` to `OutgoingDataChannel` as it is less confusing, following the discussion in https://github.com/paullouisageneau/libdatachannel/issues/607.