### PR TITLE
Tear down connections sequentially

### DIFF
--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -23,6 +23,7 @@
 #include "datachannel.hpp"
 #include "dtlstransport.hpp"
 #include "icetransport.hpp"
+#include "init.hpp"
 #include "processor.hpp"
 #include "sctptransport.hpp"
 #include "track.hpp"

--- a/src/impl/processor.cpp
+++ b/src/impl/processor.cpp
@@ -40,4 +40,13 @@ void Processor::schedule() {
 	}
 }
 
+TearDownProcessor &TearDownProcessor::Instance() {
+	static TearDownProcessor *instance = new TearDownProcessor;
+	return *instance;
+}
+
+TearDownProcessor::TearDownProcessor() {}
+
+TearDownProcessor::~TearDownProcessor() {}
+
 } // namespace rtc::impl


### PR DESCRIPTION
This PR introduces a global `Processor` to tear down connections sequentially.

It solves a possible deadlock when many active peer connections are closed at the exact same time, filling the thread pool with tasks waiting for SCTP transports.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/619