### PR TITLE
Re-enable WebSocket ping

### DIFF
--- a/src/impl/pollservice.cpp
+++ b/src/impl/pollservice.cpp
@@ -176,7 +176,7 @@ void PollService::runLoop() {
 				int timeout;
 				if (next) {
 					auto msecs = duration_cast<milliseconds>(
-					    std::max(clock::duration::zero(), *next - clock::now()));
+					    std::max(clock::duration::zero(), *next - clock::now() + 1ms));
 					PLOG_VERBOSE << "Entering poll, timeout=" << msecs.count() << "ms";
 					timeout = static_cast<int>(msecs.count());
 				} else {


### PR DESCRIPTION
This PR re-enables WebSocket ping, which was disabled by https://github.com/paullouisageneau/libdatachannel/pull/556