### PR TITLE
Assign Data Channel stream IDs on connection

### DIFF
--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -39,8 +39,8 @@ public:
 	DataChannel(impl_ptr<impl::DataChannel> impl);
 	virtual ~DataChannel();
 
-	uint16_t stream() const;
-	uint16_t id() const;
+	optional<uint16_t> stream() const;
+	optional<uint16_t> id() const;
 	string label() const;
 	string protocol() const;
 	Reliability reliability() const;

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -863,7 +863,10 @@ int rtcDeleteDataChannel(int dc) {
 int rtcGetDataChannelStream(int dc) {
 	return wrap([dc] {
 		auto dataChannel = getDataChannel(dc);
-		return int(dataChannel->id());
+		if (auto stream = dataChannel->stream())
+			return int(*stream);
+		else
+			return RTC_ERR_NOT_AVAIL;
 	});
 }
 

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -46,9 +46,9 @@ DataChannel::~DataChannel() {
 
 void DataChannel::close() { return impl()->close(); }
 
-uint16_t DataChannel::stream() const { return impl()->stream(); }
+optional<uint16_t> DataChannel::stream() const { return impl()->stream(); }
 
-uint16_t DataChannel::id() const { return impl()->stream(); }
+optional<uint16_t> DataChannel::id() const { return impl()->stream(); }
 
 string DataChannel::label() const { return impl()->label(); }
 

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -37,7 +37,7 @@ struct PeerConnection;
 struct DataChannel : Channel, std::enable_shared_from_this<DataChannel> {
 	static bool IsOpenMessage(message_ptr message);
 
-	DataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label, string protocol,
+	DataChannel(weak_ptr<PeerConnection> pc, string label, string protocol,
 	            Reliability reliability);
 	virtual ~DataChannel();
 
@@ -50,7 +50,7 @@ struct DataChannel : Channel, std::enable_shared_from_this<DataChannel> {
 	optional<message_variant> peek() override;
 	size_t availableAmount() const override;
 
-	uint16_t stream() const;
+	optional<uint16_t> stream() const;
 	string label() const;
 	string protocol() const;
 	Reliability reliability() const;
@@ -59,7 +59,7 @@ struct DataChannel : Channel, std::enable_shared_from_this<DataChannel> {
 	bool isClosed(void) const;
 	size_t maxMessageSize() const;
 
-	virtual void shiftStream();
+	virtual void assignStream(uint16_t stream);
 	virtual void open(shared_ptr<SctpTransport> transport);
 	virtual void processOpenMessage(message_ptr);
 
@@ -67,32 +67,31 @@ protected:
 	const weak_ptr<impl::PeerConnection> mPeerConnection;
 	weak_ptr<SctpTransport> mSctpTransport;
 
-	uint16_t mStream;
+	optional<uint16_t> mStream;
 	string mLabel;
 	string mProtocol;
 	shared_ptr<Reliability> mReliability;
 
 	mutable std::shared_mutex mMutex;
 
-	Queue<message_ptr> mRecvQueue;
-
 	std::atomic<bool> mIsOpen = false;
 	std::atomic<bool> mIsClosed = false;
+
+private:
+	Queue<message_ptr> mRecvQueue;
 };
 
 struct OutgoingDataChannel final : public DataChannel {
-	OutgoingDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
-	                      string protocol, Reliability reliability);
+	OutgoingDataChannel(weak_ptr<PeerConnection> pc, string label, string protocol,
+	                    Reliability reliability);
 	~OutgoingDataChannel();
 
-	void shiftStream() override;
 	void open(shared_ptr<SctpTransport> transport) override;
 	void processOpenMessage(message_ptr message) override;
 };
 
 struct IncomingDataChannel final : public DataChannel {
-	IncomingDataChannel(weak_ptr<PeerConnection> pc, weak_ptr<SctpTransport> transport,
-	                    uint16_t stream);
+	IncomingDataChannel(weak_ptr<PeerConnection> pc, weak_ptr<SctpTransport> transport);
 	~IncomingDataChannel();
 
 	void open(shared_ptr<SctpTransport> transport) override;

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -70,7 +70,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	shared_ptr<DataChannel> emplaceDataChannel(string label, DataChannelInit init);
 	shared_ptr<DataChannel> findDataChannel(uint16_t stream);
 	uint16_t maxDataChannelStream() const;
-	void shiftDataChannels();
+	void assignDataChannels();
 	void iterateDataChannels(std::function<void(shared_ptr<DataChannel> channel)> func);
 	void cleanupDataChannels();
 	void openDataChannels();
@@ -138,9 +138,12 @@ private:
 	shared_ptr<SctpTransport> mSctpTransport;
 
 	std::unordered_map<uint16_t, weak_ptr<DataChannel>> mDataChannels; // by stream ID
+	std::vector<weak_ptr<DataChannel>> mUnassignedDataChannels;
+	std::shared_mutex mDataChannelsMutex;
+
 	std::unordered_map<string, weak_ptr<Track>> mTracks;               // by mid
 	std::vector<weak_ptr<Track>> mTrackLines;                          // by SDP order
-	std::shared_mutex mDataChannelsMutex, mTracksMutex;
+	std::shared_mutex mTracksMutex;
 
 	Queue<shared_ptr<DataChannel>> mPendingDataChannels;
 	Queue<shared_ptr<Track>> mPendingTracks;

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -79,6 +79,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	shared_ptr<Track> emplaceTrack(Description::Media description);
 	void incomingTrack(Description::Media description);
+	void iterateTracks(std::function<void(shared_ptr<Track> track)> func);
 	void openTracks();
 	void closeTracks();
 
@@ -141,8 +142,8 @@ private:
 	std::vector<weak_ptr<DataChannel>> mUnassignedDataChannels;
 	std::shared_mutex mDataChannelsMutex;
 
-	std::unordered_map<string, weak_ptr<Track>> mTracks;               // by mid
-	std::vector<weak_ptr<Track>> mTrackLines;                          // by SDP order
+	std::unordered_map<string, weak_ptr<Track>> mTracks; // by mid
+	std::vector<weak_ptr<Track>> mTrackLines;            // by SDP order
 	std::shared_mutex mTracksMutex;
 
 	Queue<shared_ptr<DataChannel>> mPendingDataChannels;

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -265,10 +265,6 @@ shared_ptr<DataChannel> PeerConnection::createDataChannel(string label, DataChan
 	auto channelImpl = impl()->emplaceDataChannel(std::move(label), std::move(init));
 	auto channel = std::make_shared<DataChannel>(channelImpl);
 
-	if (auto transport = impl()->getSctpTransport())
-		if (transport->state() == impl::SctpTransport::State::Connected)
-			channelImpl->open(transport);
-
 	// Renegotiation is needed iff the current local description does not have application
 	auto local = impl()->localDescription();
 	if (!local || !local->hasApplication())


### PR DESCRIPTION
In the browser WebRTC API, `RTCDataChannel` has an unassigned state with `id = null` when it is not user-negotiated. In that case, `id` is assigned when SCTP connects.

This PR changes the stream id assignment logic to match the browser behavior, so the stream id is guaranteed to never change once assigned. It introduces a breaking change to the library interface as `DataChannel::id()` now returns an optional.

Implements https://github.com/paullouisageneau/libdatachannel/issues/613