### PR TITLE
Add buffered amount support for WebSocket

### DIFF
--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -67,6 +67,7 @@ protected:
 	Queue<message_ptr> mIncomingQueue;
 	std::thread mRecvThread;
 	std::atomic<unsigned int> mCurrentDscp;
+	std::atomic<bool> mOutgoingResult = true;
 
 #if USE_GNUTLS
 	gnutls_session_t mSession;

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -333,6 +333,10 @@ SctpTransport::~SctpTransport() {
 	Instances->erase(this);
 }
 
+void SctpTransport::onBufferedAmount(amount_callback callback) {
+	mBufferedAmountCallback = std::move(callback);
+}
+
 void SctpTransport::start() {
 	Transport::start();
 

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -53,6 +53,8 @@ public:
 	              state_callback stateChangeCallback);
 	~SctpTransport();
 
+	void onBufferedAmount(amount_callback callback);
+
 	void start() override;
 	bool stop() override;
 	bool send(message_ptr message) override; // false if buffered
@@ -60,10 +62,6 @@ public:
 	void closeStream(unsigned int stream);
 
 	unsigned int maxStream() const;
-
-	void onBufferedAmount(amount_callback callback) {
-		mBufferedAmountCallback = std::move(callback);
-	}
 
 	// Stats
 	void clearStats();

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -95,7 +95,7 @@ bool TcpTransport::send(message_ptr message) {
 	if (state() != State::Connected)
 		throw std::runtime_error("Connection is not open");
 
-	if (!message)
+	if (!message || message->size() == 0)
 		return trySendQueue();
 
 	PLOG_VERBOSE << "Send size=" << message->size();

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -71,6 +71,14 @@ TcpTransport::TcpTransport(socket_t sock, state_callback callback)
 
 TcpTransport::~TcpTransport() { stop(); }
 
+void TcpTransport::onBufferedAmount(amount_callback callback) {
+	mBufferedAmountCallback = std::move(callback);
+}
+
+void TcpTransport::setReadTimeout(std::chrono::milliseconds readTimeout) {
+	mReadTimeout = readTimeout;
+}
+
 void TcpTransport::start() {
 	Transport::start();
 
@@ -117,13 +125,12 @@ bool TcpTransport::outgoing(message_ptr message) {
 		return true;
 
 	mSendQueue.push(message);
+	updateBufferedAmount(ptrdiff_t(message->size()));
 	setPoll(PollService::Direction::Both);
 	return false;
 }
 
 string TcpTransport::remoteAddress() const { return mHostname + ':' + mService; }
-
-void TcpTransport::setReadTimeout(std::chrono::milliseconds readTimeout) { mReadTimeout = readTimeout; }
 
 void TcpTransport::connect() {
 	PLOG_DEBUG << "Connecting to " << mHostname << ":" << mService;
@@ -269,11 +276,15 @@ bool TcpTransport::trySendQueue() {
 	// mSendMutex must be locked
 	while (auto next = mSendQueue.peek()) {
 		message_ptr message = std::move(*next);
-		if (!trySendMessage(message)) {
+		size_t size = message->size();
+		if (!trySendMessage(message)) { // replaces message
 			mSendQueue.exchange(message);
+			updateBufferedAmount(-ptrdiff_t(size) + ptrdiff_t(message->size()));
 			return false;
 		}
+
 		mSendQueue.pop();
+		updateBufferedAmount(-ptrdiff_t(size));
 	}
 
 	return true;
@@ -281,6 +292,7 @@ bool TcpTransport::trySendQueue() {
 
 bool TcpTransport::trySendMessage(message_ptr &message) {
 	// mSendMutex must be locked
+
 	auto data = reinterpret_cast<const char *>(message->data());
 	auto size = message->size();
 	while (size) {
@@ -305,6 +317,26 @@ bool TcpTransport::trySendMessage(message_ptr &message) {
 	}
 	message = nullptr;
 	return true;
+}
+
+void TcpTransport::updateBufferedAmount(ptrdiff_t delta) {
+	// Requires mSendMutex to be locked
+
+	if (delta == 0)
+		return;
+
+	mBufferedAmount = size_t(std::max(ptrdiff_t(mBufferedAmount) + delta, ptrdiff_t(0)));
+
+	// Synchronously call the buffered amount callback
+	triggerBufferedAmount(mBufferedAmount);
+}
+
+void TcpTransport::triggerBufferedAmount(size_t amount) {
+	try {
+		mBufferedAmountCallback(amount);
+	} catch (const std::exception &e) {
+		PLOG_WARNING << "TCP buffered amount callback: " << e.what();
+	}
 }
 
 void TcpTransport::process(PollService::Event event) {

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -34,9 +34,14 @@ namespace rtc::impl {
 
 class TcpTransport : public Transport {
 public:
+	using amount_callback = std::function<void(size_t amount)>;
+
 	TcpTransport(string hostname, string service, state_callback callback); // active
 	TcpTransport(socket_t sock, state_callback callback);                   // passive
 	~TcpTransport();
+
+	void onBufferedAmount(amount_callback callback);
+	void setReadTimeout(std::chrono::milliseconds readTimeout);
 
 	void start() override;
 	bool stop() override;
@@ -48,8 +53,6 @@ public:
 	bool isActive() const { return mIsActive; }
 	string remoteAddress() const;
 
-	void setReadTimeout(std::chrono::milliseconds readTimeout);
-
 private:
 	void connect();
 	void prepare(const sockaddr *addr, socklen_t addrlen);
@@ -58,15 +61,19 @@ private:
 
 	bool trySendQueue();
 	bool trySendMessage(message_ptr &message);
+	void updateBufferedAmount(ptrdiff_t delta);
+	void triggerBufferedAmount(size_t amount);
 
 	void process(PollService::Event event);
 
 	const bool mIsActive;
 	string mHostname, mService;
+	amount_callback mBufferedAmountCallback;
 	optional<std::chrono::milliseconds> mReadTimeout;
 
 	socket_t mSock;
 	Queue<message_ptr> mSendQueue;
+	size_t mBufferedAmount = 0;
 	std::mutex mSendMutex;
 };
 

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -27,6 +27,7 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
+#include <atomic>
 #include <thread>
 
 namespace rtc::impl {
@@ -50,6 +51,7 @@ public:
 
 protected:
 	virtual void incoming(message_ptr message) override;
+	virtual bool outgoing(message_ptr message) override;
 	virtual void postHandshake();
 	void runRecvLoop();
 
@@ -64,6 +66,7 @@ protected:
 
 	message_ptr mIncomingMessage;
 	size_t mIncomingMessagePosition = 0;
+	std::atomic<bool> mOutgoingResult = true;
 
 	static ssize_t WriteCallback(gnutls_transport_ptr_t ptr, const void *data, size_t len);
 	static ssize_t ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_t maxlen);

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -221,6 +221,8 @@ shared_ptr<TcpTransport> WebSocket::setTcpTransport(shared_ptr<TcpTransport> tra
 		if (std::atomic_load(&mTcpTransport))
 			throw std::logic_error("TCP transport is already set");
 
+		transport->onBufferedAmount(weak_bind(&WebSocket::triggerBufferedAmount, this, _1));
+
 		transport->onStateChange([this, weak_this = weak_from_this()](State transportState) {
 			auto shared_this = weak_this.lock();
 			if (!shared_this)
@@ -409,6 +411,9 @@ void WebSocket::closeTransports() {
 
 	if (ws)
 		ws->onRecv(nullptr);
+
+	if (tcp)
+		tcp->onBufferedAmount(nullptr);
 
 	using array = std::array<shared_ptr<Transport>, 3>;
 	array transports{std::move(ws), std::move(tls), std::move(tcp)};

--- a/test/websocket.cpp
+++ b/test/websocket.cpp
@@ -60,7 +60,7 @@ void test_websocket() {
 
 	ws.open("wss://echo.websocket.org:443/");
 
-	int attempts = 10;
+	int attempts = 20;
 	while ((!ws.isOpen() || !received) && attempts--)
 		this_thread::sleep_for(1s);
 


### PR DESCRIPTION
This PR implements the buffered amount mechanism for `WebSocket`, allowing the user to get back pressure signals like for `DataChannel`.