### PR TITLE
Expose pingInterval and maxOutstandingPings in C API

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -370,6 +370,8 @@ typedef struct {
 	const char *proxyServer;     // unsupported for now
 	const char **protocols;
 	int protocolsCount;
+	int pingInterval;        // in milliseconds, 0 means default, < 0 means disabled
+	int maxOutstandingPings; // 0 means default, < 0 means disabled
 } rtcWsConfiguration;
 
 RTC_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -23,7 +23,7 @@
 
 #include "channel.hpp"
 #include "common.hpp"
-#include "configuration.hpp"
+#include "configuration.hpp" // for ProxyServer
 
 namespace rtc {
 
@@ -46,9 +46,8 @@ public:
 		bool disableTlsVerification = false; // if true, don't verify the TLS certificate
 		optional<ProxyServer> proxyServer;   // unsupported for now
 		std::vector<string> protocols;
+		optional<std::chrono::milliseconds> pingInterval; // zero to disable
 		optional<int> maxOutstandingPings;
-		std::chrono::milliseconds pingInterval =
-			std::chrono::seconds(10); // interval at which to send pings
 	};
 
 	WebSocket();

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1298,6 +1298,17 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 		for (int i = 0; i < config->protocolsCount; ++i)
 			c.protocols.emplace_back(string(config->protocols[i]));
 
+		if (config->pingInterval > 0)
+			c.pingInterval = std::chrono::milliseconds(config->pingInterval);
+		else if (config->pingInterval < 0)
+			c.pingInterval = std::chrono::milliseconds::zero(); // setting to 0 disables,
+			                                                    // not setting keeps default
+
+		if (config->maxOutstandingPings > 0)
+			c.maxOutstandingPings = config->maxOutstandingPings;
+		else if (config->maxOutstandingPings < 0)
+			c.maxOutstandingPings = 0; // setting to 0 disables, not setting keeps default
+
 		auto webSocket = std::make_shared<WebSocket>(std::move(c));
 		webSocket->open(url);
 		return emplaceWebSocket(webSocket);

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -249,11 +249,9 @@ void TcpTransport::prepare(const sockaddr *addr, socklen_t addrlen) {
 }
 
 void TcpTransport::setPoll(PollService::Direction direction) {
-	const auto timeout = mReadTimeout;
 	PollService::Instance().add(
-	    mSock,
-	    {direction, direction == PollService::Direction::In ? make_optional(timeout) : nullopt,
-	     std::bind(&TcpTransport::process, this, _1)});
+	    mSock, {direction, direction == PollService::Direction::In ? mReadTimeout : nullopt,
+	            std::bind(&TcpTransport::process, this, _1)});
 }
 
 void TcpTransport::close() {

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -28,6 +28,7 @@
 #if RTC_ENABLE_WEBSOCKET
 
 #include <mutex>
+#include <chrono>
 
 namespace rtc::impl {
 
@@ -45,8 +46,8 @@ public:
 	bool outgoing(message_ptr message) override;
 
 	bool isActive() const { return mIsActive; }
-
 	string remoteAddress() const;
+
 	void setReadTimeout(std::chrono::milliseconds readTimeout);
 
 private:
@@ -62,7 +63,7 @@ private:
 
 	const bool mIsActive;
 	string mHostname, mService;
-	std::chrono::milliseconds mReadTimeout = std::chrono::seconds(10);
+	optional<std::chrono::milliseconds> mReadTimeout;
 
 	socket_t mSock;
 	Queue<message_ptr> mSendQueue;

--- a/src/impl/wstransport.cpp
+++ b/src/impl/wstransport.cpp
@@ -62,7 +62,7 @@ WsTransport::WsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<TlsTranspo
           std::visit(rtc::overloaded{[](shared_ptr<TcpTransport> l) { return l->isActive(); },
                                      [](shared_ptr<TlsTransport> l) { return l->isClient(); }},
                      lower)),
-      mMaxPongsMissed(maxOutstandingPings) {
+      mMaxOutstandingPings(std::move(maxOutstandingPings)) {
 
 	onRecv(std::move(recvCallback));
 
@@ -375,7 +375,7 @@ bool WsTransport::sendFrame(const Frame &frame) {
 
 void WsTransport::addOutstandingPing() {
 	++mPingsOutstanding;
-	if (mMaxPongsMissed && *mMaxPongsMissed > 0 && mPingsOutstanding > *mMaxPongsMissed) {
+	if (mMaxOutstandingPings && *mMaxOutstandingPings > 0 && mPingsOutstanding > *mMaxOutstandingPings) {
 		changeState(State::Failed);
 	}
 }

--- a/src/impl/wstransport.cpp
+++ b/src/impl/wstransport.cpp
@@ -53,8 +53,8 @@ using random_bytes_engine =
     std::independent_bits_engine<std::default_random_engine, CHAR_BIT, unsigned short>;
 
 WsTransport::WsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<TlsTransport>> lower,
-                         shared_ptr<WsHandshake> handshake, message_callback recvCallback,
-                         state_callback stateCallback, std::optional<int> maxOutstandingPings)
+                         shared_ptr<WsHandshake> handshake, int maxOutstandingPings,
+                         message_callback recvCallback, state_callback stateCallback)
     : Transport(std::visit([](auto l) { return std::static_pointer_cast<Transport>(l); }, lower),
                 std::move(stateCallback)),
       mHandshake(std::move(handshake)),
@@ -62,7 +62,7 @@ WsTransport::WsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<TlsTranspo
           std::visit(rtc::overloaded{[](shared_ptr<TcpTransport> l) { return l->isActive(); },
                                      [](shared_ptr<TlsTransport> l) { return l->isClient(); }},
                      lower)),
-      mMaxOutstandingPings(std::move(maxOutstandingPings)) {
+      mMaxOutstandingPings(maxOutstandingPings) {
 
 	onRecv(std::move(recvCallback));
 
@@ -318,7 +318,7 @@ void WsTransport::recvFrame(const Frame &frame) {
 	}
 	case PONG: {
 		PLOG_DEBUG << "WebSocket received pong";
-		mPingsOutstanding = 0;
+		mOutstandingPings = 0;
 		break;
 	}
 	case CLOSE: {
@@ -374,8 +374,8 @@ bool WsTransport::sendFrame(const Frame &frame) {
 }
 
 void WsTransport::addOutstandingPing() {
-	++mPingsOutstanding;
-	if (mMaxOutstandingPings && *mMaxOutstandingPings > 0 && mPingsOutstanding > *mMaxOutstandingPings) {
+	++mOutstandingPings;
+	if (mMaxOutstandingPings > 0 && mOutstandingPings > mMaxOutstandingPings) {
 		changeState(State::Failed);
 	}
 }

--- a/src/impl/wstransport.hpp
+++ b/src/impl/wstransport.hpp
@@ -33,8 +33,8 @@ class TlsTransport;
 class WsTransport final : public Transport {
 public:
 	WsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<TlsTransport>> lower,
-				shared_ptr<WsHandshake> handshake, message_callback recvCallback,
-				state_callback stateCallback, optional<int> maxOutstandingPings);
+	            shared_ptr<WsHandshake> handshake, int maxOutstandingPings,
+	            message_callback recvCallback, state_callback stateCallback);
 	~WsTransport();
 
 	void start() override;
@@ -75,12 +75,12 @@ private:
 
 	const shared_ptr<WsHandshake> mHandshake;
 	const bool mIsClient;
-	const optional<int> mMaxOutstandingPings;
+	const int mMaxOutstandingPings;
 
 	binary mBuffer;
 	binary mPartial;
 	Opcode mPartialOpcode;
-	int mPingsOutstanding = 0;
+	int mOutstandingPings = 0;
 };
 
 } // namespace rtc::impl

--- a/src/impl/wstransport.hpp
+++ b/src/impl/wstransport.hpp
@@ -75,7 +75,7 @@ private:
 
 	const shared_ptr<WsHandshake> mHandshake;
 	const bool mIsClient;
-	const optional<int> mMaxPongsMissed;
+	const optional<int> mMaxOutstandingPings;
 
 	binary mBuffer;
 	binary mPartial;


### PR DESCRIPTION
This PR exposes `pingInterval` and `maxOutstandingPings` in C API. It also makes `WebSocket::Configuration::pingInterval` an optional for consistency with other settings (especially `SctpSettings`).