### PR TITLE
Fix possible close ping-pong with destroyed DataChannel

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -455,6 +455,9 @@ void PeerConnection::forwardMessage(message_ptr message) {
 	}
 
 	if (!channel) {
+		if (message->type == Message::Control) // ignore control messages like Close
+			return;
+
 		// Invalid, close the DataChannel
 		PLOG_WARNING << "Got unexpected message on stream " << stream;
 		if (auto sctpTransport = getSctpTransport())


### PR DESCRIPTION
This PR prevents resetting the stream when a locally-destroyed DataChannel is closed by the remote peer, as it may lead to both peers sending close messages in a loop.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/652