### PR TITLE
Refactor DataChannel close message

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -454,8 +454,8 @@ void PeerConnection::forwardMessage(message_ptr message) {
 	}
 
 	if (!channel) {
-		if (message->type == Message::Control) // ignore control messages like Close
-			return;
+		if (message->type == Message::Reset)
+			return; // ignore
 
 		// Invalid, close the DataChannel
 		PLOG_WARNING << "Got unexpected message on stream " << stream;
@@ -682,7 +682,7 @@ void PeerConnection::assignDataChannels() {
 			stream += 2;
 		}
 
-		PLOG_DEBUG << "Assigning stream " << stream  << " to DataChannel";
+		PLOG_DEBUG << "Assigning stream " << stream << " to DataChannel";
 
 		channel->assignStream(stream);
 		mDataChannels.emplace(std::make_pair(stream, channel));

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -886,11 +886,9 @@ void SctpTransport::processNotification(const union sctp_notification *notify, s
 		// corresponding outgoing stream.
 		// See https://www.rfc-editor.org/rfc/rfc8831.html#section-6.7
 		if (flags & SCTP_STREAM_RESET_INCOMING_SSN) {
-			const byte dataChannelCloseMessage{0x04};
 			for (int i = 0; i < count; ++i) {
 				uint16_t streamId = reset_event.strreset_stream_list[i];
-				recv(make_message(&dataChannelCloseMessage, &dataChannelCloseMessage + 1,
-				                  Message::Control, streamId));
+				recv(make_message(0, Message::Reset, streamId));
 			}
 		}
 		break;


### PR DESCRIPTION
This PR refactors the DataChannel close message to replace the `MESSAGE_CLOSE` control message with the more consistent `Message::Reset`, which is already used to reset the stream in the other direction. It also changes the callback logic for `DataChannel`: the `onClosed` callback is now triggered immediately rather than being delayed if messages are pending (i.e. if the user has not set the `onMessage` callback and did not read all available messages on `onAvailable`).