### PR TITLE
Fixed SCTP unable to write on close

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -405,12 +405,12 @@ void SctpTransport::close() {
 	if (!mSock)
 		return;
 
-	usrsctp_deregister_address(this);
-	Instances->erase(this);
-
 	mProcessor.join();
 	usrsctp_close(mSock);
 	mSock = nullptr;
+
+	usrsctp_deregister_address(this);
+	Instances->erase(this);
 }
 
 bool SctpTransport::send(message_ptr message) {


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/paullouisageneau/libdatachannel/pull/646 which prevents usrsctp from writing while closing, forcing the remote peer to time out.