### PR TITLE
Ignores RFCd RTCP packets: Goodbye/Application Specific

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -506,8 +506,11 @@ void PeerConnection::forwardMedia(message_ptr message) {
 					ssrcs.insert(chunk->ssrc());
 				}
 			} else {
+				// PT=203 == Goodbye
+				// PT=204 == Application Specific
 				// PT=207 == Extended Report
-				if (header->payloadType() != 207) {
+				if (header->payloadType() != 203 && header->payloadType() != 204 &&
+				    header->payloadType() != 207) {
 					COUNTER_UNKNOWN_PACKET_TYPE++;
 				}
 			}


### PR DESCRIPTION
Prevent handling of two other RFCd packets used by browsers.

Fixes #665 