### PR TITLE
Fix race condition creating malformed WebSocket frames

### DIFF
--- a/src/impl/wstransport.cpp
+++ b/src/impl/wstransport.cpp
@@ -333,6 +333,8 @@ void WsTransport::recvFrame(const Frame &frame) {
 }
 
 bool WsTransport::sendFrame(const Frame &frame) {
+	std::lock_guard lock(mSendMutex);
+
 	PLOG_DEBUG << "WebSocket sending frame: opcode=" << int(frame.opcode)
 	           << ", length=" << frame.length;
 

--- a/src/impl/wstransport.hpp
+++ b/src/impl/wstransport.hpp
@@ -77,6 +77,8 @@ private:
 	binary mBuffer;
 	binary mPartial;
 	Opcode mPartialOpcode;
+
+	std::mutex mSendMutex;
 };
 
 } // namespace rtc::impl


### PR DESCRIPTION
This PR fixes the race condition described in https://github.com/paullouisageneau/libdatachannel/issues/664 by synchronizing `WsTransport::sendFrame()`.