### PR TITLE
Add Media Interceptor API

### DIFF
--- a/include/rtc/message.hpp
+++ b/include/rtc/message.hpp
@@ -70,6 +70,14 @@ RTC_CPP_EXPORT message_ptr make_message(binary &&data, Message::Type type = Mess
 
 RTC_CPP_EXPORT message_ptr make_message(message_variant data);
 
+#if RTC_ENABLE_MEDIA
+
+// Reconstructs a message_ptr from an opaque rtcMessage pointer that
+// was allocated by rtcCreateOpaqueMessage().
+message_ptr make_message_from_opaque_ptr(rtcMessage *&&message);
+
+#endif
+
 RTC_CPP_EXPORT message_variant to_variant(Message &&message);
 RTC_CPP_EXPORT message_variant to_variant(const Message &message);
 

--- a/include/rtc/message.hpp
+++ b/include/rtc/message.hpp
@@ -71,6 +71,7 @@ RTC_CPP_EXPORT message_ptr make_message(binary &&data, Message::Type type = Mess
 RTC_CPP_EXPORT message_ptr make_message(message_variant data);
 
 RTC_CPP_EXPORT message_variant to_variant(Message &&message);
+RTC_CPP_EXPORT message_variant to_variant(const Message &message);
 
 } // namespace rtc
 

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -92,6 +92,9 @@ public:
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 
+	void setMediaHandler(shared_ptr<MediaHandler> handler);
+	shared_ptr<MediaHandler> getMediaHandler();
+
 	[[nodiscard]] shared_ptr<DataChannel> createDataChannel(string label, DataChannelInit init = {});
 	void onDataChannel(std::function<void(std::shared_ptr<DataChannel> dataChannel)> callback);
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -135,6 +135,8 @@ typedef void(RTC_API *rtcOpenCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcClosedCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcErrorCallbackFunc)(int id, const char *error, void *ptr);
 typedef void(RTC_API *rtcMessageCallbackFunc)(int id, const char *message, int size, void *ptr);
+typedef void *(RTC_API *rtcInterceptorCallbackFunc)(int pc, const char *message, int size,
+                                                    void *ptr);
 typedef void(RTC_API *rtcBufferedAmountLowCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
 
@@ -302,6 +304,20 @@ typedef struct {
 	const char *msid;    // optional
 	const char *trackId; // optional, track ID used in MSID
 } rtcSsrcForTypeInit;
+
+// Opaque message
+
+// Opaque type used (via rtcMessage*) to reference an rtc::Message
+typedef void* rtcMessage;
+
+// Allocate a new opaque message.
+// Must be explicitly freed by rtcDeleteOpaqueMessage() unless
+// explicitly returned by a media interceptor callback;
+RTC_EXPORT rtcMessage *rtcCreateOpaqueMessage(void *data, int size);
+RTC_EXPORT void rtcDeleteOpaqueMessage(rtcMessage *msg);
+
+// Set MediaInterceptor for peer connection
+RTC_EXPORT int rtcSetMediaInterceptorCallback(int id, rtcInterceptorCallbackFunc cb);
 
 // Set H264PacketizationHandler for track
 RTC_EXPORT int rtcSetH264PacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -281,6 +281,43 @@ createRtpPacketizationConfig(const rtcPacketizationHandlerInit *init) {
 	                                                init->timestamp);
 }
 
+class MediaInterceptor final : public MediaHandler {
+public:
+	using MessageCallback = std::function<void *(void *data, int size)>;
+
+	MediaInterceptor(MessageCallback cb) : incomingCallback(cb) {}
+
+	// Called when there is traffic coming from the peer
+	message_ptr incoming(message_ptr msg) override {
+		// If no callback is provided, just forward the message on
+		if (!incomingCallback) {
+			return msg;
+		}
+
+		auto res = incomingCallback(reinterpret_cast<void *>(msg->data()), msg->size());
+
+		// If a null pointer was returned, drop the incoming message
+		if (res == nullptr) {
+			return nullptr;
+		}
+
+		// If the original data pointer was returned, forward the incoming message
+		if (res == msg->data()) {
+			return msg;
+		}
+
+		// Construct a true message_ptr from the returned opaque pointer
+		return make_message_from_opaque_ptr(std::move(reinterpret_cast<rtcMessage *>(res)));
+	};
+
+	// Called when there is traffic that needs to be sent to the peer
+	// This is a no-op for media interceptors
+	message_ptr outgoing(message_ptr ptr) override { return ptr; };
+
+private:
+	MessageCallback incomingCallback;
+};
+
 #endif // RTC_ENABLE_MEDIA
 
 #if RTC_ENABLE_WEBSOCKET
@@ -1062,6 +1099,39 @@ void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, 
 	}
 
 	description->addSSRC(ssrc, name, msid, trackID);
+}
+
+rtcMessage *rtcCreateOpaqueMessage(void *data, int size) {
+	auto src = reinterpret_cast<std::byte *>(data);
+	auto msg = new Message(src, src + size);
+	// Downgrade the message pointer to the opaque rtcMessage* type
+	return reinterpret_cast<rtcMessage *>(msg);
+}
+
+void rtcDeleteOpaqueMessage(rtcMessage *msg) {
+	// Cast the opaque pointer back to it's true type before deleting
+	delete reinterpret_cast<Message *>(msg);
+}
+
+int rtcSetMediaInterceptorCallback(int pc, rtcInterceptorCallbackFunc cb) {
+	return wrap([&] {
+		auto peerConnection = getPeerConnection(pc);
+
+		if (cb == nullptr) {
+			peerConnection->setMediaHandler(nullptr);
+			return RTC_ERR_SUCCESS;
+		}
+
+		auto interceptor = std::make_shared<MediaInterceptor>([pc, cb](void *data, int size) {
+			if (auto ptr = getUserPointer(pc))
+				return cb(pc, reinterpret_cast<const char *>(data), size, *ptr);
+			return data;
+		});
+
+		peerConnection->setMediaHandler(interceptor);
+
+		return RTC_ERR_SUCCESS;
+	});
 }
 
 int rtcSetH264PacketizationHandler(int tr, const rtcPacketizationHandlerInit *init) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1174,6 +1174,8 @@ void PeerConnection::resetCallbacks() {
 	localCandidateCallback = nullptr;
 	stateChangeCallback = nullptr;
 	gatheringStateChangeCallback = nullptr;
+	signalingStateChangeCallback = nullptr;
+	trackCallback = nullptr;
 }
 
 void PeerConnection::updateTrackSsrcCache(const Description &description) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -349,7 +349,8 @@ void PeerConnection::closeTransports() {
 	if (!changeState(State::Closed))
 		return; // already closed
 
-	// Reset callbacks now that state is changed
+	// Reset intercceptor and callbacks now that state is changed
+	setMediaHandler(nullptr);
 	resetCallbacks();
 
 	// Pass the pointers to a thread, allowing to terminate a transport from its own thread
@@ -474,6 +475,14 @@ void PeerConnection::forwardMessage(message_ptr message) {
 void PeerConnection::forwardMedia(message_ptr message) {
 	if (!message)
 		return;
+
+	auto handler = getMediaHandler();
+
+	if (handler) {
+		message = handler->incoming(message);
+		if (!message)
+			return;
+	}
 
 	// Browsers like to compound their packets with a random SSRC.
 	// we have to do this monstrosity to distribute the report blocks
@@ -1064,6 +1073,18 @@ void PeerConnection::processRemoteCandidate(Candidate candidate) {
 string PeerConnection::localBundleMid() const {
 	std::lock_guard lock(mLocalDescriptionMutex);
 	return mLocalDescription ? mLocalDescription->bundleMid() : "0";
+}
+
+void PeerConnection::setMediaHandler(shared_ptr<MediaHandler> handler) {
+	std::unique_lock lock(mMediaHandlerMutex);
+	if (mMediaHandler)
+		mMediaHandler->onOutgoing(nullptr);
+	mMediaHandler = handler;
+}
+
+shared_ptr<MediaHandler> PeerConnection::getMediaHandler() {
+	std::shared_lock lock(mMediaHandlerMutex);
+	return mMediaHandler;
 }
 
 void PeerConnection::triggerDataChannel(weak_ptr<DataChannel> weakDataChannel) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -963,7 +963,7 @@ void PeerConnection::processLocalDescription(Description description) {
 	}
 
 	mProcessor.enqueue(&PeerConnection::trigger<Description>, shared_from_this(),
-	                   localDescriptionCallback, std::move(description));
+	                   &localDescriptionCallback, std::move(description));
 
 	// Reciprocated tracks might need to be open
 	if (auto dtlsTransport = std::atomic_load(&mDtlsTransport);
@@ -988,7 +988,7 @@ void PeerConnection::processLocalCandidate(Candidate candidate) {
 	mLocalDescription->addCandidate(candidate);
 
 	mProcessor.enqueue(&PeerConnection::trigger<Candidate>, shared_from_this(),
-	                   localCandidateCallback, std::move(candidate));
+	                   &localCandidateCallback, std::move(candidate));
 }
 
 void PeerConnection::processRemoteDescription(Description description) {
@@ -1135,8 +1135,8 @@ bool PeerConnection::changeState(State newState) {
 		auto callback = std::move(stateChangeCallback); // steal the callback
 		callback(State::Closed);                        // call it synchronously
 	} else {
-		mProcessor.enqueue(&PeerConnection::trigger<State>, shared_from_this(), stateChangeCallback,
-		                   newState);
+		mProcessor.enqueue(&PeerConnection::trigger<State>, shared_from_this(),
+		                   &stateChangeCallback, newState);
 	}
 	return true;
 }
@@ -1149,7 +1149,7 @@ bool PeerConnection::changeGatheringState(GatheringState newState) {
 	s << newState;
 	PLOG_INFO << "Changed gathering state to " << s.str();
 	mProcessor.enqueue(&PeerConnection::trigger<GatheringState>, shared_from_this(),
-	                   gatheringStateChangeCallback, newState);
+	                   &gatheringStateChangeCallback, newState);
 
 	return true;
 }
@@ -1162,7 +1162,7 @@ bool PeerConnection::changeSignalingState(SignalingState newState) {
 	s << newState;
 	PLOG_INFO << "Changed signaling state to " << s.str();
 	mProcessor.enqueue(&PeerConnection::trigger<SignalingState>, shared_from_this(),
-	                   signalingStateChangeCallback, newState);
+	                   &signalingStateChangeCallback, newState);
 
 	return true;
 }

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -105,8 +105,8 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void resetCallbacks();
 
 	// Helper method for asynchronous callback invocation
-	template <typename... Args> void trigger(synchronized_callback<Args...> &cb, Args... args) {
-		cb(std::move(args...));
+	template <typename... Args> void trigger(synchronized_callback<Args...> *cb, Args... args) {
+		(*cb)(std::move(args...));
 	}
 
 	const Configuration config;

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -89,6 +89,9 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void processRemoteCandidate(Candidate candidate);
 	string localBundleMid() const;
 
+	void setMediaHandler(shared_ptr<MediaHandler> handler);
+	shared_ptr<MediaHandler> getMediaHandler();
+
 	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel);
 	void triggerTrack(weak_ptr<Track> weakTrack);
 
@@ -134,6 +137,10 @@ private:
 	optional<Description> mLocalDescription, mRemoteDescription;
 	optional<Description> mCurrentLocalDescription;
 	mutable std::mutex mLocalDescriptionMutex, mRemoteDescriptionMutex;
+
+	shared_ptr<MediaHandler> mMediaHandler;
+
+	mutable std::shared_mutex mMediaHandlerMutex;
 
 	shared_ptr<IceTransport> mIceTransport;
 	shared_ptr<DtlsTransport> mDtlsTransport;

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -73,16 +73,24 @@ void Track::close() {
 }
 
 optional<message_variant> Track::receive() {
-	if (auto next = mRecvQueue.tryPop())
-		return to_variant(std::move(**next));
-
+	if (auto next = mRecvQueue.tryPop()) {
+		message_ptr message = *next;
+		if (message->type == Message::Control)
+			return to_variant(**next); // The same message may be frowarded into multiple Tracks
+		else
+			return to_variant(std::move(*message));
+	}
 	return nullopt;
 }
 
 optional<message_variant> Track::peek() {
-	if (auto next = mRecvQueue.peek())
-		return to_variant(std::move(**next));
-
+	if (auto next = mRecvQueue.peek()) {
+		message_ptr message = *next;
+		if (message->type == Message::Control)
+			return to_variant(**next); // The same message may be forwarded into multiple Tracks
+		else
+			return to_variant(std::move(*message));
+	}
 	return nullopt;
 }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -57,4 +57,13 @@ message_variant to_variant(Message &&message) {
 	}
 }
 
+message_variant to_variant(const Message &message) {
+	switch (message.type) {
+	case Message::String:
+		return string(reinterpret_cast<const char *>(message.data()), message.size());
+	default:
+		return message;
+	}
+}
+
 } // namespace rtc

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -48,6 +48,15 @@ message_ptr make_message(message_variant data) {
 	    std::move(data));
 }
 
+#if RTC_ENABLE_MEDIA
+
+message_ptr make_message_from_opaque_ptr(rtcMessage *&&message) {
+	auto ptr = std::unique_ptr<Message>(reinterpret_cast<Message *>(message));
+	return message_ptr(std::move(ptr));
+}
+
+#endif
+
 message_variant to_variant(Message &&message) {
 	switch (message.type) {
 	case Message::String:

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -249,6 +249,12 @@ void PeerConnection::addRemoteCandidate(Candidate candidate) {
 	impl()->processRemoteCandidate(std::move(candidate));
 }
 
+void PeerConnection::setMediaHandler(shared_ptr<MediaHandler> handler) {
+	impl()->setMediaHandler(std::move(handler));
+};
+
+shared_ptr<MediaHandler> PeerConnection::getMediaHandler() { return impl()->getMediaHandler(); };
+
 optional<string> PeerConnection::localAddress() const {
 	auto iceTransport = impl()->getIceTransport();
 	return iceTransport ? iceTransport->getLocalAddress() : nullopt;


### PR DESCRIPTION
This PR introduces a new "media interceptor" API (for both C and C++). This essentially allows developers to intercept media forwarding and process it themselves, optionally allowing libdatachannel to continue forwarding the media packet afterwards. This is required for users to be able to implement transport congestion control logic, etc.

Additionally the synchronized callbacks have been refactored to allow them to provide actual return types.