### PR TITLE
Fix compilation with VS 2019

### DIFF
--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -21,6 +21,7 @@
 
 #include "impl/internals.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <exception>
 #include <mutex>

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -26,6 +26,8 @@
 #include "rtc/datachannel.hpp"
 #include "rtc/track.hpp"
 
+#include <algorithm>
+
 #ifdef _WIN32
 #include <winsock2.h>
 #else
@@ -259,8 +261,8 @@ void DataChannel::incoming(message_ptr message) {
 	}
 }
 
-OutgoingDataChannel::OutgoingDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream,
-                                             string label, string protocol, Reliability reliability)
+OutgoingDataChannel::OutgoingDataChannel(weak_ptr<PeerConnection> pc, uint16_t stream, string label,
+                                         string protocol, Reliability reliability)
     : DataChannel(pc, stream, std::move(label), std::move(protocol), std::move(reliability)) {}
 
 OutgoingDataChannel::~OutgoingDataChannel() {}

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -20,10 +20,10 @@
 #include "icetransport.hpp"
 #include "internals.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <exception>
-#include <iostream>
 
 #if !USE_GNUTLS
 #ifdef _WIN32

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -33,9 +33,11 @@
 #include "dtlssrtptransport.hpp"
 #endif
 
+#include <algorithm>
 #include <array>
 #include <iomanip>
 #include <set>
+#include <sstream>
 #include <thread>
 
 using namespace std::placeholders;

--- a/src/impl/pollservice.cpp
+++ b/src/impl/pollservice.cpp
@@ -21,6 +21,7 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
+#include <algorithm>
 #include <cassert>
 
 namespace rtc::impl {

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -21,6 +21,7 @@
 #include "internals.hpp"
 #include "logcounter.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstdarg>
 #include <cstdio>

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -21,10 +21,10 @@
 
 #if RTC_ENABLE_WEBSOCKET
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <exception>
-#include <iostream>
 
 using namespace std::chrono;
 


### PR DESCRIPTION
This PR explicitly adds the `algorithm` include where `std::min` or `std::max` are used.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/679