### PR TITLE
Fix race condition during destruction / deletion of PeerConnections.

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -73,11 +73,6 @@ PeerConnection::PeerConnection(Configuration config_)
 	}
 }
 
-PeerConnection::~PeerConnection() {
-	PLOG_VERBOSE << "Destroying PeerConnection";
-	mProcessor.join();
-}
-
 void PeerConnection::close() {
 	PLOG_VERBOSE << "Closing PeerConnection";
 
@@ -88,6 +83,11 @@ void PeerConnection::close() {
 	mProcessor.enqueue(&PeerConnection::closeTracks, shared_from_this());
 
 	closeTransports();
+
+	// We must join all tasks here, in order to ensure all references to 'this' are freed.
+	// otherwise the destructor will never be called, causing async callbacks to fire after the base
+	// PeerConnection was freed.
+	mProcessor.join();
 }
 
 optional<Description> PeerConnection::localDescription() const {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -83,11 +83,6 @@ void PeerConnection::close() {
 	mProcessor.enqueue(&PeerConnection::closeTracks, shared_from_this());
 
 	closeTransports();
-
-	// We must join all tasks here, in order to ensure all references to 'this' are freed.
-	// otherwise the destructor will never be called, causing async callbacks to fire after the base
-	// PeerConnection was freed.
-	mProcessor.join();
 }
 
 optional<Description> PeerConnection::localDescription() const {
@@ -1165,6 +1160,11 @@ bool PeerConnection::changeSignalingState(SignalingState newState) {
 	                   signalingStateChangeCallback, newState);
 
 	return true;
+}
+
+void PeerConnection::join() {
+	// Allows the wrapping PC to wait for callbacks to finish in it's dtor.
+	mProcessor.join();
 }
 
 void PeerConnection::resetCallbacks() {

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -102,6 +102,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	bool changeGatheringState(GatheringState newState);
 	bool changeSignalingState(SignalingState newState);
 
+	void join();
 	void resetCallbacks();
 
 	// Helper method for asynchronous callback invocation

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -43,7 +43,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	using SignalingState = rtc::PeerConnection::SignalingState;
 
 	PeerConnection(Configuration config_);
-	~PeerConnection();
+	~PeerConnection() = default;
 
 	void close();
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -53,6 +53,10 @@ PeerConnection::~PeerConnection() {
 	} catch (const std::exception &e) {
 		PLOG_ERROR << e.what();
 	}
+
+	// Force callbacks to run in impl() so that the shared references to it will free
+	// before our dtor ends, otherwise it won't be freed until after this dtor runs.
+	impl()->join();
 }
 
 void PeerConnection::close() { impl()->close(); }


### PR DESCRIPTION
Add mProcessor.join() to impl/PeerConnection::close(). Reset impl/PeerConnection dtor to default.

This fixes a race condition that will occur when the shared_pointer of the impl() PeerConnection has more use_count than 1 at the time of the destruction of the wrapping PeerConnection, causing callbacks to still fire after the wrapper is dropped, which in turn is due to the fact that the impl() PeerConnection's destructor is never called. Since the wrapping PeerConnection is the only way to initialize the impl() PeerConnection, it is safe to only join in close(), which is always called upon wrapping PeerConnection dtor.