### PR TITLE
Fix missing reset for signaling state and track callbacks

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1193,6 +1193,8 @@ void PeerConnection::resetCallbacks() {
 	localCandidateCallback = nullptr;
 	stateChangeCallback = nullptr;
 	gatheringStateChangeCallback = nullptr;
+	signalingStateChangeCallback = nullptr;
+	trackCallback = nullptr;
 }
 
 } // namespace rtc::impl


### PR DESCRIPTION
`signalingStateChangeCallback` and `trackCallback` were not reset properly in `impl::PeerConnection::resetCallbacks()`.