### PR TITLE
Fix empty messages received on Track

### DIFF
--- a/include/rtc/message.hpp
+++ b/include/rtc/message.hpp
@@ -71,6 +71,7 @@ RTC_CPP_EXPORT message_ptr make_message(binary &&data, Message::Type type = Mess
 RTC_CPP_EXPORT message_ptr make_message(message_variant data);
 
 RTC_CPP_EXPORT message_variant to_variant(Message &&message);
+RTC_CPP_EXPORT message_variant to_variant(const Message &message);
 
 } // namespace rtc
 

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -73,16 +73,24 @@ void Track::close() {
 }
 
 optional<message_variant> Track::receive() {
-	if (auto next = mRecvQueue.tryPop())
-		return to_variant(std::move(**next));
-
+	if (auto next = mRecvQueue.tryPop()) {
+		message_ptr message = *next;
+		if (message->type == Message::Control)
+			return to_variant(**next); // The same message may be frowarded into multiple Tracks
+		else
+			return to_variant(std::move(*message));
+	}
 	return nullopt;
 }
 
 optional<message_variant> Track::peek() {
-	if (auto next = mRecvQueue.peek())
-		return to_variant(std::move(**next));
-
+	if (auto next = mRecvQueue.peek()) {
+		message_ptr message = *next;
+		if (message->type == Message::Control)
+			return to_variant(**next); // The same message may be forwarded into multiple Tracks
+		else
+			return to_variant(std::move(*message));
+	}
 	return nullopt;
 }
 

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -57,4 +57,13 @@ message_variant to_variant(Message &&message) {
 	}
 }
 
+message_variant to_variant(const Message &message) {
+	switch (message.type) {
+	case Message::String:
+		return string(reinterpret_cast<const char *>(message.data()), message.size());
+	default:
+		return message;
+	}
+}
+
 } // namespace rtc


### PR DESCRIPTION
This PR fixes `Track::receive()` always moving the message data whereas control messages might be forwarded into multiple tracks, which could create empty messages.