### PR TITLE
Fix callbacks called after close

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -981,7 +981,7 @@ void PeerConnection::processLocalDescription(Description description) {
 	}
 
 	mProcessor.enqueue(&PeerConnection::trigger<Description>, shared_from_this(),
-	                   localDescriptionCallback, std::move(description));
+	                   &localDescriptionCallback, std::move(description));
 
 	// Reciprocated tracks might need to be open
 	if (auto dtlsTransport = std::atomic_load(&mDtlsTransport);
@@ -1006,7 +1006,7 @@ void PeerConnection::processLocalCandidate(Candidate candidate) {
 	mLocalDescription->addCandidate(candidate);
 
 	mProcessor.enqueue(&PeerConnection::trigger<Candidate>, shared_from_this(),
-	                   localCandidateCallback, std::move(candidate));
+	                   &localCandidateCallback, std::move(candidate));
 }
 
 void PeerConnection::processRemoteDescription(Description description) {
@@ -1154,8 +1154,8 @@ bool PeerConnection::changeState(State newState) {
 		auto callback = std::move(stateChangeCallback); // steal the callback
 		callback(State::Closed);                        // call it synchronously
 	} else {
-		mProcessor.enqueue(&PeerConnection::trigger<State>, shared_from_this(), stateChangeCallback,
-		                   newState);
+		mProcessor.enqueue(&PeerConnection::trigger<State>, shared_from_this(),
+		                   &stateChangeCallback, newState);
 	}
 	return true;
 }
@@ -1168,7 +1168,7 @@ bool PeerConnection::changeGatheringState(GatheringState newState) {
 	s << newState;
 	PLOG_INFO << "Changed gathering state to " << s.str();
 	mProcessor.enqueue(&PeerConnection::trigger<GatheringState>, shared_from_this(),
-	                   gatheringStateChangeCallback, newState);
+	                   &gatheringStateChangeCallback, newState);
 
 	return true;
 }
@@ -1181,7 +1181,7 @@ bool PeerConnection::changeSignalingState(SignalingState newState) {
 	s << newState;
 	PLOG_INFO << "Changed signaling state to " << s.str();
 	mProcessor.enqueue(&PeerConnection::trigger<SignalingState>, shared_from_this(),
-	                   signalingStateChangeCallback, newState);
+	                   &signalingStateChangeCallback, newState);
 
 	return true;
 }

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -105,8 +105,8 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void resetCallbacks();
 
 	// Helper method for asynchronous callback invocation
-	template <typename... Args> void trigger(synchronized_callback<Args...> &cb, Args... args) {
-		cb(std::move(args...));
+	template <typename... Args> void trigger(synchronized_callback<Args...> *cb, Args... args) {
+		(*cb)(std::move(args...));
 	}
 
 	const Configuration config;


### PR DESCRIPTION
Some callbacks could be called after `PeerConnection::close()` because they were copied when enqueued. This PR changes `PeerConnection::trigger()` to take a pointer to the callback so it is never copied.