### PR TITLE
Fix rtcSendMessage return value

### DIFF
--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -693,13 +693,10 @@ int rtcSendMessage(int id, const char *data, int size) {
 		if (size >= 0) {
 			auto b = reinterpret_cast<const byte *>(data);
 			channel->send(binary(b, b + size));
-			return size;
 		} else {
-			string str(data);
-			int len = int(str.size());
-			channel->send(std::move(str));
-			return len;
+			channel->send(string(data));
 		}
+		return RTC_ERR_SUCCESS;
 	});
 }
 


### PR DESCRIPTION
In the C API, `rtcSendMessage` should return `RTC_ERR_SUCCESS` on success, as indicated in the API reference.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/722