### PR TITLE
Add a configuration option to force track allocation

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -85,6 +85,7 @@ struct RTC_CPP_EXPORT Configuration {
 	bool enableIceTcp = false;    // libnice only
 	bool enableIceUdpMux = false; // libjuice only
 	bool disableAutoNegotiation = false;
+	bool forceMediaTransport = false;
 
 	// Port range
 	uint16_t portRangeBegin = 1024;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -239,7 +239,8 @@ shared_ptr<DtlsTransport> PeerConnection::initDtlsTransport() {
 		    };
 
 		shared_ptr<DtlsTransport> transport;
-		if (auto local = localDescription(); local && local->hasAudioOrVideo()) {
+		auto local = localDescription();
+		if (config.forceMediaTransport || (local && local->hasAudioOrVideo())) {
 #if RTC_ENABLE_MEDIA
 			PLOG_INFO << "This connection requires media support";
 


### PR DESCRIPTION
When creating a `PeerConnection` without a track, libdatachannel will not initialize the SRTP transport (as an optimization, since tracks are apparently not going to be used).

But that's a problem if a track is added dynamically later, with `peer_connection->addTrack()`. At the moment, it is just ignored. This PR fixes this behavior in two ways:

* It adds a `Configuration` option to force the SRTP initialization (as a way to say "Don't optimize, I _will_ use tracks").
* It throws an exception if `addTrack()` is called in the situation where it would be ignored.

Note that `Configuration.forceTrackAllocation` defaults to `false`, such that it does not change the current libdatachannel behavior.

This is the first part discussed in https://github.com/paullouisageneau/libdatachannel/issues/730.