### PR TITLE
Add operator<< to Description::Direction

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -329,5 +329,6 @@ private:
 RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, const rtc::Description &description);
 RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, rtc::Description::Type type);
 RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, rtc::Description::Role role);
+RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, const rtc::Description::Direction &direction);
 
 #endif

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1259,3 +1259,25 @@ std::ostream &operator<<(std::ostream &out, rtc::Description::Role role) {
 	}
 	return out;
 }
+
+std::ostream &operator<<(std::ostream &out, const rtc::Description::Direction &direction) {
+	switch (direction) {
+	case rtc::Description::Direction::RecvOnly:
+		out << "RecvOnly";
+		break;
+	case rtc::Description::Direction::SendOnly:
+		out << "SendOnly";
+		break;
+	case rtc::Description::Direction::SendRecv:
+		out << "SendRecv";
+		break;
+	case rtc::Description::Direction::Inactive:
+		out << "Inactive";
+		break;
+	case rtc::Description::Direction::Unknown:
+	default:
+		out << "Unknown";
+		break;
+	}
+	return out;
+}


### PR DESCRIPTION
Add `operator<<` to `Description::Direction`. It seems like it makes sense to have this operator too, similar to the others next to it.