### PR TITLE
Fix incoming track mechanism

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -717,7 +717,7 @@ shared_ptr<Track> PeerConnection::emplaceTrack(Description::Media description) {
 		mTrackLines.emplace_back(track);
 	}
 
-	if (description.isRemoved())
+	if (track->description().isRemoved())
 		track->close();
 
 	return track;

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -77,7 +77,6 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void remoteCloseDataChannels();
 
 	shared_ptr<Track> emplaceTrack(Description::Media description);
-	void incomingTrack(Description::Media description);
 	void iterateTracks(std::function<void(shared_ptr<Track> track)> func);
 	void openTracks();
 	void closeTracks();


### PR DESCRIPTION
This PR fixes the incoming track mechanism:
- The incoming track handling is moved inline to simply it and prevent unlocking the tracks mutex
- Allow the track description to be modified in the `onTrack` callback (for instance to set a locally-sent SSRC)