### PR TITLE
Add configuration option to force media transport in C API

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -84,6 +84,7 @@ typedef struct {
 	bool enableIceTcp;
 	bool enableIceUdpMux;
 	bool disableAutoNegotiation;
+	bool forceMediaTransport;
 	uint16_t portRangeBegin;
 	uint16_t portRangeEnd;
 	int mtu;
@@ -105,6 +106,7 @@ Arguments:
   - `enableIceTcp`: if true, generate TCP candidates for ICE (ignored with libjuice as ICE backend)
   - `enableIceUdpMux`: if true, connections are multiplexed on the same UDP port (should be combined with `portRangeBegin` and `portRangeEnd`, ignored with libnice as ICE backend)
   - `disableAutoNegotiation`: if true, the user is responsible for calling `rtcSetLocalDescription` after creating a Data Channel and after setting the remote description
+  - `forceMediaTransport`: if true, the connection allocates the SRTP media transport even if no tracks are present (necessary to add tracks during later renegotiation)
   - `portRangeBegin` (optional): first port (included) of the allowed local port range (0 if unused)
   - `portRangeEnd` (optional): last port (included) of the allowed local port (0 if unused)
   - `mtu` (optional): manually set the Maximum Transfer Unit (MTU) for the connection (0 if automatic)

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -159,6 +159,7 @@ typedef struct {
 	bool enableIceTcp;    // libnice only
 	bool enableIceUdpMux; // libjuice only
 	bool disableAutoNegotiation;
+	bool forceMediaTransport;
 	uint16_t portRangeBegin; // 0 means automatic
 	uint16_t portRangeEnd;   // 0 means automatic
 	int mtu;                 // <= 0 means automatic

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -87,6 +87,7 @@ typedef struct {
 	bool enableIceTcp;
 	bool enableIceUdpMux;
 	bool disableAutoNegotiation;
+	bool forceMediaTransport;
 	uint16_t portRangeBegin;
 	uint16_t portRangeEnd;
 	int mtu;
@@ -108,6 +109,7 @@ Arguments:
   - `enableIceTcp`: if true, generate TCP candidates for ICE (ignored with libjuice as ICE backend)
   - `enableIceUdpMux`: if true, connections are multiplexed on the same UDP port (should be combined with `portRangeBegin` and `portRangeEnd`, ignored with libnice as ICE backend)
   - `disableAutoNegotiation`: if true, the user is responsible for calling `rtcSetLocalDescription` after creating a Data Channel and after setting the remote description
+  - `forceMediaTransport`: if true, the connection allocates the SRTP media transport even if no tracks are present (necessary to add tracks during later renegotiation)
   - `portRangeBegin` (optional): first port (included) of the allowed local port range (0 if unused)
   - `portRangeEnd` (optional): last port (included) of the allowed local port (0 if unused)
   - `mtu` (optional): manually set the Maximum Transfer Unit (MTU) for the connection (0 if automatic)

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -395,6 +395,7 @@ int rtcCreatePeerConnection(const rtcConfiguration *config) {
 		c.enableIceTcp = config->enableIceTcp;
 		c.enableIceUdpMux = config->enableIceUdpMux;
 		c.disableAutoNegotiation = config->disableAutoNegotiation;
+		c.forceMediaTransport = config->forceMediaTransport;
 
 		if (config->mtu > 0)
 			c.mtu = size_t(config->mtu);


### PR DESCRIPTION
This PR adds a `forceMediaTransport` flag to C API.

Follow-up on https://github.com/paullouisageneau/libdatachannel/pull/733