### PR TITLE
Support for nal start codes preceded by a zero

### DIFF
--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -63,12 +63,16 @@ NalUnitStartSequenceMatch StartSequenceMatchSucc(NalUnitStartSequenceMatch match
 	case NUSM_secondZero:
 		if (byte == 0x00 && detectLong) {
 			return NUSM_thirdZero;
+		} else if (byte == 0x00 && detectShort) {
+			return NUSM_secondZero;
 		} else if (byte == 0x01 && detectShort) {
 			return NUSM_shortMatch;
 		}
 		break;
 	case NUSM_thirdZero:
-		if (byte == 0x01 && detectLong) {
+		if (byte == 0x00 && detectLong) {
+			return NUSM_thirdZero;
+		} else if (byte == 0x01 && detectLong) {
 			return NUSM_longMatch;
 		}
 		break;


### PR DESCRIPTION
This PR address an issue in the StartSequenceMatchSucc which didn't correctly identify long/short nal start sequences that were preceded by a zero.

With a byte sequence of 0x00, 0x00, 0x00, 0x0, 0x01:
The unfixed code returns : NUSM_firstZero, NUSM_secondZero, NUSM_thirdZero, NUSM_noMatch

This change will result in the sequence:
NUSM_firstZero, NUSM_secondZero, NUSM_thirdZero, NUSM_thirdZero, NUSM_longMatch

Thus allowing the 3/4 byte sequence detection to continue to shift with any number of preceding zeroes.