### PR TITLE
Deprecate start time mechanism for RTP packetization

### DIFF
--- a/examples/streamer/fileparser.cpp
+++ b/examples/streamer/fileparser.cpp
@@ -21,10 +21,15 @@
 
 using namespace std;
 
-FileParser::FileParser(string directory, string extension, uint32_t samplesPerSecond, bool loop): sampleDuration_us(1000 * 1000 / samplesPerSecond), StreamSource() {
+FileParser::FileParser(string directory, string extension, uint32_t samplesPerSecond, bool loop) {
     this->directory = directory;
     this->extension = extension;
     this->loop = loop;
+    this->sampleDuration_us = 1000 * 1000 / samplesPerSecond;
+}
+
+FileParser::~FileParser() {
+	stop();
 }
 
 void FileParser::start() {
@@ -33,7 +38,8 @@ void FileParser::start() {
 }
 
 void FileParser::stop() {
-    StreamSource::stop();
+    sample = {};
+    sampleTime_us = 0;
     counter = -1;
 }
 
@@ -57,3 +63,16 @@ void FileParser::loadNextSample() {
     sample = *reinterpret_cast<vector<byte> *>(&fileContents);
     sampleTime_us += sampleDuration_us;
 }
+
+rtc::binary FileParser::getSample() {
+	return sample;
+}
+
+uint64_t FileParser::getSampleTime_us() {
+	return sampleTime_us;
+}
+
+uint64_t FileParser::getSampleDuration_us() {
+	return sampleDuration_us;
+}
+

--- a/examples/streamer/fileparser.hpp
+++ b/examples/streamer/fileparser.hpp
@@ -26,15 +26,23 @@
 class FileParser: public StreamSource {
     std::string directory;
     std::string extension;
+    uint64_t sampleDuration_us;
+    uint64_t sampleTime_us = 0;
     uint32_t counter = -1;
     bool loop;
     uint64_t loopTimestampOffset = 0;
+protected:
+    rtc::binary sample = {};
 public:
-    const uint64_t sampleDuration_us;
-    virtual void start();
-    virtual void stop();
     FileParser(std::string directory, std::string extension, uint32_t samplesPerSecond, bool loop);
-    virtual void loadNextSample();
+    virtual ~FileParser();
+    virtual void start() override;
+    virtual void stop() override;
+    virtual void loadNextSample() override;
+
+    rtc::binary getSample() override;
+    uint64_t getSampleTime_us() override;
+    uint64_t getSampleDuration_us() override;
 };
 
 #endif /* fileparser_hpp */

--- a/examples/streamer/helpers.hpp
+++ b/examples/streamer/helpers.hpp
@@ -25,9 +25,9 @@
 
 struct ClientTrackData {
     std::shared_ptr<rtc::Track> track;
-	std::shared_ptr<rtc::RtcpSrReporter> sender;
+    std::shared_ptr<rtc::RtcpSrReporter> sender;
 
-	ClientTrackData(std::shared_ptr<rtc::Track> track, std::shared_ptr<rtc::RtcpSrReporter> sender);
+    ClientTrackData(std::shared_ptr<rtc::Track> track, std::shared_ptr<rtc::RtcpSrReporter> sender);
 };
 
 struct Client {
@@ -43,9 +43,12 @@ struct Client {
     }
     std::optional<std::shared_ptr<ClientTrackData>> video;
     std::optional<std::shared_ptr<ClientTrackData>> audio;
-    std::optional<std::shared_ptr<rtc::DataChannel>> dataChannel{};
+    std::optional<std::shared_ptr<rtc::DataChannel>> dataChannel;
+
     void setState(State state);
     State getState();
+
+    uint32_t rtpStartTimestamp = 0;
 
 private:
     std::shared_mutex _mutex;

--- a/examples/streamer/stream.cpp
+++ b/examples/streamer/stream.cpp
@@ -39,16 +39,8 @@ void usleep(__int64 usec)
 #include <unistd.h>
 #endif
 
-void StreamSource::stop() {
-    sampleTime_us = 0;
-    sample = {};
-}
-
-StreamSource::~StreamSource() {
-    stop();
-}
-
-Stream::Stream(std::shared_ptr<StreamSource> video, std::shared_ptr<StreamSource> audio): std::enable_shared_from_this<Stream>(), video(video), audio(audio) { }
+Stream::Stream(std::shared_ptr<StreamSource> video, std::shared_ptr<StreamSource> audio):
+	std::enable_shared_from_this<Stream>(), video(video), audio(audio) { }
 
 Stream::~Stream() {
     stop();

--- a/examples/streamer/stream.hpp
+++ b/examples/streamer/stream.hpp
@@ -24,19 +24,15 @@
 
 class StreamSource {
 protected:
-    uint64_t sampleTime_us = 0;
-    rtc::binary sample = {};
 
 public:
-    StreamSource() { }
     virtual void start() = 0;
-    virtual void stop();
+    virtual void stop() = 0;
     virtual void loadNextSample() = 0;
 
-    inline uint64_t getSampleTime_us() { return sampleTime_us; }
-    inline rtc::binary getSample() { return sample; }
-
-    ~StreamSource();
+    virtual uint64_t getSampleTime_us() = 0;
+    virtual uint64_t getSampleDuration_us() = 0;
+	virtual rtc::binary getSample() = 0;
 };
 
 class Stream: std::enable_shared_from_this<Stream> {
@@ -48,12 +44,14 @@ class Stream: std::enable_shared_from_this<Stream> {
 public:
     const std::shared_ptr<StreamSource> audio;
     const std::shared_ptr<StreamSource> video;
+
     Stream(std::shared_ptr<StreamSource> video, std::shared_ptr<StreamSource> audio);
+    ~Stream();
+
     enum class StreamSourceType {
         Audio,
         Video
     };
-    ~Stream();
 
 private:
     rtc::synchronized_callback<StreamSourceType, uint64_t, rtc::binary> sampleHandler;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -293,13 +293,6 @@ typedef struct {
 } rtcPacketizationHandlerInit;
 
 typedef struct {
-	double seconds;     // Start time in seconds
-	bool since1970;     // true if seconds since 1970
-	                    // false if seconds since 1900
-	uint32_t timestamp; // Start timestamp
-} rtcStartTime;
-
-typedef struct {
 	uint32_t ssrc;
 	const char *name;    // optional
 	const char *msid;    // optional
@@ -318,12 +311,6 @@ RTC_EXPORT int rtcChainRtcpSrReporter(int tr);
 // Chain RtcpNackResponder to handler chain for given track
 RTC_EXPORT int rtcChainRtcpNackResponder(int tr, unsigned int maxStoredPacketsCount);
 
-/// Set start time for RTP stream
-RTC_EXPORT int rtcSetRtpConfigurationStartTime(int id, const rtcStartTime *startTime);
-
-// Start stats recording for RTCP Sender Reporter
-RTC_EXPORT int rtcStartRtcpSenderReporterRecording(int id);
-
 // Transform seconds to timestamp using track's clock rate, result is written to timestamp
 RTC_EXPORT int rtcTransformSecondsToTimestamp(int id, double seconds, uint32_t *timestamp);
 
@@ -332,9 +319,6 @@ RTC_EXPORT int rtcTransformTimestampToSeconds(int id, uint32_t timestamp, double
 
 // Get current timestamp, result is written to timestamp
 RTC_EXPORT int rtcGetCurrentTrackTimestamp(int id, uint32_t *timestamp);
-
-// Get start timestamp for track identified by given id, result is written to timestamp
-RTC_EXPORT int rtcGetTrackStartTimestamp(int id, uint32_t *timestamp);
 
 // Set RTP timestamp for track identified by given id
 RTC_EXPORT int rtcSetTrackRtpTimestamp(int id, uint32_t timestamp);

--- a/include/rtc/rtcpsrreporter.hpp
+++ b/include/rtc/rtcpsrreporter.hpp
@@ -28,23 +28,10 @@
 namespace rtc {
 
 class RTC_CPP_EXPORT RtcpSrReporter final : public MediaHandlerElement {
-	bool needsToReport = false;
-
-	uint32_t packetCount = 0;
-	uint32_t payloadOctets = 0;
-	double timeOffset = 0;
-
-	uint32_t mPreviousReportedTimestamp = 0;
-
 	void addToReport(RtpHeader *rtp, uint32_t rtpSize);
 	message_ptr getSenderReport(uint32_t timestamp);
 
 public:
-	static uint64_t secondsToNTP(double seconds);
-
-	/// Timestamp of previous sender report
-	const uint32_t &previousReportedTimestamp = mPreviousReportedTimestamp;
-
 	/// RTP configuration
 	const shared_ptr<RtpPacketizationConfig> rtpConfig;
 
@@ -53,14 +40,18 @@ public:
 	ChainedOutgoingProduct processOutgoingBinaryMessage(ChainedMessagesProduct messages,
 	                                                    message_ptr control) override;
 
-	/// Set `needsToReport` flag. Sender report will be sent before next RTP packet with same
-	/// timestamp.
+	uint32_t lastReportedTimestamp() const;
 	void setNeedsToReport();
 
-	/// Set offset to compute NTS for RTCP SR packets. Offset represents relation between real start
-	/// time and timestamp of the stream in RTP packets
-	/// @note `time_offset = rtpConfig->startTime - rtpConfig->timestampToSeconds(rtpConfig->timestamp)`
-	void startRecording();
+	// deprecated, do not call
+	[[deprecated]] void startRecording();
+	[[deprecated]] uint32_t previousReportedTimestamp() const { return lastReportedTimestamp(); }
+
+private:
+	uint32_t mPacketCount = 0;
+	uint32_t mPayloadOctets = 0;
+	uint32_t mLastReportedTimestamp = 0;
+	bool mNeedsToReport = false;
 };
 
 } // namespace rtc

--- a/include/rtc/rtppacketizationconfig.hpp
+++ b/include/rtc/rtppacketizationconfig.hpp
@@ -25,26 +25,23 @@
 
 namespace rtc {
 
-/// RTP configuration used in packetization process
+// RTP configuration used in packetization process
 class RTC_CPP_EXPORT RtpPacketizationConfig {
-	uint32_t mStartTimestamp = 0;
-	double mStartTime = 0;
-	RtpPacketizationConfig(const RtpPacketizationConfig &) = delete;
-
 public:
 	const SSRC ssrc;
 	const std::string cname;
 	const uint8_t payloadType;
 	const uint32_t clockRate;
-	const double &startTime = mStartTime;
-	const uint32_t &startTimestamp = mStartTimestamp;
 	const uint8_t videoOrientationId;
 
-	/// current sequence number
+	// current sequence number
 	uint16_t sequenceNumber;
 
-	/// current timestamp
+	// current timestamp
 	uint32_t timestamp;
+
+	// start timestamp
+	uint32_t startTimestamp;
 
 	/// Current video orientation
 	///
@@ -66,34 +63,17 @@ public:
 	///   3 - 270 degrees
 	uint8_t videoOrientation = 0;
 
-	// For backward compatibility, do not use
-	const double &startTime_s = mStartTime;
-
-	enum class EpochStart : uint64_t {
-		T1970 = 2208988800, // number of seconds between 1970 and 1900
-		T1900 = 0
-	};
-
-	/// Creates relation between time and timestamp mapping given start time and start timestamp
-	/// @param startTime Start time of the stream
-	/// @param epochStart Type of used epoch
-	/// @param startTimestamp Corresponding timestamp for given start time (current timestamp will
-	/// be used if value is nullopt)
-	void setStartTime(double startTime, EpochStart epochStart,
-	                  optional<uint32_t> startTimestamp = std::nullopt);
-
 	/// Construct RTP configuration used in packetization process
 	/// @param ssrc SSRC of source
 	/// @param cname CNAME of source
 	/// @param payloadType Payload type of source
 	/// @param clockRate Clock rate of source used in timestamps
-	/// @param sequenceNumber Initial sequence number of RTP packets (random number is choosed if
 	/// nullopt)
-	/// @param timestamp Initial timastamp of RTP packets (random number is choosed if nullopt)
+	/// @param videoOrientationId Video orientation (see above)
 	RtpPacketizationConfig(SSRC ssrc, std::string cname, uint8_t payloadType, uint32_t clockRate,
-	                       optional<uint16_t> sequenceNumber = std::nullopt,
-	                       optional<uint32_t> timestamp = std::nullopt,
 	                       uint8_t videoOrientationId = 0);
+
+	RtpPacketizationConfig(const RtpPacketizationConfig &) = delete;
 
 	/// Convert timestamp to seconds
 	/// @param timestamp Timestamp
@@ -112,6 +92,15 @@ public:
 	/// Convert seconds to timestamp
 	/// @param seconds Number of seconds
 	uint32_t secondsToTimestamp(double seconds);
+
+	// deprecated, do not use
+	double startTime = 0.;
+	enum class EpochStart : uint64_t {
+		T1970 = 2208988800, // number of seconds between 1970 and 1900
+		T1900 = 0
+	};
+	[[deprecated]] void setStartTime(double startTime, EpochStart epochStart,
+	                                 optional<uint32_t> startTimestamp = std::nullopt);
 };
 
 } // namespace rtc

--- a/src/rtppacketizationconfig.cpp
+++ b/src/rtppacketizationconfig.cpp
@@ -25,35 +25,13 @@
 namespace rtc {
 
 RtpPacketizationConfig::RtpPacketizationConfig(SSRC ssrc, string cname, uint8_t payloadType,
-                                               uint32_t clockRate,
-                                               optional<uint16_t> sequenceNumber,
-                                               optional<uint32_t> timestamp,
-                                               uint8_t videoOrientationId)
-    : ssrc(ssrc), cname(cname), payloadType(payloadType), clockRate(clockRate), videoOrientationId(videoOrientationId) {
+                                               uint32_t clockRate, uint8_t videoOrientationId)
+    : ssrc(ssrc), cname(cname), payloadType(payloadType), clockRate(clockRate),
+      videoOrientationId(videoOrientationId) {
 	assert(clockRate > 0);
-	srand((unsigned)time(NULL));
-	if (sequenceNumber.has_value()) {
-		this->sequenceNumber = sequenceNumber.value();
-	} else {
-		this->sequenceNumber = rand();
-	}
-	if (timestamp.has_value()) {
-		this->timestamp = timestamp.value();
-	} else {
-		this->timestamp = rand();
-	}
-	this->mStartTimestamp = this->timestamp;
-}
-
-void RtpPacketizationConfig::setStartTime(double startTime, EpochStart epochStart,
-                                          optional<uint32_t> startTimestamp) {
-	this->mStartTime = startTime + double(static_cast<uint64_t>(epochStart));
-	if (startTimestamp.has_value()) {
-		this->mStartTimestamp = startTimestamp.value();
-		timestamp = this->startTimestamp;
-	} else {
-		this->mStartTimestamp = timestamp;
-	}
+	// TODO: random sequence ans timetamp
+	sequenceNumber = 0;
+	timestamp = startTimestamp = 0;
 }
 
 double RtpPacketizationConfig::getSecondsFromTimestamp(uint32_t timestamp, uint32_t clockRate) {
@@ -70,6 +48,15 @@ uint32_t RtpPacketizationConfig::getTimestampFromSeconds(double seconds, uint32_
 
 uint32_t RtpPacketizationConfig::secondsToTimestamp(double seconds) {
 	return RtpPacketizationConfig::getTimestampFromSeconds(seconds, clockRate);
+}
+
+void RtpPacketizationConfig::setStartTime(double startTime,
+										  EpochStart epochStart,
+                                          optional<uint32_t> startTimestamp) {
+	// Deprecated dummy function
+	this->startTime = startTime + double(static_cast<uint64_t>(epochStart));
+	if (startTimestamp.has_value())
+		this->timestamp = this->startTimestamp = startTimestamp.value();
 }
 
 } // namespace rtc


### PR DESCRIPTION
This PR removes the start time mechanism for RTP packetization which is mostly useless and quite confusing for users.

Methods `RtpPacketizationConfig::setStartTime()` and `RtcpSrReporter::startRecording()` are now deprecated and should not be called anymore, instead `RtpPacketizationConfig` is simply initialized with random sequence number and timestamp as recommended by RFC 3550. The corresponding optional parameters have been removed from `RtpPacketizationConfig` constructor. Additionally, the field `previousReportedTimestamp` must now be accessed with `lastReportedTimestamp()`. Corresponding functions are removed from the C API.

The streamer example has been adapted accordingly.