### PR TITLE
Close data channels and tracks asynchronously

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -92,8 +92,10 @@ void PeerConnection::close() {
 void PeerConnection::remoteClose() {
 	close();
 	if (state.load() != State::Closed) {
-		closeDataChannels();
-		closeTracks();
+		// Close data channels and tracks asynchronously
+		mProcessor.enqueue(&PeerConnection::closeDataChannels, shared_from_this());
+		mProcessor.enqueue(&PeerConnection::closeTracks, shared_from_this());
+
 		closeTransports();
 	}
 }


### PR DESCRIPTION
This PR reverts a change from https://github.com/paullouisageneau/libdatachannel/pull/735 to make data channels and track always be closed asynchronously as it was before the change.