### PR TITLE
Fix possible bad_weak_ptr errors in SCTP callbacks on deletion

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -318,12 +318,10 @@ shared_ptr<SctpTransport> PeerConnection::initSctpTransport() {
 				    mProcessor.enqueue(&PeerConnection::openDataChannels, shared_from_this());
 				    break;
 			    case SctpTransport::State::Failed:
-				    LOG_WARNING << "SCTP transport failed";
 				    changeState(State::Failed);
 				    mProcessor.enqueue(&PeerConnection::remoteClose, shared_from_this());
 				    break;
 			    case SctpTransport::State::Disconnected:
-				    LOG_INFO << "SCTP transport disconnected";
 				    changeState(State::Disconnected);
 				    mProcessor.enqueue(&PeerConnection::remoteClose, shared_from_this());
 				    break;

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -114,6 +114,7 @@ private:
 	std::mutex mRecvMutex;
 	std::recursive_mutex mSendMutex; // buffered amount callback is synchronous
 	Queue<message_ptr> mSendQueue;
+	bool mSendShutdown = false;
 	std::map<uint16_t, size_t> mBufferedAmount;
 	amount_callback mBufferedAmountCallback;
 

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -98,8 +98,8 @@ private:
 	void triggerBufferedAmount(uint16_t streamId, size_t amount);
 	void sendReset(uint16_t streamId);
 
-	void handleUpcall();
-	int handleWrite(byte *data, size_t len, uint8_t tos, uint8_t set_df);
+	void handleUpcall() noexcept;
+	int handleWrite(byte *data, size_t len, uint8_t tos, uint8_t set_df) noexcept;
 
 	void processData(binary &&data, uint16_t streamId, PayloadId ppid);
 	void processNotification(const union sctp_notification *notify, size_t len);


### PR DESCRIPTION
This PR fixes `bad_weak_ptr` errors possibly logged in SCTP callbacks while the transport is deleted, typically `SCTP upcall: bad_weak_ptr`. It also takes the opportunity to clean up irrelevant log counters and replace them with proper warnings.