### PR TITLE
Fix cleanup waiting for tasks scheduled in the future

### DIFF
--- a/src/impl/certificate.hpp
+++ b/src/impl/certificate.hpp
@@ -21,6 +21,7 @@
 
 #include "common.hpp"
 #include "configuration.hpp" // for CertificateType
+#include "init.hpp"
 #include "tls.hpp"
 
 #include <future>
@@ -46,6 +47,8 @@ public:
 	string fingerprint() const;
 
 private:
+	const init_token mInitToken = Init::Instance().token();
+
 #if USE_GNUTLS
 	Certificate(shared_ptr<gnutls_certificate_credentials_t> creds);
 	const shared_ptr<gnutls_certificate_credentials_t> mCredentials;

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -158,6 +158,7 @@ void Init::doCleanup() {
 	PLOG_DEBUG << "Global cleanup";
 
 	ThreadPool::Instance().join();
+	ThreadPool::Instance().clear();
 #if RTC_ENABLE_WEBSOCKET
 	PollService::Instance().join();
 #endif

--- a/src/impl/threadpool.cpp
+++ b/src/impl/threadpool.cpp
@@ -57,6 +57,12 @@ void ThreadPool::join() {
 	mJoining = false;
 }
 
+void ThreadPool::clear() {
+	std::unique_lock lock(mMutex);
+	while (!mTasks.empty())
+		mTasks.pop();
+}
+
 void ThreadPool::run() {
 	++mBusyWorkers;
 	scope_guard guard([&]() { --mBusyWorkers; });

--- a/src/impl/threadpool.hpp
+++ b/src/impl/threadpool.hpp
@@ -54,6 +54,7 @@ public:
 	int count() const;
 	void spawn(int count = 1);
 	void join();
+	void clear();
 	void run();
 	bool runOne();
 
@@ -115,7 +116,7 @@ auto ThreadPool::schedule(clock::time_point time, F &&f, Args &&...args)
 	});
 	std::future<R> result = task->get_future();
 
-	mTasks.push({time, [task = std::move(task), token = Init::Instance().token()]() { return (*task)(); }});
+	mTasks.push({time, [task = std::move(task)]() { return (*task)(); }});
 	mTasksCondition.notify_one();
 	return result;
 }


### PR DESCRIPTION
This PR fixes `ThreadPool` so it doesn't prevent cleanup when tasks are scheduled in the future, for instance the recently-introduced `WebSocket` close timeout task.