### PR TITLE
Fix export define for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,7 @@ set_target_properties(datachannel PROPERTIES
 	SOVERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17
 	CXX_VISIBILITY_PRESET default)
-target_compile_definitions(datachannel PRIVATE datachannel_EXPORTS)
+target_compile_definitions(datachannel PRIVATE RTC_EXPORTS)
 
 add_library(datachannel-static STATIC EXCLUDE_FROM_ALL
 	${LIBDATACHANNEL_SOURCES}
@@ -242,7 +242,7 @@ add_library(datachannel-static STATIC EXCLUDE_FROM_ALL
 set_target_properties(datachannel-static PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
-target_compile_definitions(datachannel-static PRIVATE datachannel_EXPORTS)
+target_compile_definitions(datachannel-static PRIVATE RTC_EXPORTS)
 target_compile_definitions(datachannel-static PUBLIC RTC_STATIC)
 
 target_include_directories(datachannel PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,19 +227,23 @@ add_library(datachannel SHARED
 	${LIBDATACHANNEL_HEADERS}
 	${LIBDATACHANNEL_IMPL_SOURCES}
 	${LIBDATACHANNEL_IMPL_HEADERS})
+set_target_properties(datachannel PROPERTIES
+	VERSION ${PROJECT_VERSION}
+	SOVERSION ${PROJECT_VERSION}
+	CXX_STANDARD 17
+	CXX_VISIBILITY_PRESET default)
+target_compile_definitions(datachannel PRIVATE datachannel_EXPORTS)
+
 add_library(datachannel-static STATIC EXCLUDE_FROM_ALL
 	${LIBDATACHANNEL_SOURCES}
 	${LIBDATACHANNEL_HEADERS}
 	${LIBDATACHANNEL_IMPL_SOURCES}
 	${LIBDATACHANNEL_IMPL_HEADERS})
-
-set_target_properties(datachannel PROPERTIES
-	VERSION ${PROJECT_VERSION}
-	CXX_STANDARD 17
-	CXX_VISIBILITY_PRESET default)
 set_target_properties(datachannel-static PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	CXX_STANDARD 17)
+target_compile_definitions(datachannel-static PRIVATE datachannel_EXPORTS)
+target_compile_definitions(datachannel-static PUBLIC RTC_STATIC)
 
 target_include_directories(datachannel PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,8 @@ else
         CPPFLAGS+=-DRTC_ENABLE_WEBSOCKET=0
 endif
 
+CPPFLAGS+=-DRTC_EXPORTS
+
 INCLUDES+=$(if $(LIBS),$(shell pkg-config --cflags $(LIBS)),)
 LDLIBS+=$(LOCALLIBS) $(if $(LIBS),$(shell pkg-config --libs $(LIBS)),)
 

--- a/include/rtc/common.hpp
+++ b/include/rtc/common.hpp
@@ -23,7 +23,7 @@
 #define RTC_CPP_EXPORT
 #else // dynamic library
 #ifdef _WIN32
-#ifdef datachannel_EXPORTS
+#ifdef RTC_EXPORTS
 #define RTC_CPP_EXPORT __declspec(dllexport) // building the library
 #else
 #define RTC_CPP_EXPORT __declspec(dllimport) // using the library

--- a/include/rtc/common.hpp
+++ b/include/rtc/common.hpp
@@ -19,24 +19,35 @@
 #ifndef RTC_COMMON_H
 #define RTC_COMMON_H
 
-#ifndef RTC_ENABLE_WEBSOCKET
-#define RTC_ENABLE_WEBSOCKET 1
+#ifdef RTC_STATIC
+#define RTC_CPP_EXPORT
+#else // dynamic library
+#ifdef _WIN32
+#ifdef datachannel_EXPORTS
+#define RTC_CPP_EXPORT __declspec(dllexport) // building the library
+#else
+#define RTC_CPP_EXPORT __declspec(dllimport) // using the library
 #endif
-
-#ifndef RTC_ENABLE_MEDIA
-#define RTC_ENABLE_MEDIA 1
+#else // not WIN32
+#define RTC_CPP_EXPORT
+#endif
 #endif
 
 #ifdef _WIN32
-#define RTC_CPP_EXPORT __declspec(dllexport)
 #ifndef _WIN32_WINNT
 #define _WIN32_WINNT 0x0602 // Windows 8
 #endif
 #ifdef _MSC_VER
 #pragma warning(disable : 4251) // disable "X needs to have dll-interface..."
 #endif
-#else
-#define RTC_CPP_EXPORT
+#endif
+
+#ifndef RTC_ENABLE_WEBSOCKET
+#define RTC_ENABLE_WEBSOCKET 1
+#endif
+
+#ifndef RTC_ENABLE_MEDIA
+#define RTC_ENABLE_MEDIA 1
 #endif
 
 #include "rtc.h" // for C API defines

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -23,15 +23,27 @@
 extern "C" {
 #endif
 
+#ifdef RTC_STATIC
+#define RTC_EXPORT
+#else // dynamic library
 #ifdef _WIN32
-#define RTC_EXPORT __declspec(dllexport)
+#ifdef datachannel_EXPORTS
+#define RTC_EXPORT __declspec(dllexport) // building the library
+#else
+#define RTC_EXPORT __declspec(dllimport) // using the library
+#endif
+#else // not WIN32
+#define RTC_EXPORT
+#endif
+#endif
+
+#ifdef _WIN32
 #ifdef CAPI_STDCALL
 #define RTC_API __stdcall
 #else
 #define RTC_API
 #endif
 #else // not WIN32
-#define RTC_EXPORT
 #define RTC_API
 #endif
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -24,16 +24,16 @@ extern "C" {
 #endif
 
 #ifdef RTC_STATIC
-#define RTC_EXPORT
+#define RTC_C_EXPORT
 #else // dynamic library
 #ifdef _WIN32
 #ifdef RTC_EXPORTS
-#define RTC_EXPORT __declspec(dllexport) // building the library
+#define RTC_C_EXPORT __declspec(dllexport) // building the library
 #else
-#define RTC_EXPORT __declspec(dllimport) // using the library
+#define RTC_C_EXPORT __declspec(dllimport) // using the library
 #endif
 #else // not WIN32
-#define RTC_EXPORT
+#define RTC_C_EXPORT
 #endif
 #endif
 
@@ -153,11 +153,11 @@ typedef void(RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
 // Log
 
 // NULL cb on the first call will log to stdout
-RTC_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb);
+RTC_C_EXPORT void rtcInitLogger(rtcLogLevel level, rtcLogCallbackFunc cb);
 
 // User pointer
-RTC_EXPORT void rtcSetUserPointer(int id, void *ptr);
-RTC_EXPORT void *rtcGetUserPointer(int i);
+RTC_C_EXPORT void rtcSetUserPointer(int id, void *ptr);
+RTC_C_EXPORT void *rtcGetUserPointer(int i);
 
 // PeerConnection
 
@@ -178,55 +178,55 @@ typedef struct {
 	int maxMessageSize;      // <= 0 means default
 } rtcConfiguration;
 
-RTC_EXPORT int rtcCreatePeerConnection(const rtcConfiguration *config); // returns pc id
-RTC_EXPORT int rtcClosePeerConnection(int pc);
-RTC_EXPORT int rtcDeletePeerConnection(int pc);
+RTC_C_EXPORT int rtcCreatePeerConnection(const rtcConfiguration *config); // returns pc id
+RTC_C_EXPORT int rtcClosePeerConnection(int pc);
+RTC_C_EXPORT int rtcDeletePeerConnection(int pc);
 
-RTC_EXPORT int rtcSetLocalDescriptionCallback(int pc, rtcDescriptionCallbackFunc cb);
-RTC_EXPORT int rtcSetLocalCandidateCallback(int pc, rtcCandidateCallbackFunc cb);
-RTC_EXPORT int rtcSetStateChangeCallback(int pc, rtcStateChangeCallbackFunc cb);
-RTC_EXPORT int rtcSetGatheringStateChangeCallback(int pc, rtcGatheringStateCallbackFunc cb);
-RTC_EXPORT int rtcSetSignalingStateChangeCallback(int pc, rtcSignalingStateCallbackFunc cb);
+RTC_C_EXPORT int rtcSetLocalDescriptionCallback(int pc, rtcDescriptionCallbackFunc cb);
+RTC_C_EXPORT int rtcSetLocalCandidateCallback(int pc, rtcCandidateCallbackFunc cb);
+RTC_C_EXPORT int rtcSetStateChangeCallback(int pc, rtcStateChangeCallbackFunc cb);
+RTC_C_EXPORT int rtcSetGatheringStateChangeCallback(int pc, rtcGatheringStateCallbackFunc cb);
+RTC_C_EXPORT int rtcSetSignalingStateChangeCallback(int pc, rtcSignalingStateCallbackFunc cb);
 
-RTC_EXPORT int rtcSetLocalDescription(int pc, const char *type);
-RTC_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
-RTC_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid);
+RTC_C_EXPORT int rtcSetLocalDescription(int pc, const char *type);
+RTC_C_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
+RTC_C_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid);
 
-RTC_EXPORT int rtcGetLocalDescription(int pc, char *buffer, int size);
-RTC_EXPORT int rtcGetRemoteDescription(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetLocalDescription(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetRemoteDescription(int pc, char *buffer, int size);
 
-RTC_EXPORT int rtcGetLocalDescriptionType(int pc, char *buffer, int size);
-RTC_EXPORT int rtcGetRemoteDescriptionType(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetLocalDescriptionType(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetRemoteDescriptionType(int pc, char *buffer, int size);
 
-RTC_EXPORT int rtcGetLocalAddress(int pc, char *buffer, int size);
-RTC_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetLocalAddress(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetRemoteAddress(int pc, char *buffer, int size);
 
-RTC_EXPORT int rtcGetSelectedCandidatePair(int pc, char *local, int localSize, char *remote,
+RTC_C_EXPORT int rtcGetSelectedCandidatePair(int pc, char *local, int localSize, char *remote,
                                            int remoteSize);
 
-RTC_EXPORT int rtcGetMaxDataChannelStream(int pc);
+RTC_C_EXPORT int rtcGetMaxDataChannelStream(int pc);
 
 // DataChannel, Track, and WebSocket common API
 
-RTC_EXPORT int rtcSetOpenCallback(int id, rtcOpenCallbackFunc cb);
-RTC_EXPORT int rtcSetClosedCallback(int id, rtcClosedCallbackFunc cb);
-RTC_EXPORT int rtcSetErrorCallback(int id, rtcErrorCallbackFunc cb);
-RTC_EXPORT int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb);
-RTC_EXPORT int rtcSendMessage(int id, const char *data, int size);
-RTC_EXPORT int rtcClose(int id);
-RTC_EXPORT int rtcDelete(int id);
-RTC_EXPORT bool rtcIsOpen(int id);
-RTC_EXPORT bool rtcIsClosed(int id);
+RTC_C_EXPORT int rtcSetOpenCallback(int id, rtcOpenCallbackFunc cb);
+RTC_C_EXPORT int rtcSetClosedCallback(int id, rtcClosedCallbackFunc cb);
+RTC_C_EXPORT int rtcSetErrorCallback(int id, rtcErrorCallbackFunc cb);
+RTC_C_EXPORT int rtcSetMessageCallback(int id, rtcMessageCallbackFunc cb);
+RTC_C_EXPORT int rtcSendMessage(int id, const char *data, int size);
+RTC_C_EXPORT int rtcClose(int id);
+RTC_C_EXPORT int rtcDelete(int id);
+RTC_C_EXPORT bool rtcIsOpen(int id);
+RTC_C_EXPORT bool rtcIsClosed(int id);
 
-RTC_EXPORT int rtcGetBufferedAmount(int id); // total size buffered to send
-RTC_EXPORT int rtcSetBufferedAmountLowThreshold(int id, int amount);
-RTC_EXPORT int rtcSetBufferedAmountLowCallback(int id, rtcBufferedAmountLowCallbackFunc cb);
+RTC_C_EXPORT int rtcGetBufferedAmount(int id); // total size buffered to send
+RTC_C_EXPORT int rtcSetBufferedAmountLowThreshold(int id, int amount);
+RTC_C_EXPORT int rtcSetBufferedAmountLowCallback(int id, rtcBufferedAmountLowCallbackFunc cb);
 
 // DataChannel, Track, and WebSocket common extended API
 
-RTC_EXPORT int rtcGetAvailableAmount(int id); // total size available to receive
-RTC_EXPORT int rtcSetAvailableCallback(int id, rtcAvailableCallbackFunc cb);
-RTC_EXPORT int rtcReceiveMessage(int id, char *buffer, int *size);
+RTC_C_EXPORT int rtcGetAvailableAmount(int id); // total size available to receive
+RTC_C_EXPORT int rtcSetAvailableCallback(int id, rtcAvailableCallbackFunc cb);
+RTC_C_EXPORT int rtcReceiveMessage(int id, char *buffer, int *size);
 
 // DataChannel
 
@@ -245,16 +245,16 @@ typedef struct {
 	uint16_t stream; // numeric ID 0-65534, ignored if manualStream is false
 } rtcDataChannelInit;
 
-RTC_EXPORT int rtcSetDataChannelCallback(int pc, rtcDataChannelCallbackFunc cb);
-RTC_EXPORT int rtcCreateDataChannel(int pc, const char *label); // returns dc id
-RTC_EXPORT int rtcCreateDataChannelEx(int pc, const char *label,
+RTC_C_EXPORT int rtcSetDataChannelCallback(int pc, rtcDataChannelCallbackFunc cb);
+RTC_C_EXPORT int rtcCreateDataChannel(int pc, const char *label); // returns dc id
+RTC_C_EXPORT int rtcCreateDataChannelEx(int pc, const char *label,
                                       const rtcDataChannelInit *init); // returns dc id
-RTC_EXPORT int rtcDeleteDataChannel(int dc);
+RTC_C_EXPORT int rtcDeleteDataChannel(int dc);
 
-RTC_EXPORT int rtcGetDataChannelStream(int dc);
-RTC_EXPORT int rtcGetDataChannelLabel(int dc, char *buffer, int size);
-RTC_EXPORT int rtcGetDataChannelProtocol(int dc, char *buffer, int size);
-RTC_EXPORT int rtcGetDataChannelReliability(int dc, rtcReliability *reliability);
+RTC_C_EXPORT int rtcGetDataChannelStream(int dc);
+RTC_C_EXPORT int rtcGetDataChannelLabel(int dc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetDataChannelProtocol(int dc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetDataChannelReliability(int dc, rtcReliability *reliability);
 
 // Track
 
@@ -269,14 +269,14 @@ typedef struct {
 	const char *trackId; // optional, track ID used in MSID
 } rtcTrackInit;
 
-RTC_EXPORT int rtcSetTrackCallback(int pc, rtcTrackCallbackFunc cb);
-RTC_EXPORT int rtcAddTrack(int pc, const char *mediaDescriptionSdp); // returns tr id
-RTC_EXPORT int rtcAddTrackEx(int pc, const rtcTrackInit *init);      // returns tr id
-RTC_EXPORT int rtcDeleteTrack(int tr);
+RTC_C_EXPORT int rtcSetTrackCallback(int pc, rtcTrackCallbackFunc cb);
+RTC_C_EXPORT int rtcAddTrack(int pc, const char *mediaDescriptionSdp); // returns tr id
+RTC_C_EXPORT int rtcAddTrackEx(int pc, const rtcTrackInit *init);      // returns tr id
+RTC_C_EXPORT int rtcDeleteTrack(int tr);
 
-RTC_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
-RTC_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
-RTC_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
+RTC_C_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
+RTC_C_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
+RTC_C_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
 
 #if RTC_ENABLE_MEDIA
 
@@ -312,34 +312,34 @@ typedef struct {
 } rtcSsrcForTypeInit;
 
 // Set H264PacketizationHandler for track
-RTC_EXPORT int rtcSetH264PacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
+RTC_C_EXPORT int rtcSetH264PacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
 
 // Set OpusPacketizationHandler for track
-RTC_EXPORT int rtcSetOpusPacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
+RTC_C_EXPORT int rtcSetOpusPacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
 
 // Chain RtcpSrReporter to handler chain for given track
-RTC_EXPORT int rtcChainRtcpSrReporter(int tr);
+RTC_C_EXPORT int rtcChainRtcpSrReporter(int tr);
 
 // Chain RtcpNackResponder to handler chain for given track
-RTC_EXPORT int rtcChainRtcpNackResponder(int tr, unsigned int maxStoredPacketsCount);
+RTC_C_EXPORT int rtcChainRtcpNackResponder(int tr, unsigned int maxStoredPacketsCount);
 
 // Transform seconds to timestamp using track's clock rate, result is written to timestamp
-RTC_EXPORT int rtcTransformSecondsToTimestamp(int id, double seconds, uint32_t *timestamp);
+RTC_C_EXPORT int rtcTransformSecondsToTimestamp(int id, double seconds, uint32_t *timestamp);
 
 // Transform timestamp to seconds using track's clock rate, result is written to seconds
-RTC_EXPORT int rtcTransformTimestampToSeconds(int id, uint32_t timestamp, double *seconds);
+RTC_C_EXPORT int rtcTransformTimestampToSeconds(int id, uint32_t timestamp, double *seconds);
 
 // Get current timestamp, result is written to timestamp
-RTC_EXPORT int rtcGetCurrentTrackTimestamp(int id, uint32_t *timestamp);
+RTC_C_EXPORT int rtcGetCurrentTrackTimestamp(int id, uint32_t *timestamp);
 
 // Set RTP timestamp for track identified by given id
-RTC_EXPORT int rtcSetTrackRtpTimestamp(int id, uint32_t timestamp);
+RTC_C_EXPORT int rtcSetTrackRtpTimestamp(int id, uint32_t timestamp);
 
 // Get timestamp of previous RTCP SR, result is written to timestamp
-RTC_EXPORT int rtcGetPreviousTrackSenderReportTimestamp(int id, uint32_t *timestamp);
+RTC_C_EXPORT int rtcGetPreviousTrackSenderReportTimestamp(int id, uint32_t *timestamp);
 
 // Set NeedsToReport flag in RtcpSrReporter handler identified by given track id
-RTC_EXPORT int rtcSetNeedsToSendRtcpSr(int id);
+RTC_C_EXPORT int rtcSetNeedsToSendRtcpSr(int id);
 
 // Get all available payload types for given codec and stores them in buffer, does nothing if
 // buffer is NULL
@@ -373,12 +373,12 @@ typedef struct {
 	int maxOutstandingPings; // 0 means default, < 0 means disabled
 } rtcWsConfiguration;
 
-RTC_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id
-RTC_EXPORT int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config);
-RTC_EXPORT int rtcDeleteWebSocket(int ws);
+RTC_C_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id
+RTC_C_EXPORT int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config);
+RTC_C_EXPORT int rtcDeleteWebSocket(int ws);
 
-RTC_EXPORT int rtcGetWebSocketRemoteAddress(int ws, char *buffer, int size);
-RTC_EXPORT int rtcGetWebSocketPath(int ws, char *buffer, int size);
+RTC_C_EXPORT int rtcGetWebSocketRemoteAddress(int ws, char *buffer, int size);
+RTC_C_EXPORT int rtcGetWebSocketPath(int ws, char *buffer, int size);
 
 // WebSocketServer
 
@@ -392,18 +392,18 @@ typedef struct {
 	const char *keyPemPass;         // NULL if no pass
 } rtcWsServerConfiguration;
 
-RTC_EXPORT int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
+RTC_C_EXPORT int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
                                         rtcWebSocketClientCallbackFunc cb); // returns wsserver id
-RTC_EXPORT int rtcDeleteWebSocketServer(int wsserver);
+RTC_C_EXPORT int rtcDeleteWebSocketServer(int wsserver);
 
-RTC_EXPORT int rtcGetWebSocketServerPort(int wsserver);
+RTC_C_EXPORT int rtcGetWebSocketServerPort(int wsserver);
 
 #endif
 
 // Optional global preload and cleanup
 
-RTC_EXPORT void rtcPreload(void);
-RTC_EXPORT void rtcCleanup(void);
+RTC_C_EXPORT void rtcPreload(void);
+RTC_C_EXPORT void rtcCleanup(void);
 
 // SCTP global settings
 
@@ -423,7 +423,7 @@ typedef struct {
 } rtcSctpSettings;
 
 // Note: SCTP settings apply to newly-created PeerConnections only
-RTC_EXPORT int rtcSetSctpSettings(const rtcSctpSettings *settings);
+RTC_C_EXPORT int rtcSetSctpSettings(const rtcSctpSettings *settings);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -27,7 +27,7 @@ extern "C" {
 #define RTC_EXPORT
 #else // dynamic library
 #ifdef _WIN32
-#ifdef datachannel_EXPORTS
+#ifdef RTC_EXPORTS
 #define RTC_EXPORT __declspec(dllexport) // building the library
 #else
 #define RTC_EXPORT __declspec(dllimport) // using the library

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1364,7 +1364,7 @@ int rtcGetWebSocketPath(int ws, char *buffer, int size) {
 	});
 }
 
-RTC_EXPORT int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
+RTC_C_EXPORT int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
                                         rtcWebSocketClientCallbackFunc cb) {
 	return wrap([&] {
 		if (!config)
@@ -1396,7 +1396,7 @@ RTC_EXPORT int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
 	});
 }
 
-RTC_EXPORT int rtcDeleteWebSocketServer(int wsserver) {
+RTC_C_EXPORT int rtcDeleteWebSocketServer(int wsserver) {
 	return wrap([&] {
 		auto webSocketServer = getWebSocketServer(wsserver);
 		webSocketServer->onClient(nullptr);
@@ -1406,7 +1406,7 @@ RTC_EXPORT int rtcDeleteWebSocketServer(int wsserver) {
 	});
 }
 
-RTC_EXPORT int rtcGetWebSocketServerPort(int wsserver) {
+RTC_C_EXPORT int rtcGetWebSocketServerPort(int wsserver) {
 	return wrap([&] {
 		auto webSocketServer = getWebSocketServer(wsserver);
 		return int(webSocketServer->port());


### PR DESCRIPTION
This PR fixes the export define for Windows, as previously it would lead to incorrect behavior, for instance re-exported symbols when used as a static library in a dynamic library.