### PR TITLE
Add PCMA/PCMU codec to description

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -239,6 +239,10 @@ public:
 		void addAudioCodec(int payloadType, string codec, optional<string> profile = std::nullopt);
 
 		void addOpusCodec(int payloadType, optional<string> profile = DEFAULT_OPUS_AUDIO_PROFILE);
+
+		void addPCMACodec(int payloadType, optional<string> profile = std::nullopt);
+
+		void addPCMUCodec(int payloadType, optional<string> profile = std::nullopt);
 	};
 
 	class RTC_CPP_EXPORT Video : public Media {

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -102,7 +102,9 @@ typedef enum {
 	RTC_CODEC_VP9 = 2,
 
 	// audio
-	RTC_CODEC_OPUS = 128
+	RTC_CODEC_OPUS = 128,
+    RTC_CODEC_PCMU = 129,
+    RTC_CODEC_PCMA = 130
 } rtcCodec;
 
 typedef enum {

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -984,6 +984,8 @@ int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
 				mid = "video";
 				break;
 			case RTC_CODEC_OPUS:
+            case RTC_CODEC_PCMU:
+            case RTC_CODEC_PCMA:
 				mid = "audio";
 				break;
 			default:
@@ -1015,12 +1017,20 @@ int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
 			optDescription = desc;
 			break;
 		}
-		case RTC_CODEC_OPUS: {
+		case RTC_CODEC_OPUS:
+        case RTC_CODEC_PCMU:
+        case RTC_CODEC_PCMA:{
 			auto desc = Description::Audio(mid, direction);
 			switch (init->codec) {
 			case RTC_CODEC_OPUS:
 				desc.addOpusCodec(init->payloadType);
 				break;
+            case RTC_CODEC_PCMU:
+                desc.addPCMUCodec(init->payloadType);
+                break;
+            case RTC_CODEC_PCMA:
+                desc.addPCMACodec(init->payloadType);
+                break;
 			default:
 				break;
 			}

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1086,8 +1086,13 @@ Description::Audio::Audio(string mid, Direction dir)
     : Media("audio 9 UDP/TLS/RTP/SAVPF", std::move(mid), dir) {}
 
 void Description::Audio::addAudioCodec(int payloadType, string codec, optional<string> profile) {
-	if (codec.find('/') == string::npos)
-		codec += "/48000/2";
+	if (codec.find('/') == string::npos){
+        if(0 == codec.compare("OPUS"))
+            codec += "/48000/2";
+        else if(0 == codec.compare("PCMA") || 0 == codec.compare("PCMU"))
+            codec += "/8000/1";
+    }
+
 
 	RtpMap map(std::to_string(payloadType) + ' ' + codec);
 
@@ -1099,6 +1104,14 @@ void Description::Audio::addAudioCodec(int payloadType, string codec, optional<s
 
 void Description::Audio::addOpusCodec(int payloadType, optional<string> profile) {
 	addAudioCodec(payloadType, "OPUS", profile);
+}
+
+void Description::Audio::addPCMACodec(int payloadType, optional<string> profile) {
+    addAudioCodec(payloadType, "PCMA", profile);
+}
+
+void Description::Audio::addPCMUCodec(int payloadType, optional<string> profile) {
+    addAudioCodec(payloadType, "PCMU", profile);
 }
 
 Description::Video::Video(string mid, Direction dir)

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1087,10 +1087,10 @@ Description::Audio::Audio(string mid, Direction dir)
 
 void Description::Audio::addAudioCodec(int payloadType, string codec, optional<string> profile) {
 	if (codec.find('/') == string::npos){
-        if(0 == codec.compare("OPUS"))
-            codec += "/48000/2";
-        else if(0 == codec.compare("PCMA") || 0 == codec.compare("PCMU"))
+        if(codec == "PCMA" || codec == "PCMU")
             codec += "/8000/1";
+        else
+            codec += "/48000/2";
     }
 
 


### PR DESCRIPTION
This pr supports setting the PCMA/PCMU encoder for webrtc.
test case is adapted from [media_sender](https://github.com/paullouisageneau/libdatachannel/blob/b0a5d99059fe6482ab85400ced92d92bc973bc41/examples/media-sender/main.cpp#L76)

1.    ` rtc::Description::Audio media("audio", rtc::Description::Direction::SendOnly);media.addPCMUCodec(123);`

2.    ffmpeg -stream_loop -1  -re -i test.mp4 -vn  -acodec pcm_mulaw  -ar 8000 -ac 1 -f rtp rtp://127.0.0.1:6000 
