### PR TITLE
Remove the check for transport-cc in src/description.cpp

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -946,8 +946,7 @@ string Description::Media::generateSdpLines(string_view eol) const {
 		sdp << eol;
 
 		for (const auto &val : map.rtcpFbs)
-			if (val != "transport-cc")
-				sdp << "a=rtcp-fb:" << map.payloadType << ' ' << val << eol;
+			sdp << "a=rtcp-fb:" << map.payloadType << ' ' << val << eol;
 
 		for (const auto &val : map.fmtps)
 			sdp << "a=fmtp:" << map.payloadType << ' ' << val << eol;


### PR DESCRIPTION
As previously discussed in issue #732, there was a check in src/description.cpp since commit be7a6324dda0fdf0bc3f241f1a6ba7b1b108aa8a (from 2+ years ago) that prevented the addition of a transport-cc line to the SDP. It wasn't clear why the check was added.

We've been using a build with transport-cc disabled (and a transport-cc line in the description) for a while now without any problem since issue #740 was resolved. Without that check, the examples continue to work and the tests pass. So, arguably, whatever issue the check was working around has long been resolved and it's safe to remove it now especially after PR #678 is merged