### PR TITLE
libnice: close agent before releasing it

### DIFF
--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -84,7 +84,7 @@ private:
 	static void LogCallback(juice_log_level_t level, const char *message);
 #else
 	uint32_t mStreamId = 0;
-	unique_ptr<NiceAgent, void (*)(gpointer)> mNiceAgent;
+	unique_ptr<NiceAgent, void (*)(NiceAgent *)> mNiceAgent;
 	unique_ptr<GMainLoop, void (*)(GMainLoop *)> mMainLoop;
 	std::thread mMainLoopThread;
 	guint mTimeoutId = 0;


### PR DESCRIPTION
Fixes the following warning:

> nice: Agent 0xaaaab3ae7690 : We still have alive TURN refreshes. Consider using
> nice_agent_close_async() to prune them before releasing the agent.