### PR TITLE
Fix static linking flags in Jamfile

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -89,6 +89,7 @@ alias juice
     : # no default build
     : # usage requirements
     <include>./deps/libjuice/include
+    <define>JUICE_STATIC
     <library>juice-static.lib
     ;
 

--- a/Jamfile
+++ b/Jamfile
@@ -39,6 +39,7 @@ lib libdatachannel
 	<include>./include
 	<define>RTC_ENABLE_MEDIA=0
 	<define>RTC_ENABLE_WEBSOCKET=0
+	<define>RTC_STATIC
 	<library>/libdatachannel//plog
 	<toolset>gcc:<cxxflags>"-pthread -Wno-pedantic -Wno-unused-parameter -Wno-unused-variable"
 	<toolset>clang:<cxxflags>"-pthread -Wno-pedantic -Wno-unused-parameter -Wno-unused-variable"
@@ -76,6 +77,7 @@ alias juice
     : # no default build
     : # usage requirements
     <include>./deps/libjuice/include
+    <define>JUICE_STATIC
     <gnutls>on:<library>libjuice-gnutls.a
     <gnutls>on:<library>nettle/<link>shared
     <gnutls>off:<library>libjuice-openssl.a


### PR DESCRIPTION
This PR adds the proper static linking flags in Jamfile in order to fix compilation on Windows.