### PR TITLE
Catch exceptions from user callbacks early

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1094,7 +1094,13 @@ void PeerConnection::triggerPendingDataChannels() {
 			break;
 
 		auto impl = std::move(*next);
-		dataChannelCallback(std::make_shared<rtc::DataChannel>(impl));
+
+		try {
+			dataChannelCallback(std::make_shared<rtc::DataChannel>(impl));
+		} catch (const std::exception &e) {
+			PLOG_WARNING << "Uncaught exception in callback: " << e.what();
+		}
+
 		impl->triggerOpen();
 	}
 }
@@ -1106,7 +1112,13 @@ void PeerConnection::triggerPendingTracks() {
 			break;
 
 		auto impl = std::move(*next);
-		trackCallback(std::make_shared<rtc::Track>(impl));
+
+		try {
+			trackCallback(std::make_shared<rtc::Track>(impl));
+		} catch (const std::exception &e) {
+			PLOG_WARNING << "Uncaught exception in callback: " << e.what();
+		}
+
 		// Do not trigger open immediately for tracks as it'll be done later
 	}
 }

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -96,7 +96,11 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	// Helper method for asynchronous callback invocation
 	template <typename... Args> void trigger(synchronized_callback<Args...> *cb, Args... args) {
-		(*cb)(std::move(args...));
+		try {
+			(*cb)(std::move(args...));
+		} catch (const std::exception &e) {
+			PLOG_WARNING << "Uncaught exception in callback: " << e.what();
+		}
 	}
 
 	const Configuration config;


### PR DESCRIPTION
This PR introduces try catch blocks to ensure exceptions leaking from user callbacks are caught early, otherwise in some situations it could introduce undesired behavior changes like a second callback not called as it should.