### PR TITLE
Remove set user pointer for inexistent dc

### DIFF
--- a/examples/copy-paste-capi/answerer.c
+++ b/examples/copy-paste-capi/answerer.c
@@ -70,7 +70,6 @@ int main(int argc, char **argv) {
 	rtcSetStateChangeCallback(peer->pc, stateChangeCallback);
 	rtcSetGatheringStateChangeCallback(peer->pc, gatheringStateCallback);
 
-	rtcSetUserPointer(peer->dc, NULL);
 	rtcSetDataChannelCallback(peer->pc, dataChannelCallback);
 
 	sleep(1);


### PR DESCRIPTION
The value of dc is set by memset on the top.
The datachannel is received only later.
