### PR TITLE
Fix possible out-of-bound zero character in C API

### DIFF
--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -188,7 +188,7 @@ int copyAndReturn(string s, char *buffer, int size) {
 	if (!buffer)
 		return int(s.size() + 1);
 
-	if (size < int(s.size()))
+	if (size < int(s.size() + 1))
 		return RTC_ERR_TOO_SMALL;
 
 	std::copy(s.begin(), s.end(), buffer);
@@ -205,7 +205,6 @@ int copyAndReturn(binary b, char *buffer, int size) {
 
 	auto data = reinterpret_cast<const char *>(b.data());
 	std::copy(data, data + b.size(), buffer);
-	buffer[b.size()] = '\0';
 	return int(b.size());
 }
 


### PR DESCRIPTION
This PR fixes the `copyAndReturn()` C API helper function which would write an out-of-bound 0 if the message is the same size as the buffer.