### PR TITLE
Fix DataChannel message peeking

### DIFF
--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -114,7 +114,7 @@ optional<message_variant> DataChannel::receive() {
 
 optional<message_variant> DataChannel::peek() {
 	auto next = mRecvQueue.peek();
-	return next ? std::make_optional(to_variant(std::move(**next))) : nullopt;
+	return next ? std::make_optional(to_variant(**next)) : nullopt;
 }
 
 size_t DataChannel::availableAmount() const { return mRecvQueue.amount(); }

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -176,6 +176,11 @@ static void deletePeer(Peer *peer) {
 
 int test_capi_connectivity_main() {
 	int attempts;
+	char buffer[BUFFER_SIZE];
+	char buffer2[BUFFER_SIZE];
+	const char *test = "foo";
+	const int testLen = 3;
+	int size = 0;
 
 	rtcInitLogger(RTC_LOG_DEBUG, nullptr);
 
@@ -245,9 +250,6 @@ int test_capi_connectivity_main() {
 		fprintf(stderr, "DataChannel is not connected\n");
 		goto error;
 	}
-
-	char buffer[BUFFER_SIZE];
-	char buffer2[BUFFER_SIZE];
 
 	if (rtcGetLocalDescriptionType(peer1->pc, buffer, BUFFER_SIZE) < 0) {
 		fprintf(stderr, "rtcGetLocalDescriptionType failed\n");
@@ -337,6 +339,22 @@ int test_capi_connectivity_main() {
 
 	if (rtcGetMaxDataChannelStream(peer1->pc) <= 0 || rtcGetMaxDataChannelStream(peer2->pc) <= 0) {
 		fprintf(stderr, "rtcGetMaxDataChannelStream failed\n");
+		goto error;
+	}
+
+	rtcSetMessageCallback(peer2->dc, NULL);
+	if (rtcSendMessage(peer1->dc, test, testLen) < 0) {
+		fprintf(stderr, "rtcSendMessage failed\n");
+		goto error;
+	}
+	sleep(1);
+	size = 0;
+	if (rtcReceiveMessage(peer2->dc, NULL, &size) < 0 || size != testLen) {
+		fprintf(stderr, "rtcReceiveMessage failed to peek message size\n");
+		goto error;
+	}
+	if (rtcReceiveMessage(peer2->dc, buffer, &size) < 0 || size != testLen) {
+		fprintf(stderr, "rtcReceiveMessage failed to get the message\n");
 		goto error;
 	}
 


### PR DESCRIPTION
This PR fixes DataChannel message peeking, either from C++ API with `DataChannel::peek()` or C API with `rtcReceiveMessage()` with `NULL` buffer. The next message was moved away and therefore appeared empty on second call.

Fixes issue with `rtcReceiveMessage()` reported in https://github.com/paullouisageneau/libdatachannel/pull/580#issuecomment-1412603702