### PR TITLE
Fix TLS pull timeout function for GnuTLS

### DIFF
--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -266,6 +266,12 @@ ssize_t TlsTransport::ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_
 int TlsTransport::TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms) {
 	TlsTransport *t = static_cast<TlsTransport *>(ptr);
 	try {
+		message_ptr &message = t->mIncomingMessage;
+		size_t &position = t->mIncomingMessagePosition;
+
+		if(message && position < message->size())
+			return 1;
+
 		bool isReadable = t->mIncomingQueue.wait(
 		    ms != GNUTLS_INDEFINITE_TIMEOUT ? std::make_optional(milliseconds(ms)) : nullopt);
 		return isReadable ? 1 : 0;


### PR DESCRIPTION
The pull timeout function for GnuTLS `TlsTransport::TimeoutCallback()` did not take the potential pending partial message into account and could theoretically wait whereas data in pending.