### PR TITLE
libnice: Use a single global thread for ICE transport

### DIFF
--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -32,6 +32,9 @@ namespace rtc::impl {
 
 class IceTransport : public Transport {
 public:
+	static void Init();
+	static void Cleanup();
+
 	enum class GatheringState { New = 0, InProgress = 1, Complete = 2 };
 
 	using candidate_callback = std::function<void(const Candidate &candidate)>;
@@ -83,10 +86,11 @@ private:
 	static void RecvCallback(juice_agent_t *agent, const char *data, size_t size, void *user_ptr);
 	static void LogCallback(juice_log_level_t level, const char *message);
 #else
-	uint32_t mStreamId = 0;
+	static unique_ptr<GMainLoop, void (*)(GMainLoop *)> MainLoop;
+	static std::thread MainLoopThread;
+
 	unique_ptr<NiceAgent, void (*)(NiceAgent *)> mNiceAgent;
-	unique_ptr<GMainLoop, void (*)(GMainLoop *)> mMainLoop;
-	std::thread mMainLoopThread;
+	uint32_t mStreamId = 0;
 	guint mTimeoutId = 0;
 	std::mutex mOutgoingMutex;
 	unsigned int mOutgoingDscp;

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -141,6 +141,7 @@ void Init::doInit() {
 #if RTC_ENABLE_MEDIA
 	DtlsSrtpTransport::Init();
 #endif
+	IceTransport::Init();
 }
 
 void Init::doCleanup() {
@@ -167,6 +168,7 @@ void Init::doCleanup() {
 #if RTC_ENABLE_MEDIA
 	DtlsSrtpTransport::Cleanup();
 #endif
+	IceTransport::Cleanup();
 
 #ifdef _WIN32
 	WSACleanup();


### PR DESCRIPTION
This PR changes the ICE transport with libnice to use a single global loop instead of creating one per connection. This makes the ICE transport behave similarly to when using libjuice and allows the library to scale to a high number of connections.