### PR TITLE
Send the DTLS close_notify alert

### DIFF
--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -415,7 +415,8 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 
 		SSL_CTX_set_min_proto_version(mCtx, DTLS1_VERSION);
 		SSL_CTX_set_read_ahead(mCtx, 1);
-		SSL_CTX_set_quiet_shutdown(mCtx, 1);
+		//sent the dtls close_notify alert
+		//SSL_CTX_set_quiet_shutdown(mCtx, 1);
 		SSL_CTX_set_info_callback(mCtx, InfoCallback);
 
 		SSL_CTX_set_verify(mCtx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,


### PR DESCRIPTION
hi~ @paullouisageneau 

when I use pc->close() to stop sending media data, The peer connection is not closed until timeout.

should we send the dtls close_notify alert for faster hangup without signaling server ?

![image](https://user-images.githubusercontent.com/36155473/220838013-4ecd6cd0-72b1-48db-971f-98428d7d21a4.png)
ref: https://www.openssl.org/docs/man1.0.2/man3/SSL_shutdown.html

browse will send a close_notify alert.
![image](https://user-images.githubusercontent.com/36155473/220837682-99bd75cc-fa3d-4ab8-aa65-69c1f4f8594d.png)


