### PR TITLE
Addressing HTTP Header with empty values

### DIFF
--- a/src/impl/wshandshake.cpp
+++ b/src/impl/wshandshake.cpp
@@ -262,7 +262,11 @@ std::multimap<string, string> WsHandshake::parseHttpHeaders(const std::list<stri
 	for (const auto &line : lines) {
 		if (size_t pos = line.find_first_of(':'); pos != string::npos) {
 			string key = line.substr(0, pos);
-			string value = line.substr(line.find_first_not_of(' ', pos + 1));
+			string value = "";
+			if (size_t subPos = line.find_first_not_of(' ', pos + 1); subPos != string::npos )
+			{
+				value = line.substr(subPos);
+			}
 			std::transform(key.begin(), key.end(), key.begin(),
 			               [](char c) { return std::tolower(c); });
 			headers.emplace(std::move(key), std::move(value));


### PR DESCRIPTION
Hi @paullouisageneau,

I recently encounted an issue were the websocket class was unable to establish a connection to a server because the HTTP response header contained key:value pairs that looked like: ``` X-Custom-Header: ```. 

I looked into and it appears the code in wshandshake assumes that there will be a non ```' '``` character after the ```:``` and tries to create a substring. I created a quick patch to check the subpos before using it to generate a substring.