### PR TITLE
Fix crash in TcpTransport

### DIFF
--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -384,7 +384,7 @@ void TcpTransport::triggerBufferedAmount(size_t amount) {
 }
 
 void TcpTransport::process(PollService::Event event) {
-	auto self = shared_from_this();
+	auto self = weak_from_this().lock();
 	try {
 		switch (event) {
 		case PollService::Event::Error: {

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -384,6 +384,7 @@ void TcpTransport::triggerBufferedAmount(size_t amount) {
 }
 
 void TcpTransport::process(PollService::Event event) {
+	auto self = shared_from_this();
 	try {
 		switch (event) {
 		case PollService::Event::Error: {

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -385,6 +385,9 @@ void TcpTransport::triggerBufferedAmount(size_t amount) {
 
 void TcpTransport::process(PollService::Event event) {
 	auto self = weak_from_this().lock();
+	if (!self)
+		return;
+
 	try {
 		switch (event) {
 		case PollService::Event::Error: {


### PR DESCRIPTION
Addressing issue where the tcptransport object could go out of scope during a process call (#816). As per @paullouisageneau suggestion I modified the process function to grab a shared pointer to prevent the class from going out of scope. I decided to grab the weak_ptr and lock it to avoid the potential throw from shared_from_this.

I test this change with my current setup of letting the WebSocket connection timeout after having been connected. It now correctly closes the WebSocket and doesn't crash.