### PR TITLE
Improve error handling for unsupported proxies

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -374,7 +374,7 @@ int rtcSetSsrcForType(const char *mediaType, const char *sdp, char *buffer, cons
 
 typedef struct {
 	bool disableTlsVerification; // if true, don't verify the TLS certificate
-	const char *proxyServer;
+	const char *proxyServer;     // only non-authenticated http supported for now
 	const char **protocols;
 	int protocolsCount;
 	int pingInterval;        // in milliseconds, 0 means default, < 0 means disabled

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -34,7 +34,7 @@ public:
 
 	struct Configuration {
 		bool disableTlsVerification = false; // if true, don't verify the TLS certificate
-		optional<ProxyServer> proxyServer;
+		optional<ProxyServer> proxyServer;   // only non-authenticated http supported for now
 		std::vector<string> protocols;
 		optional<std::chrono::milliseconds> pingInterval; // zero to disable
 		optional<int> maxOutstandingPings;

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -51,8 +51,9 @@ void WebSocket::open(const string &url) {
 	if (config.proxyServer) {		
 		if( config.proxyServer->type == ProxyServer::Type::Socks5)
 			throw std::invalid_argument("Proxy server support for WebSocket is not implemented for Socks5");
-		if (config.proxyServer->username || config.proxyServer->password)
+		if (config.proxyServer->username || config.proxyServer->password) {
 			PLOG_WARNING << "HTTP authentication support for proxy is not implemented";
+		}
 	}
 
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -47,6 +47,11 @@ void WebSocket::open(const string &url) {
 
 	if (state != State::Closed)
 		throw std::logic_error("WebSocket must be closed before opening");
+	
+	if (config.proxyServer) {		
+		if( config.proxyServer->type == ProxyServer::Type::Socks5)
+			throw std::invalid_argument("Proxy server support for WebSocket is not implemented for Socks5");
+	}
 
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B
 	static const char *rs =

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -51,6 +51,8 @@ void WebSocket::open(const string &url) {
 	if (config.proxyServer) {		
 		if( config.proxyServer->type == ProxyServer::Type::Socks5)
 			throw std::invalid_argument("Proxy server support for WebSocket is not implemented for Socks5");
+		if (config.proxyServer->username || config.proxyServer->password)
+			PLOG_WARNING << "HTTP authentication support for proxy is not implemented";
 	}
 
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B


### PR DESCRIPTION
This PR cleans up a side-effect from the PR #827, that is descripted in issue #837. 

This PR modifies the open function to throw an exception if a non-http proxy is supplied in the WebSocket configuration. In addition I added a warning that username + password are not supported on the http proxy for now.