### PR TITLE
Fix renaming of rtcGetLastTrackSenderReportTimestamp() in C API header

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -327,7 +327,7 @@ RTC_C_EXPORT int rtcGetCurrentTrackTimestamp(int id, uint32_t *timestamp);
 // Set RTP timestamp for track identified by given id
 RTC_C_EXPORT int rtcSetTrackRtpTimestamp(int id, uint32_t timestamp);
 
-// Get timestamp of previous RTCP SR, result is written to timestamp
+// Get timestamp of last RTCP SR, result is written to timestamp
 RTC_C_EXPORT int rtcGetLastTrackSenderReportTimestamp(int id, uint32_t *timestamp);
 
 // Set NeedsToReport flag in RtcpSrReporter handler identified by given track id

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -328,7 +328,7 @@ RTC_C_EXPORT int rtcGetCurrentTrackTimestamp(int id, uint32_t *timestamp);
 RTC_C_EXPORT int rtcSetTrackRtpTimestamp(int id, uint32_t timestamp);
 
 // Get timestamp of previous RTCP SR, result is written to timestamp
-RTC_C_EXPORT int rtcGetPreviousTrackSenderReportTimestamp(int id, uint32_t *timestamp);
+RTC_C_EXPORT int rtcGetLastTrackSenderReportTimestamp(int id, uint32_t *timestamp);
 
 // Set NeedsToReport flag in RtcpSrReporter handler identified by given track id
 RTC_C_EXPORT int rtcSetNeedsToSendRtcpSr(int id);


### PR DESCRIPTION
The C API function `rtcGetLastTrackSenderReportTimestamp()` was not renamed in the header.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/844