### PR TITLE
Prevent poll service failure with WSAENOTSOCK on Windows

### DIFF
--- a/src/impl/pollservice.cpp
+++ b/src/impl/pollservice.cpp
@@ -104,11 +104,13 @@ void PollService::prepare(std::vector<struct pollfd> &pfds, optional<clock::time
 }
 
 void PollService::process(std::vector<struct pollfd> &pfds) {
-	std::unique_lock lock(mMutex);
-
 	auto it = pfds.begin();
-	mInterrupter->process(*it++);
+	if (it != pfds.end()) {
+		std::unique_lock lock(mMutex);
+		mInterrupter->process(*it++);
+	}
 	while (it != pfds.end()) {
+		std::unique_lock lock(mMutex);
 		socket_t sock = it->fd;
 		auto jt = mSocks->find(sock);
 		if (jt != mSocks->end()) {


### PR DESCRIPTION
This PR introduces a workaround to prevent `PollService::runLoop()` from failing if `WSAPoll()` returns `WSAENOTSOCK` on Windows.