### PR TITLE
Fix RTC_CODEC_VP9 in C API adding VP8 instead of VP9

### DIFF
--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -998,7 +998,7 @@ int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
 				desc.addVP8Codec(init->payloadType);
 				break;
 			case RTC_CODEC_VP9:
-				desc.addVP8Codec(init->payloadType);
+				desc.addVP9Codec(init->payloadType);
 				break;
 			default:
 				break;


### PR DESCRIPTION
Fix https://github.com/paullouisageneau/libdatachannel/issues/868