### PR TITLE
Fix incorrect check concealing failures with OpenSSL

### DIFF
--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -102,15 +102,12 @@ bool check(int success, const string &message) {
 }
 
 bool check(SSL *ssl, int ret, const string &message) {
-	if (ret == BIO_EOF)
-		return true;
-
 	unsigned long err = SSL_get_error(ssl, ret);
 	if (err == SSL_ERROR_NONE || err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
 		return true;
 	}
 	if (err == SSL_ERROR_ZERO_RETURN) {
-		PLOG_DEBUG << "DTLS connection cleanly closed";
+		PLOG_DEBUG << "OpenSSL connection cleanly closed";
 		return false;
 	}
 	string str = error_string(err);


### PR DESCRIPTION
This PR fixes `openssl::check()` by removing the incorrect `BIO_EOF` check which was concealing failure conditions. The empty input BIO situation is handled by the `err == SSL_ERROR_WANT_READ` check.

Fix https://github.com/paullouisageneau/libdatachannel/issues/869