### PR TITLE
Fix MbedTLS sync and refactor MbedTLS error checking

### DIFF
--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -71,12 +71,12 @@ protected:
 	static int TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms);
 
 #elif USE_MBEDTLS
-	std::mutex mMutex;
-
 	mbedtls_entropy_context mEntropy;
 	mbedtls_ctr_drbg_context mDrbg;
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
+
+	std::mutex mSslMutex;
 
 	uint32_t mFinMs = 0, mIntMs = 0;
 	std::chrono::time_point<std::chrono::steady_clock> mTimerSetAt;

--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -8,9 +8,8 @@
 
 #include "tls.hpp"
 
-#include "internals.hpp"
-
 #include <fstream>
+#include <stdexcept>
 
 #if USE_GNUTLS
 
@@ -19,10 +18,8 @@ namespace rtc::gnutls {
 bool check(int ret, const string &message) {
 	if (ret < 0) {
 		if (!gnutls_error_is_fatal(ret)) {
-			PLOG_INFO << gnutls_strerror(ret);
 			return false;
 		}
-		PLOG_ERROR << message << ": " << gnutls_strerror(ret);
 		throw std::runtime_error(message + ": " + gnutls_strerror(ret));
 	}
 	return true;
@@ -103,7 +100,6 @@ void check(int ret, const string &message) {
 		const size_t bufferSize = 1024;
 		char buffer[bufferSize];
 		mbedtls_strerror(ret, reinterpret_cast<char *>(buffer), bufferSize);
-		PLOG_ERROR << message << ": " << buffer;
 		throw std::runtime_error(message + ": " + std::string(buffer));
 	}
 }
@@ -171,7 +167,6 @@ bool check(int success, const string &message) {
 		return true;
 
 	string str = error_string(ERR_get_error());
-	PLOG_ERROR << message << ": " << str;
 	throw std::runtime_error(message + ": " + str);
 }
 
@@ -181,11 +176,9 @@ bool check(SSL *ssl, int ret, const string &message) {
 		return true;
 	}
 	if (err == SSL_ERROR_ZERO_RETURN) {
-		PLOG_DEBUG << "OpenSSL connection cleanly closed";
 		return false;
 	}
 	string str = error_string(err);
-	PLOG_ERROR << str;
 	throw std::runtime_error(message + ": " + str);
 }
 

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -52,7 +52,7 @@ gnutls_datum_t make_datum(char *data, size_t size);
 
 namespace rtc::mbedtls {
 
-void check(int ret, const string &message = "MbedTLS error");
+bool check(int ret, const string &message = "MbedTLS error");
 
 string format_time(const std::chrono::system_clock::time_point &tp);
 

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -65,14 +65,15 @@ protected:
 	static ssize_t WriteCallback(gnutls_transport_ptr_t ptr, const void *data, size_t len);
 	static ssize_t ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_t maxlen);
 	static int TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms);
-#elif USE_MBEDTLS
-	std::mutex mSendMutex;
-	std::atomic<bool> mOutgoingResult = true;
 
+#elif USE_MBEDTLS
 	mbedtls_entropy_context mEntropy;
 	mbedtls_ctr_drbg_context mDrbg;
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
+
+	std::mutex mSslMutex;
+	std::atomic<bool> mOutgoingResult = true;
 
 	message_ptr mIncomingMessage;
 	size_t mIncomingMessagePosition = 0;


### PR DESCRIPTION
This PR fixes the missing lock when calling `mbedtls_ssl_read()` in `TlsTransport` and refactors error checking for MbedTLS.