### PR TITLE
Synchronize calls to the same OpenSSL object

### DIFF
--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -73,6 +73,7 @@ protected:
 	SSL_CTX *mCtx = NULL;
 	SSL *mSsl = NULL;
 	BIO *mInBio, *mOutBio;
+	std::mutex mSslMutex;
 
 	static BIO_METHOD *BioMethods;
 	static int TransportExIndex;

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -67,11 +67,13 @@ protected:
 	SSL_CTX *mCtx;
 	SSL *mSsl;
 	BIO *mInBio, *mOutBio;
+	std::mutex mSslMutex;
+
+	bool flushOutput();
 
 	static int TransportExIndex;
-
-	static int CertificateCallback(int preverify_ok, X509_STORE_CTX *ctx);
 	static void InfoCallback(const SSL *ssl, int where, int ret);
+
 #endif
 };
 


### PR DESCRIPTION
OpenSSL does not guarantee that any of its objects can be used concurrently by multiple threads, even for `SSL_read()` and `SSL_write()` without renegotiation. Therefore, this PR synchronizes OpenSSL calls in `DtlsTransport` and `TlsTransport`.