### PR TITLE
Add datachannel-native to external resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Features:
 - Unity bindings for Windows 10 and Hololens: [datachannel-unity](https://github.com/hanseuljun/datachannel-unity)
 - WebAssembly wrapper compatible with libdatachannel: [datachannel-wasm](https://github.com/paullouisageneau/datachannel-wasm)
 - Lightweight STUN/TURN server: [Violet](https://github.com/paullouisageneau/violet)
-- Native platform (Android/iOS/macOS) wrapper for libdatachannel(https://github.com/swarm-cloud/datachannel-native)
+- Native platform (Android/iOS/macOS) wrapper for libdatachannel: [datachannel-native](https://github.com/swarm-cloud/datachannel-native)
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Features:
 - Unity bindings for Windows 10 and Hololens: [datachannel-unity](https://github.com/hanseuljun/datachannel-unity)
 - WebAssembly wrapper compatible with libdatachannel: [datachannel-wasm](https://github.com/paullouisageneau/datachannel-wasm)
 - Lightweight STUN/TURN server: [Violet](https://github.com/paullouisageneau/violet)
+- Native platform (Android/iOS/macOS) wrapper for libdatachannel(https://github.com/swarm-cloud/datachannel-native)
 
 ## Thanks
 


### PR DESCRIPTION
datachannel-native is a Native platform (Android/iOS/macOS) wrapper for libdatachannel, it's used in production and working perfect :)