### PR TITLE
Add Simulcast support

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -91,6 +91,7 @@ public:
 		std::vector<string> attributes() const;
 		void addAttribute(string attr);
 		void removeAttribute(const string &attr);
+		void addRid(string rid);
 
 		struct RTC_CPP_EXPORT ExtMap {
 			static int parseId(string_view description);
@@ -119,6 +120,7 @@ public:
 
 	protected:
 		Entry(const string &mline, string mid, Direction dir = Direction::Unknown);
+
 		virtual string generateSdpLines(string_view eol) const;
 
 		std::vector<string> mAttributes;
@@ -128,6 +130,7 @@ public:
 		string mType;
 		string mDescription;
 		string mMid;
+		std::vector<string> mRids;
 		Direction mDirection;
 		bool mIsRemoved;
 	};

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -39,6 +39,7 @@ struct RTC_CPP_EXPORT RtpExtensionHeader {
 
 	void clearBody();
 	void writeCurrentVideoOrientation(size_t offset, uint8_t id, uint8_t value);
+	void writeOneByteHeader(size_t offset, uint8_t id, const byte *value, size_t size);
 };
 
 struct RTC_CPP_EXPORT RtpHeader {

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -130,12 +130,20 @@ void RtpExtensionHeader::setHeaderLength(uint16_t headerLength) {
 
 void RtpExtensionHeader::clearBody() { std::memset(getBody(), 0, getSize()); }
 
-void RtpExtensionHeader::writeCurrentVideoOrientation(size_t offset, uint8_t id, uint8_t value) {
-	if ((id == 0) || (id > 14) || ((offset + 2) > getSize()))
+void RtpExtensionHeader::writeOneByteHeader(size_t offset, uint8_t id, const byte *value, size_t size) {
+	if ((id == 0) || (id > 14) || (size == 0) || (size > 16) || ((offset + 1 + size) > getSize()))
 		return;
 	auto buf = getBody() + offset;
 	buf[0] = id << 4;
-	buf[1] = value;
+	if (size != 1) {
+		buf[0] |= (uint8_t(size) - 1);
+	}
+	std::memcpy(buf + 1, value, size);
+}
+
+void RtpExtensionHeader::writeCurrentVideoOrientation(size_t offset, const uint8_t id, uint8_t value) {
+	auto v = std::byte{value};
+	writeOneByteHeader(offset, id, &v, 1);
 }
 
 SSRC RtcpReportBlock::getSSRC() const { return ntohl(_ssrc); }


### PR DESCRIPTION
This allow senders to send multiple quality levels as one stream. 

I also added an example. It just works against the public WHIP/WHEP server I run. I will adjust to w/e you think is best @paullouisageneau. I need to make everything argv driven, but currently you can 

* run example
* `ffmpeg -re -f lavfi -i testsrc=size=640x480:rate=30 -pix_fmt yuv420p -c:v libx264 -g 10 -preset ultrafast -tune zerolatency -f rtp -payload_type 96 'rtp://127.0.0.1:6000?pkt_size=1200`
* Load https://b.siobud.com/seanTest

Then you will see a drop down where you can select different quality levels.