### PR TITLE
Fix multiple issues with OpenSSL

### DIFF
--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -393,8 +393,7 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 
 		SSL_CTX_set_min_proto_version(mCtx, DTLS1_VERSION);
 		SSL_CTX_set_read_ahead(mCtx, 1);
-		//sent the dtls close_notify alert
-		//SSL_CTX_set_quiet_shutdown(mCtx, 1);
+		SSL_CTX_set_quiet_shutdown(mCtx, 0); // send the close_notify alert
 		SSL_CTX_set_info_callback(mCtx, InfoCallback);
 
 		SSL_CTX_set_verify(mCtx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -479,7 +479,6 @@ void DtlsTransport::stop() {
 	unregisterIncoming();
 	mIncomingQueue.stop();
 	mRecvThread.join();
-	SSL_shutdown(mSsl);
 }
 
 bool DtlsTransport::send(message_ptr message) {
@@ -624,6 +623,10 @@ void DtlsTransport::runRecvLoop() {
 
 			mIncomingQueue.wait(duration);
 		}
+
+		std::lock_guard lock(mSslMutex);
+		SSL_shutdown(mSsl);
+
 	} catch (const std::exception &e) {
 		PLOG_ERROR << "DTLS recv: " << e.what();
 	}

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -64,7 +64,7 @@ gnutls_datum_t make_datum(char *data, size_t size);
 namespace rtc::openssl {
 
 void init();
-string error_string(unsigned long err);
+string error_string(unsigned long error);
 
 bool check(int success, const string &message = "OpenSSL error");
 bool check(SSL *ssl, int ret, const string &message = "OpenSSL error");

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -325,7 +325,7 @@ TlsTransport::TlsTransport(shared_ptr<TcpTransport> lower, optional<string> host
 		SSL_CTX_set_options(mCtx, SSL_OP_NO_SSLv3 | SSL_OP_NO_RENEGOTIATION);
 		SSL_CTX_set_min_proto_version(mCtx, TLS1_VERSION);
 		SSL_CTX_set_read_ahead(mCtx, 1);
-		SSL_CTX_set_quiet_shutdown(mCtx, 1);
+		SSL_CTX_set_quiet_shutdown(mCtx, 0); // send the close_notify alert
 		SSL_CTX_set_info_callback(mCtx, InfoCallback);
 		SSL_CTX_set_verify(mCtx, SSL_VERIFY_NONE, NULL);
 

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -322,7 +322,7 @@ TlsTransport::TlsTransport(shared_ptr<TcpTransport> lower, optional<string> host
 			}
 		}
 
-		SSL_CTX_set_options(mCtx, SSL_OP_NO_SSLv3);
+		SSL_CTX_set_options(mCtx, SSL_OP_NO_SSLv3 | SSL_OP_NO_RENEGOTIATION);
 		SSL_CTX_set_min_proto_version(mCtx, TLS1_VERSION);
 		SSL_CTX_set_read_ahead(mCtx, 1);
 		SSL_CTX_set_quiet_shutdown(mCtx, 1);

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -391,7 +391,6 @@ void TlsTransport::stop() {
 	unregisterIncoming();
 	mIncomingQueue.stop();
 	mRecvThread.join();
-	SSL_shutdown(mSsl);
 }
 
 bool TlsTransport::send(message_ptr message) {
@@ -482,6 +481,9 @@ void TlsTransport::runRecvLoop() {
 			else
 				recv(message); // Pass zero-sized messages through
 		}
+
+		std::lock_guard lock(mSslMutex);
+		SSL_shutdown(mSsl);
 
 	} catch (const std::exception &e) {
 		PLOG_ERROR << "TLS recv: " << e.what();


### PR DESCRIPTION
This PR fixes multiple issues with OpenSSL:
- Disable renegotiation in TlsTransport
- Send the close_notify alert in TlsTransport
- Call SSL_shutdown() on clean close only and synchronize it properly
- Fix OpenSSL error handling