### PR TITLE
Add type check on track to prevent PLI for non-video tracks.

### DIFF
--- a/include/rtc/rtcpnackresponder.hpp
+++ b/include/rtc/rtcpnackresponder.hpp
@@ -44,7 +44,7 @@ class RTC_CPP_EXPORT RtcpNackResponder final : public MediaHandlerElement {
 		/// Maximum storage size
 		const unsigned maximumSize;
 
-		/// Returnst current size
+		/// Returns current size
 		unsigned size();
 
 	public:

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -119,8 +119,8 @@ bool RtcpReceivingSession::send(message_ptr msg) {
 }
 
 bool RtcpReceivingSession::requestKeyframe() {
-	pushPLI();
-	return true; // TODO Make this false when it is impossible (i.e. Opus).
+	pushPLI(); 
+	return true;
 }
 
 void RtcpReceivingSession::pushPLI() {

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -119,7 +119,7 @@ bool RtcpReceivingSession::send(message_ptr msg) {
 }
 
 bool RtcpReceivingSession::requestKeyframe() {
-	pushPLI(); 
+	pushPLI();
 	return true;
 }
 

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -45,9 +45,12 @@ void Track::setMediaHandler(shared_ptr<MediaHandler> handler) {
 }
 
 bool Track::requestKeyframe() {
-	if (auto handler = impl()->getMediaHandler())
-		return handler->requestKeyframe();
-
+	// only push PLI for video
+	if (description().type() == "video") {
+		if (auto handler = impl()->getMediaHandler()) {
+			return handler->requestKeyframe();
+		}
+	}
 	return false;
 }
 


### PR DESCRIPTION
While looking at where to handle incoming PLI messages, I made the following minor changes:
- Fix typo in rtcpnackrsponder.hpp
- Remove irrelevant comment in rtcpreceivingsession.cpp
- Modify requestKeyframe method to prevent PLI on non-video tracks