### PR TITLE
Add PeerConnection::setConfiguration() method

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -75,6 +75,7 @@ struct RTC_CPP_EXPORT Configuration {
 	bool enableIceTcp = false;    // libnice only
 	bool enableIceUdpMux = false; // libjuice only
 	bool disableAutoNegotiation = false;
+	bool disableAutoGathering = false;
 	bool forceMediaTransport = false;
 
 	// Port range

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -93,6 +93,7 @@ public:
 	void setLocalDescription(Description::Type type = Description::Type::Unspec);
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
+	void gatherLocalCandidates(std::vector<IceServer> additionalIceServers = {});
 
 	void setMediaHandler(shared_ptr<MediaHandler> handler);
 	shared_ptr<MediaHandler> getMediaHandler();

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -50,7 +50,7 @@ public:
 	Description getLocalDescription(Description::Type type) const;
 	void setRemoteDescription(const Description &description);
 	bool addRemoteCandidate(const Candidate &candidate);
-	void gatherLocalCandidates(string mid);
+	void gatherLocalCandidates(string mid, std::vector<IceServer> additionalIceServers = {});
 
 	optional<string> getLocalAddress() const;
 	optional<string> getRemoteAddress() const;
@@ -69,6 +69,8 @@ private:
 	void processGatheringDone();
 	void processTimeout();
 
+	void addIceServer(IceServer server);
+
 	Description::Role mRole;
 	string mMid;
 	std::chrono::milliseconds mTrickleTimeout;
@@ -79,6 +81,7 @@ private:
 
 #if !USE_NICE
 	unique_ptr<juice_agent_t, void (*)(juice_agent_t *)> mAgent;
+	int mTURNServersAdded = 0;
 
 	static void StateChangeCallback(juice_agent_t *agent, juice_state_t state, void *user_ptr);
 	static void CandidateCallback(juice_agent_t *agent, const char *sdp, void *user_ptr);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -146,8 +146,21 @@ void PeerConnection::setLocalDescription(Description::Type type) {
 	impl()->changeSignalingState(newSignalingState);
 	signalingLock.unlock();
 
-	if (impl()->gatheringState == GatheringState::New) {
+	if (impl()->gatheringState == GatheringState::New && !impl()->config.disableAutoGathering) {
 		iceTransport->gatherLocalCandidates(impl()->localBundleMid());
+	}
+}
+
+void PeerConnection::gatherLocalCandidates(std::vector<IceServer> additionalIceServers) {
+	auto iceTransport = impl()->getIceTransport();
+	if (!iceTransport) {
+		throw std::logic_error("No IceTransport. Local Description has not been set");
+	}
+
+	if (impl()->gatheringState == GatheringState::New) {
+		iceTransport->gatherLocalCandidates(impl()->localBundleMid(), additionalIceServers);
+	} else {
+		PLOG_WARNING << "Candidates gathering already started";
 	}
 }
 


### PR DESCRIPTION
This PR allows changing the peerconnection configuration before the ICE transport has been inited on sLD or sRD.

This is needed in order to support setting the STUN/TURN servers received on the POST answer of a WHIP call.