### PR TITLE
Update Opus to have proper media format

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1127,7 +1127,7 @@ void Description::Audio::addAudioCodec(int payloadType, string codec, optional<s
 }
 
 void Description::Audio::addOpusCodec(int payloadType, optional<string> profile) {
-	addAudioCodec(payloadType, "OPUS", profile);
+	addAudioCodec(payloadType, "opus", profile);
 }
 
 void Description::Audio::addPCMACodec(int payloadType, optional<string> profile) {


### PR DESCRIPTION
Defined as `opus` in [rfc7587#section-6.1](https://datatracker.ietf.org/doc/html/rfc7587#section-6.1)