### PR TITLE
Fix possible data channel id reuse before remote close

### DIFF
--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -26,13 +26,7 @@ DataChannel::DataChannel(impl_ptr<impl::DataChannel> impl)
     : CheshireCat<impl::DataChannel>(impl),
       Channel(std::dynamic_pointer_cast<impl::Channel>(impl)) {}
 
-DataChannel::~DataChannel() {
-	try {
-		close();
-	} catch (const std::exception &e) {
-		PLOG_ERROR << e.what();
-	}
-}
+DataChannel::~DataChannel() {}
 
 void DataChannel::close() { return impl()->close(); }
 

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -102,9 +102,7 @@ void DataChannel::close() {
 }
 
 void DataChannel::remoteClose() {
-	mIsOpen = false;
-	if (!mIsClosed.exchange(true))
-		triggerClosed();
+	close();
 }
 
 optional<message_variant> DataChannel::receive() {

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -79,8 +79,11 @@ DataChannel::DataChannel(weak_ptr<PeerConnection> pc, string label, string proto
 
 DataChannel::~DataChannel() {
 	PLOG_VERBOSE << "Destroying DataChannel";
-
-	close();
+	try {
+		close();
+	} catch (const std::exception &e) {
+		PLOG_ERROR << e.what();
+	}
 }
 
 void DataChannel::close() {

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -58,7 +58,8 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
 
 	shared_ptr<DataChannel> emplaceDataChannel(string label, DataChannelInit init);
-	shared_ptr<DataChannel> findDataChannel(uint16_t stream);
+	std::pair<shared_ptr<DataChannel>, bool> findDataChannel(uint16_t stream);
+	bool removeDataChannel(uint16_t stream);
 	uint16_t maxDataChannelStream() const;
 	void assignDataChannels();
 	void iterateDataChannels(std::function<void(shared_ptr<DataChannel> channel)> func);

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -62,7 +62,6 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	uint16_t maxDataChannelStream() const;
 	void assignDataChannels();
 	void iterateDataChannels(std::function<void(shared_ptr<DataChannel> channel)> func);
-	void cleanupDataChannels();
 	void openDataChannels();
 	void closeDataChannels();
 	void remoteCloseDataChannels();

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -30,8 +30,11 @@ Track::Track(weak_ptr<PeerConnection> pc, Description::Media description)
 
 Track::~Track() {
 	PLOG_VERBOSE << "Destroying Track";
-
-	close();
+	try {
+		close();
+	} catch (const std::exception &e) {
+		PLOG_ERROR << e.what();
+	}
 }
 
 string Track::mid() const {


### PR DESCRIPTION
This PR fixes the data channel map cleanup logic as it could result in a new data channel reusing the same stream id immediately after destruction while the remote side might still be sending on the stream. The proper logic is to unregister data channels on remote reset.