### PR TITLE
Fix DataChannel to reset stream on close if ack is not received

### DIFF
--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -95,11 +95,12 @@ void DataChannel::close() {
 		transport = mSctpTransport.lock();
 	}
 
-	if (mIsOpen.exchange(false) && transport && mStream.has_value())
-		transport->closeStream(mStream.value());
+	if (!mIsClosed.exchange(true)) {
+		if (transport && mStream.has_value())
+			transport->closeStream(mStream.value());
 
-	if (!mIsClosed.exchange(true))
 		triggerClosed();
+	}
 
 	resetCallbacks();
 }
@@ -140,7 +141,7 @@ Reliability DataChannel::reliability() const {
 	return *mReliability;
 }
 
-bool DataChannel::isOpen(void) const { return mIsOpen; }
+bool DataChannel::isOpen(void) const { return !mIsClosed && mIsOpen; }
 
 bool DataChannel::isClosed(void) const { return mIsClosed; }
 

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -435,7 +435,7 @@ void PeerConnection::forwardMessage(message_ptr message) {
 		if (found) {
 			// The stream is already used, the receiver must close the DataChannel
 			PLOG_WARNING << "Got open message on already used stream " << stream;
-			if(channel && channel->isOpen())
+			if(channel && !channel->isClosed())
 				channel->close();
 			else
 				sctpTransport->closeStream(message->stream);


### PR DESCRIPTION
`DataChannel::close()` would call `closeStream()` to reset the outgoing stream only if open, this is incorrect as it must also be done if the remote peer resets the stream instead of sending an ack.