### PR TITLE
Use plog::UTF8Converter instead of std::codecvt_utf8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ if(WIN32)
 	if(MSVC)
 		add_definitions(-DNOMINMAX)
 		add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-		add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 	endif()
 endif()
 

--- a/Jamfile
+++ b/Jamfile
@@ -26,7 +26,6 @@ lib libdatachannel
 	<toolset>msvc:<define>WIN32_LEAN_AND_MEAN
 	<toolset>msvc:<define>NOMINMAX
 	<toolset>msvc:<define>_CRT_SECURE_NO_WARNINGS
-	<toolset>msvc:<define>_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 	<library>/libdatachannel//usrsctp
 	<library>/libdatachannel//juice
 	<library>/libdatachannel//plog

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "plog/Appenders/ColorConsoleAppender.h"
+#include "plog/Converters/UTF8Converter.h"
 #include "plog/Formatters/FuncMessageFormatter.h"
 #include "plog/Formatters/TxtFormatter.h"
 #include "plog/Init.h"
@@ -18,11 +19,6 @@
 #include "impl/init.hpp"
 
 #include <mutex>
-
-#ifdef _WIN32
-#include <codecvt>
-#include <locale>
-#endif
 
 namespace {
 
@@ -58,16 +54,10 @@ struct LogAppender : public plog::IAppender {
 		auto formatted = plog::FuncMessageFormatter::format(record);
 		formatted.pop_back(); // remove newline
 
-#ifdef _WIN32
-		using convert_type = std::codecvt_utf8<wchar_t>;
-		std::wstring_convert<convert_type, wchar_t> converter;
-		std::string str = converter.to_bytes(formatted);
-#else
-		std::string str = formatted;
-#endif
+		const auto& converted = plog::UTF8Converter::convert(formatted); // does nothing on non-Windows systems
 
-		if (!callback(static_cast<LogLevel>(severity), str))
-			std::cout << plog::severityToString(severity) << " " << str << std::endl;
+		if (!callback(static_cast<LogLevel>(severity), converted))
+			std::cout << plog::severityToString(severity) << " " << converted << std::endl;
 	}
 };
 


### PR DESCRIPTION
Plog has a built-in UTF-8 conversion, so `std::codecvt_utf8` is not required. This makes code simpler and gets rid of `std::codecvt_utf8` deprecation warnings. Also it fixes using a more recent plog version (>= 1.1.10) that supports utf8everywhere mode. That mode is triggered by the `/utf-8` switch in MSVC.