### PR TITLE
Fix H264RtpPacketizer::Separator made private by #932

### DIFF
--- a/include/rtc/h264rtppacketizer.hpp
+++ b/include/rtc/h264rtppacketizer.hpp
@@ -23,9 +23,9 @@ class RTC_CPP_EXPORT H264RtpPacketizer final : public RtpPacketizer,
 	shared_ptr<NalUnits> splitMessage(binary_ptr message);
 	const uint16_t maximumFragmentSize;
 
+public:
 	using Separator = NalUnit::Separator;
 
-public:
 	/// Default clock rate for H264 in RTP
 	inline static const uint32_t defaultClockRate = 90 * 1000;
 

--- a/include/rtc/h265rtppacketizer.hpp
+++ b/include/rtc/h265rtppacketizer.hpp
@@ -24,6 +24,8 @@ class RTC_CPP_EXPORT H265RtpPacketizer final : public RtpPacketizer,
 	const uint16_t maximumFragmentSize;
 
 public:
+	using Separator = NalUnit::Separator;
+
 	/// Default clock rate for H265 in RTP
 	inline static const uint32_t defaultClockRate = 90 * 1000;
 


### PR DESCRIPTION
PR #932 moved `H264RtpPacketizer::Separator` to `NalUnit::Separator` and introduced an alias for compatibility, however the alias was made private instead of public.