### PR TITLE
Accept both "sha-265" and "SHA-256" as hash function names in SDP

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -120,7 +120,7 @@ Description::Description(const string &sdp, Type type, Role role)
 					mRole = Role::ActPass;
 
 			} else if (key == "fingerprint") {
-				if (match_prefix(value, "sha-256 ")) {
+				if (match_prefix(value, "sha-256 ") || match_prefix(value, "SHA-256 ")) {
 					string fingerprint{value.substr(8)};
 					trim_begin(fingerprint);
 					setFingerprint(std::move(fingerprint));


### PR DESCRIPTION
Fixes https://github.com/paullouisageneau/libdatachannel/issues/968