### PR TITLE
Fix unexpected POLLHUP event on connection failure on MacOS

### DIFF
--- a/src/impl/pollservice.cpp
+++ b/src/impl/pollservice.cpp
@@ -118,7 +118,9 @@ void PollService::process(std::vector<struct pollfd> &pfds) {
 				auto &entry = jt->second;
 				const auto &params = entry.params;
 
-				if (it->revents & POLLNVAL || it->revents & POLLERR) {
+				if (it->revents & POLLNVAL || it->revents & POLLERR ||
+				    (it->revents & POLLHUP &&
+				     !(it->events & POLLIN))) { // MacOS sets POLLHUP on connection failure
 					PLOG_VERBOSE << "Poll error event";
 					auto callback = std::move(params.callback);
 					mSocks->erase(sock);

--- a/test/websocketserver.cpp
+++ b/test/websocketserver.cpp
@@ -31,6 +31,7 @@ void test_websocketserver() {
 	serverConfig.enableTls = true;
 	// serverConfig.certificatePemFile = ...
 	// serverConfig.keyPemFile = ...
+	serverConfig.bindAddress = "127.0.0.1"; // to test IPv4 fallback
 	WebSocketServer server(std::move(serverConfig));
 
 	shared_ptr<WebSocket> client;


### PR DESCRIPTION
MacOS sets POLLHUP on connection failure (same as connection close) instead of POLLERR.

This PR fixes https://github.com/paullouisageneau/libdatachannel/issues/971