### PR TITLE
Disable GCM suites if unsupported by system libSRTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ LIBS=
 LOCALLIBS=libusrsctp.a
 USRSCTP_DIR=deps/usrsctp
 SRTP_DIR=deps/libsrtp
+SRTP_CONFIGURE_FLAGS=
 JUICE_DIR=deps/libjuice
 PLOG_DIR=deps/plog
 
@@ -24,6 +25,7 @@ ifneq ($(USE_GNUTLS), 0)
 else
         CPPFLAGS+=-DUSE_GNUTLS=0
         LIBS+=openssl
+        SRTP_CONFIGURE_FLAGS+=--enable-openssl
 endif
 
 USE_NICE ?= 0
@@ -122,7 +124,7 @@ libusrsctp.a:
 
 libsrtp2.a:
 	cd $(SRTP_DIR) && \
-		./configure && \
+		./configure $(SRTP_CONFIGURE_FLAGS) && \
 		make
 	cp $(SRTP_DIR)/libsrtp2.a .
 

--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -45,6 +45,17 @@ void DtlsSrtpTransport::Init() { srtp_init(); }
 
 void DtlsSrtpTransport::Cleanup() { srtp_shutdown(); }
 
+bool DtlsSrtpTransport::IsGcmSupported() {
+#if RTC_SYSTEM_SRTP
+	// system libSRTP may not have GCM support
+	srtp_policy_t policy = {};
+	return srtp_crypto_policy_set_from_profile_for_rtp(
+	           &policy.rtp, srtp_profile_aead_aes_256_gcm) == srtp_err_status_ok;
+#else
+	return true;
+#endif
+}
+
 DtlsSrtpTransport::DtlsSrtpTransport(shared_ptr<IceTransport> lower,
                                      shared_ptr<Certificate> certificate, optional<size_t> mtu,
                                      verifier_callback verifierCallback,
@@ -326,9 +337,9 @@ void DtlsSrtpTransport::postHandshake() {
 	std::memcpy(mServerSessionKey.data() + keySize, serverSalt, saltSize);
 
 	srtp_policy_t inbound = {};
-	if(srtp_crypto_policy_set_from_profile_for_rtp(&inbound.rtp, srtpProfile))
+	if (srtp_crypto_policy_set_from_profile_for_rtp(&inbound.rtp, srtpProfile))
 		throw std::runtime_error("SRTP profile is not supported");
-	if(srtp_crypto_policy_set_from_profile_for_rtcp(&inbound.rtcp, srtpProfile))
+	if (srtp_crypto_policy_set_from_profile_for_rtcp(&inbound.rtcp, srtpProfile))
 		throw std::runtime_error("SRTP profile is not supported");
 
 	inbound.ssrc.type = ssrc_any_inbound;
@@ -342,9 +353,9 @@ void DtlsSrtpTransport::postHandshake() {
 		                         to_string(static_cast<int>(err)));
 
 	srtp_policy_t outbound = {};
-	if(srtp_crypto_policy_set_from_profile_for_rtp(&outbound.rtp, srtpProfile))
+	if (srtp_crypto_policy_set_from_profile_for_rtp(&outbound.rtp, srtpProfile))
 		throw std::runtime_error("SRTP profile is not supported");
-	if(srtp_crypto_policy_set_from_profile_for_rtcp(&outbound.rtcp, srtpProfile))
+	if (srtp_crypto_policy_set_from_profile_for_rtcp(&outbound.rtcp, srtpProfile))
 		throw std::runtime_error("SRTP profile is not supported");
 
 	outbound.ssrc.type = ssrc_any_outbound;
@@ -361,7 +372,7 @@ void DtlsSrtpTransport::postHandshake() {
 }
 
 #if !USE_GNUTLS && !USE_MBEDTLS
-ProfileParams DtlsSrtpTransport::getProfileParamsFromName(string_view name) {
+DtlsSrtpTransport::ProfileParams DtlsSrtpTransport::getProfileParamsFromName(string_view name) {
 	if (name == "SRTP_AES128_CM_SHA1_80")
 		return {srtp_profile_aes128_cm_sha1_80, SRTP_AES_128_KEY_LEN, SRTP_SALT_LEN};
 	if (name == "SRTP_AES128_CM_SHA1_32")

--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -326,11 +326,13 @@ void DtlsSrtpTransport::postHandshake() {
 	std::memcpy(mServerSessionKey.data() + keySize, serverSalt, saltSize);
 
 	srtp_policy_t inbound = {};
-	srtp_crypto_policy_set_from_profile_for_rtp(&inbound.rtp, srtpProfile);
-	srtp_crypto_policy_set_from_profile_for_rtcp(&inbound.rtcp, srtpProfile);
+	if(srtp_crypto_policy_set_from_profile_for_rtp(&inbound.rtp, srtpProfile))
+		throw std::runtime_error("SRTP profile is not supported");
+	if(srtp_crypto_policy_set_from_profile_for_rtcp(&inbound.rtcp, srtpProfile))
+		throw std::runtime_error("SRTP profile is not supported");
+
 	inbound.ssrc.type = ssrc_any_inbound;
 	inbound.key = mIsClient ? mServerSessionKey.data() : mClientSessionKey.data();
-
 	inbound.window_size = 1024;
 	inbound.allow_repeat_tx = true;
 	inbound.next = nullptr;
@@ -340,8 +342,11 @@ void DtlsSrtpTransport::postHandshake() {
 		                         to_string(static_cast<int>(err)));
 
 	srtp_policy_t outbound = {};
-	srtp_crypto_policy_set_from_profile_for_rtp(&outbound.rtp, srtpProfile);
-	srtp_crypto_policy_set_from_profile_for_rtcp(&outbound.rtcp, srtpProfile);
+	if(srtp_crypto_policy_set_from_profile_for_rtp(&outbound.rtp, srtpProfile))
+		throw std::runtime_error("SRTP profile is not supported");
+	if(srtp_crypto_policy_set_from_profile_for_rtcp(&outbound.rtcp, srtpProfile))
+		throw std::runtime_error("SRTP profile is not supported");
+
 	outbound.ssrc.type = ssrc_any_outbound;
 	outbound.key = mIsClient ? mClientSessionKey.data() : mServerSessionKey.data();
 	outbound.window_size = 1024;

--- a/src/impl/dtlssrtptransport.hpp
+++ b/src/impl/dtlssrtptransport.hpp
@@ -24,16 +24,11 @@
 
 namespace rtc::impl {
 
-struct ProfileParams {
-	srtp_profile_t srtpProfile;
-	size_t keySize;
-	size_t saltSize;
-};
-
 class DtlsSrtpTransport final : public DtlsTransport {
 public:
 	static void Init();
 	static void Cleanup();
+	static bool IsGcmSupported();
 
 	DtlsSrtpTransport(shared_ptr<IceTransport> lower, certificate_ptr certificate,
 	                  optional<size_t> mtu, verifier_callback verifierCallback,
@@ -48,6 +43,12 @@ private:
 	void postHandshake() override;
 
 #if !USE_GNUTLS && !USE_MBEDTLS
+	struct ProfileParams {
+		srtp_profile_t srtpProfile;
+		size_t keySize;
+		size_t saltSize;
+	};
+
 	ProfileParams getProfileParamsFromName(string_view name);
 #endif
 


### PR DESCRIPTION
The system libSRTP may not have GCM support, so don't negotiate GCM with OpenSSL in that case.

This PR should fix https://github.com/paullouisageneau/libdatachannel/issues/977