### PR TITLE
Fix memory leak in TlsTransport with MbedTLS

### DIFF
--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -354,7 +354,15 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 	}
 }
 
-TlsTransport::~TlsTransport() {}
+TlsTransport::~TlsTransport() {
+	stop();
+
+	PLOG_DEBUG << "Destroying TLS transport";
+	mbedtls_entropy_free(&mEntropy);
+	mbedtls_ctr_drbg_free(&mDrbg);
+	mbedtls_ssl_free(&mSsl);
+	mbedtls_ssl_config_free(&mConf);
+}
 
 void TlsTransport::start() {
 	PLOG_DEBUG << "Starting TLS transport";

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -101,6 +101,8 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 
 TlsTransport::~TlsTransport() {
 	stop();
+
+	PLOG_DEBUG << "Destroying TLS transport";
 	gnutls_deinit(mSession);
 }
 
@@ -638,6 +640,8 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 
 TlsTransport::~TlsTransport() {
 	stop();
+
+	PLOG_DEBUG << "Destroying TLS transport";
 	SSL_free(mSsl);
 	SSL_CTX_free(mCtx);
 }


### PR DESCRIPTION
The `TlsTransport` destructor was not implemented for MbedTLS, causing memory leaks when using WebSockets over TLS with MbedTLS.