### PR TITLE
Implement missing methods of RtcpReportBlock

### DIFF
--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -89,19 +89,20 @@ struct RTC_CPP_EXPORT RtcpReportBlock {
 
 	[[nodiscard]] uint16_t seqNoCycles() const;
 	[[nodiscard]] uint16_t highestSeqNo() const;
+	[[nodiscard]] uint32_t extendedHighestSeqNo() const;
 	[[nodiscard]] uint32_t jitter() const;
 	[[nodiscard]] uint32_t delaySinceSR() const;
 
 	[[nodiscard]] SSRC getSSRC() const;
 	[[nodiscard]] uint32_t getNTPOfSR() const;
-	[[nodiscard]] unsigned int getLossPercentage() const;
+	[[nodiscard]] uint8_t getLossPercentage() const;
 	[[nodiscard]] unsigned int getPacketLostCount() const;
 
 	void preparePacket(SSRC in_ssrc, unsigned int packetsLost, unsigned int totalPackets,
 	                   uint16_t highestSeqNo, uint16_t seqNoCycles, uint32_t jitter,
 	                   uint64_t lastSR_NTP, uint64_t lastSR_DELAY);
 	void setSSRC(SSRC in_ssrc);
-	void setPacketsLost(unsigned int packetsLost, unsigned int totalPackets);
+	void setPacketsLost(uint8_t packetsLost, unsigned int totalPackets);
 	void setSeqNo(uint16_t highestSeqNo, uint16_t seqNoCycles);
 	void setJitter(uint32_t jitter);
 	void setNTPOfSR(uint64_t ntp);

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -95,14 +95,14 @@ struct RTC_CPP_EXPORT RtcpReportBlock {
 
 	[[nodiscard]] SSRC getSSRC() const;
 	[[nodiscard]] uint32_t getNTPOfSR() const;
-	[[nodiscard]] uint8_t getLossPercentage() const;
-	[[nodiscard]] unsigned int getPacketLostCount() const;
+	[[nodiscard]] uint8_t getFractionLost() const;
+	[[nodiscard]] unsigned int getPacketsLostCount() const;
 
 	void preparePacket(SSRC in_ssrc, unsigned int packetsLost, unsigned int totalPackets,
 	                   uint16_t highestSeqNo, uint16_t seqNoCycles, uint32_t jitter,
 	                   uint64_t lastSR_NTP, uint64_t lastSR_DELAY);
 	void setSSRC(SSRC in_ssrc);
-	void setPacketsLost(uint8_t packetsLost, unsigned int totalPackets);
+	void setPacketsLost(uint8_t fractionLost, unsigned int packetsLostCount);
 	void setSeqNo(uint16_t highestSeqNo, uint16_t seqNoCycles);
 	void setJitter(uint32_t jitter);
 	void setNTPOfSR(uint64_t ntp);

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -169,18 +169,18 @@ void RtcpReportBlock::preparePacket(SSRC in_ssrc, [[maybe_unused]] unsigned int 
 
 void RtcpReportBlock::setSSRC(SSRC in_ssrc) { _ssrc = htonl(in_ssrc); }
 
-void RtcpReportBlock::setPacketsLost(uint8_t packetsLost,
-                                     unsigned int totalPackets) {
-	_fractionLostAndPacketsLost = ( (uint32_t)packetsLost << 24) && htonl(totalPackets);
+void RtcpReportBlock::setPacketsLost(uint8_t fractionLost,
+                                     unsigned int packetsLostCount) {
+	_fractionLostAndPacketsLost = ( (uint32_t)fractionLost << 24) && htonl(packetsLostCount);
 }
 
-uint8_t RtcpReportBlock::getLossPercentage() const {
-	// Loss percentage is expressed as 8-bit fixed point number
-	// In order to get actual percentage divide the result by 256
+uint8_t RtcpReportBlock::getFractionLost() const {
+	// Fraction lost is expressed as 8-bit fixed point number
+	// In order to get actual lost percentage divide the result by 256
 	return _fractionLostAndPacketsLost & 0xFF;
 }
 
-unsigned int RtcpReportBlock::getPacketLostCount() const {
+unsigned int RtcpReportBlock::getPacketsLostCount() const {
 	return ntohl(_fractionLostAndPacketsLost & 0xFFFFFF00);
 }
 

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -169,25 +169,26 @@ void RtcpReportBlock::preparePacket(SSRC in_ssrc, [[maybe_unused]] unsigned int 
 
 void RtcpReportBlock::setSSRC(SSRC in_ssrc) { _ssrc = htonl(in_ssrc); }
 
-void RtcpReportBlock::setPacketsLost([[maybe_unused]] unsigned int packetsLost,
-                                     [[maybe_unused]] unsigned int totalPackets) {
-	// TODO Implement loss percentages.
-	_fractionLostAndPacketsLost = 0;
+void RtcpReportBlock::setPacketsLost(uint8_t packetsLost,
+                                     unsigned int totalPackets) {
+	_fractionLostAndPacketsLost = ( (uint32_t)packetsLost << 24) && htonl(totalPackets);
 }
 
-unsigned int RtcpReportBlock::getLossPercentage() const {
-	// TODO Implement loss percentages.
-	return 0;
+uint8_t RtcpReportBlock::getLossPercentage() const {
+	// Loss percentage is expressed as 8-bit fixed point number
+	// In order to get actual percentage divide the result by 256
+	return _fractionLostAndPacketsLost & 0xFF;
 }
 
 unsigned int RtcpReportBlock::getPacketLostCount() const {
-	// TODO Implement total packets lost.
-	return 0;
+	return ntohl(_fractionLostAndPacketsLost & 0xFFFFFF00);
 }
 
 uint16_t RtcpReportBlock::seqNoCycles() const { return ntohs(_seqNoCycles); }
 
 uint16_t RtcpReportBlock::highestSeqNo() const { return ntohs(_highestSeqNo); }
+
+uint32_t RtcpReportBlock::extendedHighestSeqNo() const { return (seqNoCycles() <<  16) | highestSeqNo(); }
 
 uint32_t RtcpReportBlock::jitter() const { return ntohl(_jitter); }
 


### PR DESCRIPTION
This PR implements `setPacketsLost`, `getLossPercentage` and `getPacketLostCount` methods of `RtcpReportBlock` that we need for receiver reports.

I also added `extendedHighestSeqNo `method to return the extended sequence number of RtcpReportBlock in case one wants to access the the whole thing.