### PR TITLE
Set SCTP zero checksum

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -86,9 +86,6 @@ struct RTC_CPP_EXPORT Configuration {
 
 	// Local maximum message size for Data Channels
 	optional<size_t> maxMessageSize;
-
-	// SCTP settings
-	bool sctpZeroChecksum = false;
 };
 
 } // namespace rtc

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -86,6 +86,9 @@ struct RTC_CPP_EXPORT Configuration {
 
 	// Local maximum message size for Data Channels
 	optional<size_t> maxMessageSize;
+
+	// SCTP settings
+	bool sctpZeroChecksum = false;
 };
 
 } // namespace rtc


### PR DESCRIPTION
Based on the discussion at https://github.com/paullouisageneau/libdatachannel/discussions/1012, where it was concluded that enabling `SCTP_ACCEPT_ZERO_CHECKSUM` is not an issue, I have implemented zero checksum.