### PR TITLE
Correct NTP of Sender Report

### DIFF
--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -171,7 +171,7 @@ void RtcpReportBlock::setSSRC(SSRC in_ssrc) { _ssrc = htonl(in_ssrc); }
 
 void RtcpReportBlock::setPacketsLost(uint8_t fractionLost,
                                      unsigned int packetsLostCount) {
-	_fractionLostAndPacketsLost = ( (uint32_t)fractionLost << 24) && htonl(packetsLostCount);
+	_fractionLostAndPacketsLost = ((uint32_t)fractionLost << 24) && htonl(packetsLostCount);
 }
 
 uint8_t RtcpReportBlock::getFractionLost() const {
@@ -201,7 +201,7 @@ void RtcpReportBlock::setSeqNo(uint16_t highestSeqNo, uint16_t seqNoCycles) {
 
 void RtcpReportBlock::setJitter(uint32_t jitter) { _jitter = htonl(jitter); }
 
-void RtcpReportBlock::setNTPOfSR(uint64_t ntp) { _lastReport = htonll(ntp >> 16u); }
+void RtcpReportBlock::setNTPOfSR(uint64_t ntp) { _lastReport = htonl((uint32_t)(ntp >> 16)); }
 
 uint32_t RtcpReportBlock::getNTPOfSR() const { return ntohl(_lastReport) << 16u; }
 


### PR DESCRIPTION
Hello,

I had an issue when calling preparePacket() on a reportBlock and looking into the sender report results (arm 64-bit instance). The way the NTP timestamp was mangled wasn't correct.

As per spec it is doing the correct bit shift, however when doing the host to network byte conversion we only care about the result (which is an uint32_t). Currently it performed a host to network byte order on a uint64_t and then converted it into a uint32_t (the type of _lastReport) which, depending on the system, can provide an invalid result. 

In the updated code:
- input is an 64-bit value
- we shift it 16 right
- then take the present 32-bits (which are basically bits 16 to 48 of the original 64-bit value)
- convert it depending on the OS and store the value.

Thanks.