### PR TITLE
Add RtcpReceivingSession support to C API

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -291,6 +291,9 @@ RTC_C_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
 RTC_C_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
 RTC_C_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
 
+RTC_C_EXPORT int rtcSendTrackRequestKeyframe(int tr);
+RTC_C_EXPORT int rtcSendTrackRequestBitrate(int tr, unsigned int bitrate);
+
 #if RTC_ENABLE_MEDIA
 
 // Media
@@ -363,6 +366,9 @@ RTC_C_EXPORT int rtcSetOpusPacketizationHandler(int tr, const rtcPacketizationHa
 
 // Set AACPacketizationHandler for track
 RTC_C_EXPORT int rtcSetAACPacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
+
+// Set RtcpReceivingSession for track
+RTC_C_EXPORT int rtcSetRtcpReceivingSession(int tr);
 
 // Chain RtcpSrReporter to handler chain for given track
 RTC_C_EXPORT int rtcChainRtcpSrReporter(int tr);

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -291,8 +291,8 @@ RTC_C_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
 RTC_C_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
 RTC_C_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
 
-RTC_C_EXPORT int rtcSendTrackRequestKeyframe(int tr);
-RTC_C_EXPORT int rtcSendTrackRequestBitrate(int tr, unsigned int bitrate);
+RTC_C_EXPORT int rtcRequestKeyframe(int tr);
+RTC_C_EXPORT int rtcRequestBitrate(int tr, unsigned int bitrate);
 
 #if RTC_ENABLE_MEDIA
 
@@ -368,7 +368,7 @@ RTC_C_EXPORT int rtcSetOpusPacketizationHandler(int tr, const rtcPacketizationHa
 RTC_C_EXPORT int rtcSetAACPacketizationHandler(int tr, const rtcPacketizationHandlerInit *init);
 
 // Set RtcpReceivingSession for track
-RTC_C_EXPORT int rtcSetRtcpReceivingSession(int tr);
+RTC_C_EXPORT int rtcChainRtcpReceivingSession(int tr);
 
 // Chain RtcpSrReporter to handler chain for given track
 RTC_C_EXPORT int rtcChainRtcpSrReporter(int tr);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1144,7 +1144,7 @@ int rtcGetTrackDirection(int tr, rtcDirection *direction) {
 	});
 }
 
-int rtcSendTrackRequestKeyframe(int tr) {
+int rtcRequestKeyframe(int tr) {
 	return wrap([&] {
 		auto track = getTrack(tr);
 		track->requestKeyframe();
@@ -1152,7 +1152,7 @@ int rtcSendTrackRequestKeyframe(int tr) {
 	});
 }
 
-int rtcSendTrackRequestBitrate(int tr, unsigned int bitrate) {
+int rtcRequestBitrate(int tr, unsigned int bitrate) {
 	return wrap([&] {
 		auto track = getTrack(tr);
 		track->requestBitrate(bitrate);
@@ -1292,11 +1292,11 @@ int rtcSetAACPacketizationHandler(int tr, const rtcPacketizationHandlerInit *ini
 	});
 }
 
-int rtcSetRtcpReceivingSession(int tr) {
+int rtcChainRtcpReceivingSession(int tr) {
 	return wrap([&] {
 		auto track = getTrack(tr);
 		auto session = std::make_shared<rtc::RtcpReceivingSession>();
-		track->setMediaHandler(session);
+		track->chainMediaHandler(session);
 		return RTC_ERR_SUCCESS;
 	});
 }

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1144,6 +1144,22 @@ int rtcGetTrackDirection(int tr, rtcDirection *direction) {
 	});
 }
 
+int rtcSendTrackRequestKeyframe(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		track->requestKeyframe();
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSendTrackRequestBitrate(int tr, unsigned int bitrate) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		track->requestBitrate(bitrate);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 #if RTC_ENABLE_MEDIA
 
 void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, const char *_msid,
@@ -1272,6 +1288,15 @@ int rtcSetAACPacketizationHandler(int tr, const rtcPacketizationHandlerInit *ini
 		// create packetizer
 		auto packetizer = std::make_shared<AACRtpPacketizer>(rtpConfig);
 		track->setMediaHandler(packetizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSetRtcpReceivingSession(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto session = std::make_shared<rtc::RtcpReceivingSession>();
+		track->setMediaHandler(session);
 		return RTC_ERR_SUCCESS;
 	});
 }


### PR DESCRIPTION
I've straightforwardly added `RtcpReceivingSession` to the CAPI.
As for usage, also added `rtcSendTrackRequestKeyframe` and `rtcSendTrackRequestBitrate` to the Track API. 

With the current master branch, it causes a SEGV when setting `RtcpReceivingSession`.
so this PR necessary to merge #1027 beforehand.

related: #549 