### PR TITLE
Refactor Data Channel reliability API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/track.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/capi_connectivity.cpp

--- a/DOC.md
+++ b/DOC.md
@@ -644,8 +644,8 @@ Arguments:
   - `reliability`: a structure of reliability settings containing:
     - `unordered`: if `true`, the Data Channel will not enforce message ordering, else it will be ordered
     - `unreliable`: if `true`, the Data Channel will not enforce strict reliability, else it will be reliable
-    - `maxPacketLifeTime`: if unreliable, maximum packet life time in milliseconds
-    - `maxRetransmits`: if unreliable and maxPacketLifeTime is 0, maximum number of retransmissions (0 means no retransmission)
+    - `maxPacketLifeTime`: if unreliable, time window in milliseconds during which transmissions and retransmissions may occur
+    - `maxRetransmits`: if unreliable and maxPacketLifeTime is 0, maximum number of attempted retransmissions (0 means no retransmission)
   - `protocol` (optional): a user-defined UTF-8 string representing the Data Channel protocol, empty if NULL
   - `negotiated`: if `true`, the Data Channel is assumed to be negotiated by the user and won't be negotiated by the WebRTC layer
   - `manualStream`: if `true`, the Data Channel will use `stream` as stream ID, else an available id is automatically selected

--- a/include/rtc/reliability.hpp
+++ b/include/rtc/reliability.hpp
@@ -16,10 +16,25 @@
 namespace rtc {
 
 struct Reliability {
-	enum class Type { Reliable = 0, Rexmit, Timed };
-
-	Type type = Type::Reliable;
+	// It true, the channel does not enforce message ordering and out-of-order delivery is allowed
 	bool unordered = false;
+
+	// If both maxPacketLifeTime or maxRetransmits are unset, the channel is reliable.
+	// If either maxPacketLifeTime or maxRetransmits is set, the channel is unreliable.
+	// (The settings are exclusive so both maxPacketLifetime and maxRetransmits must not be set.)
+
+	// Time window during which transmissions and retransmissions may occur
+	optional<std::chrono::milliseconds> maxPacketLifeTime;
+
+	// Maximum number of retransmissions that are attempted
+	optional<unsigned int> maxRetransmits;
+
+	// For backward compatibility, do not use
+	enum class Type { Reliable = 0, Rexmit, Timed };
+	union {
+		Type typeDeprecated = Type::Reliable;
+		[[deprecated("Use maxPacketLifeTime or maxRetransmits")]] Type type;
+	};
 	variant<int, std::chrono::milliseconds> rexmit = 0;
 };
 

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -245,8 +245,8 @@ RTC_C_EXPORT int rtcReceiveMessage(int id, char *buffer, int *size);
 typedef struct {
 	bool unordered;
 	bool unreliable;
-	int maxPacketLifeTime; // ignored if reliable
-	int maxRetransmits;    // ignored if reliable
+	unsigned int maxPacketLifeTime; // ignored if reliable
+	unsigned int maxRetransmits;    // ignored if reliable
 } rtcReliability;
 
 typedef struct {

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -647,8 +647,8 @@ Arguments:
   - `reliability`: a structure of reliability settings containing:
     - `unordered`: if `true`, the Data Channel will not enforce message ordering, else it will be ordered
     - `unreliable`: if `true`, the Data Channel will not enforce strict reliability, else it will be reliable
-    - `maxPacketLifeTime`: if unreliable, maximum packet life time in milliseconds
-    - `maxRetransmits`: if unreliable and maxPacketLifeTime is 0, maximum number of retransmissions (0 means no retransmission)
+    - `maxPacketLifeTime`: if unreliable, time window in milliseconds during which transmissions and retransmissions may occur
+    - `maxRetransmits`: if unreliable and maxPacketLifeTime is 0, maximum number of attempted retransmissions (0 means no retransmission)
   - `protocol` (optional): a user-defined UTF-8 string representing the Data Channel protocol, empty if NULL
   - `negotiated`: if `true`, the Data Channel is assumed to be negotiated by the user and won't be negotiated by the WebRTC layer
   - `manualStream`: if `true`, the Data Channel will use `stream` as stream ID, else an available id is automatically selected

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -10,6 +10,7 @@
 #include "dtlstransport.hpp"
 #include "internals.hpp"
 #include "logcounter.hpp"
+#include "utils.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -50,27 +51,10 @@
 using namespace std::chrono_literals;
 using namespace std::chrono;
 
-namespace {
-
-template <typename T> uint16_t to_uint16(T i) {
-	if (i >= 0 && static_cast<typename std::make_unsigned<T>::type>(i) <=
-	                  std::numeric_limits<uint16_t>::max())
-		return static_cast<uint16_t>(i);
-	else
-		throw std::invalid_argument("Integer out of range");
-}
-
-template <typename T> uint32_t to_uint32(T i) {
-	if (i >= 0 && static_cast<typename std::make_unsigned<T>::type>(i) <=
-	                  std::numeric_limits<uint32_t>::max())
-		return static_cast<uint32_t>(i);
-	else
-		throw std::invalid_argument("Integer out of range");
-}
-
-} // namespace
-
 namespace rtc::impl {
+
+using utils::to_uint16;
+using utils::to_uint32;
 
 static LogCounter COUNTER_UNKNOWN_PPID(plog::warning,
                                        "Number of SCTP packets received with an unknown PPID");

--- a/src/impl/utils.hpp
+++ b/src/impl/utils.hpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <map>
 #include <random>
+#include <stdexcept>
 #include <vector>
 
 namespace rtc::impl::utils {
@@ -58,6 +59,22 @@ template <typename Generator = std::mt19937> auto random_bytes_engine() {
 	static_assert(char_independent_bits_engine::min() == std::numeric_limits<uint8_t>::min());
 	static_assert(char_independent_bits_engine::max() == std::numeric_limits<uint8_t>::max());
 	return random_engine<char_independent_bits_engine, uint8_t>();
+}
+
+template <typename T> uint16_t to_uint16(T i) {
+	if (i >= 0 && static_cast<typename std::make_unsigned<T>::type>(i) <=
+	                  std::numeric_limits<uint16_t>::max())
+		return static_cast<uint16_t>(i);
+	else
+		throw std::invalid_argument("Integer out of range");
+}
+
+template <typename T> uint32_t to_uint32(T i) {
+	if (i >= 0 && static_cast<typename std::make_unsigned<T>::type>(i) <=
+	                  std::numeric_limits<uint32_t>::max())
+		return static_cast<uint32_t>(i);
+	else
+		throw std::invalid_argument("Integer out of range");
 }
 
 namespace this_thread {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -15,8 +15,9 @@
 using namespace std;
 using namespace chrono_literals;
 
-void test_negotiated();
 void test_connectivity(bool signal_wrong_fingerprint);
+void test_negotiated();
+void test_reliability();
 void test_turn_connectivity();
 void test_track();
 void test_capi_connectivity();
@@ -72,6 +73,14 @@ int main(int argc, char **argv) {
 		cout << "*** Finished WebRTC negotiated DataChannel test" << endl;
 	} catch (const exception &e) {
 		cerr << "WebRTC negotiated DataChannel test failed: " << e.what() << endl;
+		return -1;
+	}
+	try {
+		cout << endl << "*** Running WebRTC reliability mode test..." << endl;
+		test_reliability();
+		cout << "*** Finished WebRTC reliaility mode test" << endl;
+	} catch (const exception &e) {
+		cerr << "WebRTC reliability test failed: " << e.what() << endl;
 		return -1;
 	}
 #if RTC_ENABLE_MEDIA

--- a/test/reliability.cpp
+++ b/test/reliability.cpp
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2019 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "rtc/rtc.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+using namespace rtc;
+using namespace std;
+
+void test_reliability() {
+	InitLogger(LogLevel::Debug);
+
+	Configuration config1;
+	// STUN server example (not necessary to connect locally)
+	config1.iceServers.emplace_back("stun:stun.l.google.com:19302");
+
+	PeerConnection pc1(config1);
+
+	Configuration config2;
+	// STUN server example (not necessary to connect locally)
+	config2.iceServers.emplace_back("stun:stun.l.google.com:19302");
+
+	PeerConnection pc2(config2);
+
+	pc1.onLocalDescription([&pc2](Description sdp) {
+		cout << "Description 1: " << sdp << endl;
+		pc2.setRemoteDescription(string(sdp));
+	});
+
+	pc1.onLocalCandidate([&pc2](Candidate candidate) {
+		cout << "Candidate 1: " << candidate << endl;
+		pc2.addRemoteCandidate(string(candidate));
+	});
+
+	pc2.onLocalDescription([&pc1](Description sdp) {
+		cout << "Description 2: " << sdp << endl;
+		pc1.setRemoteDescription(string(sdp));
+	});
+
+	pc2.onLocalCandidate([&pc1](Candidate candidate) {
+		cout << "Candidate 2: " << candidate << endl;
+		pc1.addRemoteCandidate(string(candidate));
+	});
+
+	Reliability reliableOrdered;
+	auto dcReliableOrdered = pc1.createDataChannel("reliable_ordered", {reliableOrdered});
+
+	Reliability reliableUnordered;
+	reliableUnordered.unordered = true;
+	auto dcReliableUnordered = pc1.createDataChannel("reliable_unordered", {reliableUnordered});
+
+	Reliability unreliableMaxPacketLifeTime;
+	unreliableMaxPacketLifeTime.unordered = true;
+	unreliableMaxPacketLifeTime.maxPacketLifeTime = 222ms;
+	auto dcUnreliableMaxPacketLifeTime =
+	    pc1.createDataChannel("unreliable_maxpacketlifetime", {unreliableMaxPacketLifeTime});
+
+	Reliability unreliableMaxRetransmits;
+	unreliableMaxRetransmits.unordered = true;
+	unreliableMaxRetransmits.maxRetransmits = 2;
+	auto dcUnreliableMaxRetransmits =
+	    pc1.createDataChannel("unreliable_maxretransmits", {unreliableMaxRetransmits});
+
+	std::atomic<int> count = 0;
+	std::atomic<bool> failed = false;
+	pc2.onDataChannel([&count, &failed](shared_ptr<DataChannel> dc) {
+		cout << "DataChannel 2: Received with label \"" << dc->label() << "\"" << endl;
+
+		auto label = dc->label();
+		auto reliability = dc->reliability();
+
+		try {
+			if (label == "reliable_ordered") {
+				if (reliability.unordered != false || reliability.maxPacketLifeTime ||
+				    reliability.maxRetransmits)
+					throw std::runtime_error("Expected reliable ordered");
+			} else if (label == "reliable_unordered") {
+				if (reliability.unordered != true || reliability.maxPacketLifeTime ||
+				    reliability.maxRetransmits)
+					throw std::runtime_error("Expected reliable unordered");
+			} else if (label == "unreliable_maxpacketlifetime") {
+				if (!reliability.maxPacketLifeTime || *reliability.maxPacketLifeTime != 222ms ||
+				    reliability.maxRetransmits)
+					throw std::runtime_error("Expected maxPacketLifeTime to be set");
+			} else if (label == "unreliable_maxretransmits") {
+				if (reliability.maxPacketLifeTime || !reliability.maxRetransmits ||
+				    *reliability.maxRetransmits != 2)
+					throw std::runtime_error("Expected maxRetransmits to be set");
+			} else
+				throw std::runtime_error("Unexpected label: " + label);
+		} catch (const std::exception &e) {
+			cerr << "Error: " << e.what();
+			failed = true;
+			return;
+		}
+		++count;
+	});
+
+	// Wait a bit
+	int attempts = 10;
+	shared_ptr<DataChannel> adc2;
+	while (count != 4 && !failed && attempts--)
+		this_thread::sleep_for(1s);
+
+	if (pc1.state() != PeerConnection::State::Connected ||
+	    pc2.state() != PeerConnection::State::Connected)
+		throw runtime_error("PeerConnection is not connected");
+
+	if (failed)
+		throw runtime_error("Incorrect reliability settings");
+
+	if (count != 4)
+		throw runtime_error("Some DataChannels are not open");
+
+	pc1.close();
+
+	cout << "Success" << endl;
+}


### PR DESCRIPTION
This PR refactors the C++ reliability API for clarity and consistency with both the C API and the WebRTC JavaScript API. Legacy fields are deprecated but kept for backward compatibility.