### PR TITLE
Use caCertificatePemFile in OpenSSL backend

### DIFF
--- a/src/impl/verifiedtlstransport.cpp
+++ b/src/impl/verifiedtlstransport.cpp
@@ -45,6 +45,9 @@ VerifiedTlsTransport::VerifiedTlsTransport(
 		throw;
 	}
 #else
+	if (cacert) {
+		SSL_CTX_load_verify_file(mCtx,  reinterpret_cast<const char *>(cacert->c_str()));
+	}
 	SSL_set_verify(mSsl, SSL_VERIFY_PEER, NULL);
 	SSL_set_verify_depth(mSsl, 4);
 #endif


### PR DESCRIPTION
This PR considers the `caCertificatePemFile` for the OpenSSL backend, allowing to accept self-signed certificates, useful for local development (https://letsencrypt.org/docs/certificates-for-localhost/#for-local-development).

**Expected:**
Self-signed certificates should be accepted if the client adds the certificate as verified.

**Example:**

Creation of certificates: 
```
openssl req -x509 -out localhost.crt -keyout localhost.key \
  -newkey rsa:2048 -nodes -sha256 \
  -subj '/CN=localhost' -extensions EXT -config <( \
   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
```

Server side:
```
  WebSocketServer::Configuration serverConfig;
  serverConfig.port = 48080;
  serverConfig.enableTls = true;
  serverConfig.certificatePemFile = "localhost.crt";
  serverConfig.keyPemFile = "localhost.key";
  serverConfig.bindAddress = "localhost";
```

Client:
```
  WebSocket::Configuration config;
  config.disableTlsVerification = false;
  config.caCertificatePemFile = "localhost.crt";
  WebSocket ws(config);
```
