### PR TITLE
Add #include <algorithm> to fix building with gcc 14

### DIFF
--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -12,6 +12,7 @@
 #include "transport.hpp"
 #include "utils.hpp"
 
+#include <algorithm>
 #include <iostream>
 #include <random>
 #include <sstream>


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were used internally by the library. In libdatachannel's case it is the `<algorithm>` header.

GCC 14 porting guide: https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes