### PR TITLE
Ensure rtpExtHeaderSize is a multiple of 4

### DIFF
--- a/src/rtppacketizer.cpp
+++ b/src/rtppacketizer.cpp
@@ -40,6 +40,8 @@ message_ptr RtpPacketizer::packetize(shared_ptr<binary> payload, bool mark) {
 	if (rtpExtHeaderSize != 0)
 		rtpExtHeaderSize += 4;
 
+	rtpExtHeaderSize = (rtpExtHeaderSize + 3) & ~3;
+
 	auto message = make_message(RtpHeaderSize + rtpExtHeaderSize + payload->size());
 	auto *rtp = (RtpHeader *)message->data();
 	rtp->setPayloadType(rtpConfig->payloadType);
@@ -57,8 +59,7 @@ message_ptr RtpPacketizer::packetize(shared_ptr<binary> payload, bool mark) {
 		auto extHeader = rtp->getExtensionHeader();
 		extHeader->setProfileSpecificId(0xbede);
 
-		auto headerLength = static_cast<uint16_t>(rtpExtHeaderSize - 4);
-		headerLength = static_cast<uint16_t>((headerLength + 3) / 4);
+		auto headerLength = static_cast<uint16_t>(rtpExtHeaderSize / 4) - 1;
 
 		extHeader->setHeaderLength(headerLength);
 		extHeader->clearBody();


### PR DESCRIPTION
As defined in RFC3550, headerLength counts the number of 32-bit words. Therefore, rtpExtHeaderSize must always be a multiple of 4.

