### PR TITLE
Fix media description m-line parsing

### DIFF
--- a/test/track.cpp
+++ b/test/track.cpp
@@ -95,6 +95,11 @@ void test_track() {
 	media.setBitrate(3000);
 	media.addSSRC(1234, "video-send");
 
+	const auto mediaSdp1 = string(media);
+	const auto mediaSdp2 = string(Description::Media(mediaSdp1));
+	if (mediaSdp2 != mediaSdp1)
+		throw runtime_error("Media description parsing test failed");
+
 	auto t1 = pc1.addTrack(media);
 
 	pc1.setLocalDescription();


### PR DESCRIPTION
This PR fixes m-line parsing when constructing `Description::Media` from an SDP description with `m=` prefix.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1074
