### PR TITLE
Add maxMessageSize to Websocket configuration

### DIFF
--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -43,6 +43,7 @@ public:
 		optional<string> certificatePemFile;
 		optional<string> keyPemFile;
 		optional<string> keyPemPass;
+		optional<size_t> maxMessageSize;
 	};
 
 	WebSocket();

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -156,7 +156,7 @@ bool WebSocket::isOpen() const { return state == State::Open; }
 
 bool WebSocket::isClosed() const { return state == State::Closed; }
 
-size_t WebSocket::maxMessageSize() const { return DEFAULT_MAX_MESSAGE_SIZE; }
+size_t WebSocket::maxMessageSize() const { return config.maxMessageSize.value_or(DEFAULT_MAX_MESSAGE_SIZE); }
 
 optional<message_variant> WebSocket::receive() {
 	auto next = mRecvQueue.pop();

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -41,7 +41,7 @@ bool WebSocket::isOpen() const { return impl()->state.load() == State::Open; }
 
 bool WebSocket::isClosed() const { return impl()->state.load() == State::Closed; }
 
-size_t WebSocket::maxMessageSize() const { return DEFAULT_MAX_MESSAGE_SIZE; }
+size_t WebSocket::maxMessageSize() const { return impl()->maxMessageSize(); }
 
 void WebSocket::open(const string &url) { impl()->open(url); }
 


### PR DESCRIPTION
The commits associated with this pull request add a member to the configuration struct of the websocket implementation-class.

If the option is set in the configuration struct being passed to the Websocket constructor, the configured value is used instead of the message size limit as defined in src/impl/internals.hpp.