### PR TITLE
Configure datachannel target_properties for APPLE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,13 @@ set_target_properties(datachannel PROPERTIES
 	SOVERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
 	CXX_STANDARD 17
 	CXX_VISIBILITY_PRESET default)
+
+if(APPLE)
+	set_target_properties(datachannel PROPERTIES
+		VERSION ${PROJECT_VERSION_MAJOR}
+		SOVERSION ${PROJECT_VERSION_MAJOR})
+endif()
+
 target_compile_definitions(datachannel PRIVATE RTC_EXPORTS)
 
 add_library(datachannel-static STATIC EXCLUDE_FROM_ALL


### PR DESCRIPTION
After 7591b9695c libdatachannel stopped working with OBS on macOS[0].
XCode only resolves one level of symlinks [1]. libdatachannel
is generating two levels.

This commit updates the shared object to only use only the major version
in the name.

[0] https://stackoverflow.com/questions/29946961/xcode-copy-files-build-phase-and-symlinks
[1] https://github.com/obsproject/obs-deps/pull/204#discussion_r1449200874