### PR TITLE
Fix crash in IceTransport::TimeoutCallback with libnice

### DIFF
--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -604,16 +604,14 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 }
 
 IceTransport::~IceTransport() {
-	if (mTimeoutId) {
-		g_source_remove(mTimeoutId);
-		mTimeoutId = 0;
-	}
-
 	PLOG_DEBUG << "Destroying ICE transport";
 	nice_agent_attach_recv(mNiceAgent.get(), mStreamId, 1, g_main_loop_get_context(MainLoop.get()),
 	                       NULL, NULL);
 	nice_agent_remove_stream(mNiceAgent.get(), mStreamId);
 	mNiceAgent.reset();
+
+	if (mTimeoutId)
+		g_source_remove(mTimeoutId);
 }
 
 Description::Role IceTransport::role() const { return mRole; }


### PR DESCRIPTION
This PR fixes a possible race condition when destroying `IceTransport` with libnice: the destructor disarms the timer, the nice agent changes states and rearms the timer, then the destructor destroys the nice agent. It would result in `IceTransport::TimeoutCallback` being called later for a destroyed object.

It should fix https://github.com/paullouisageneau/libdatachannel/issues/1102