### PR TITLE
Fix iterator past end of vector

### DIFF
--- a/src/message.cpp
+++ b/src/message.cpp
@@ -31,7 +31,7 @@ message_ptr make_message(size_t size, message_ptr orig) {
 		return nullptr;
 
 	auto message = std::make_shared<Message>(size, orig->type);
-	std::copy(orig->begin(), std::min(orig->end(), orig->begin() + size), message->begin());
+	std::copy(orig->begin(), orig->begin() + std::min(size, orig->size()), message->begin());
 	message->stream = orig->stream;
 	message->reliability = orig->reliability;
 	return message;


### PR DESCRIPTION
This PR fixes the iterator past end of vector introduced in #1118.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1125