### PR TITLE
RFC: introduce function SetRemoteGatherDone

### DIFF
--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -93,6 +93,7 @@ public:
 	void setLocalDescription(Description::Type type = Description::Type::Unspec);
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
+	void setRemoteGatherDone();
 
 	void setMediaHandler(shared_ptr<MediaHandler> handler);
 	shared_ptr<MediaHandler> getMediaHandler();

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -213,6 +213,7 @@ RTC_C_EXPORT int rtcSetSignalingStateChangeCallback(int pc, rtcSignalingStateCal
 RTC_C_EXPORT int rtcSetLocalDescription(int pc, const char *type);
 RTC_C_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
 RTC_C_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid);
+RTC_C_EXPORT int rtcSetRemoteGatherDone(int pc);
 
 RTC_C_EXPORT int rtcGetLocalDescription(int pc, char *buffer, int size);
 RTC_C_EXPORT int rtcGetRemoteDescription(int pc, char *buffer, int size);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -584,6 +584,14 @@ int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid) {
 	});
 }
 
+int rtcSetRemoteGatherDone(int pc) {
+	return wrap([&] {
+		auto peerConnection = getPeerConnection(pc);
+		peerConnection->setRemoteGatherDone();
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcGetLocalDescription(int pc, char *buffer, int size) {
 	return wrap([&] {
 		auto peerConnection = getPeerConnection(pc);

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -202,6 +202,8 @@ void IceTransport::setRemoteDescription(const Description &description) {
 		throw std::invalid_argument("Invalid ICE settings from remote SDP");
 }
 
+void IceTransport::setRemoteGatherDone() { juice_set_remote_gathering_done(mAgent.get()); }
+
 bool IceTransport::addRemoteCandidate(const Candidate &candidate) {
 	// Don't try to pass unresolved candidates for more safety
 	if (!candidate.isResolved())
@@ -663,6 +665,8 @@ void IceTransport::setRemoteDescription(const Description &description) {
 	                                description.generateApplicationSdp("\n").c_str()) < 0)
 		throw std::invalid_argument("Invalid ICE settings from remote SDP");
 }
+
+void IceTransport::setRemoteGatherDone() {}
 
 bool IceTransport::addRemoteCandidate(const Candidate &candidate) {
 	// Don't try to pass unresolved candidates to libnice for more safety

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -50,6 +50,7 @@ public:
 	Description getLocalDescription(Description::Type type) const;
 	void setRemoteDescription(const Description &description);
 	bool addRemoteCandidate(const Candidate &candidate);
+	void setRemoteGatherDone();
 	void gatherLocalCandidates(string mid);
 
 	optional<string> getLocalAddress() const;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1127,6 +1127,13 @@ void PeerConnection::processRemoteCandidate(Candidate candidate) {
 	}
 }
 
+void PeerConnection::setRemoteGatherDone() {
+	auto iceTransport = std::atomic_load(&mIceTransport);
+	if (!iceTransport)
+		throw std::logic_error("setting remote gather done without ICE transport");
+	iceTransport->setRemoteGatherDone();
+}
+
 string PeerConnection::localBundleMid() const {
 	std::lock_guard lock(mLocalDescriptionMutex);
 	return mLocalDescription ? mLocalDescription->bundleMid() : "0";

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -78,6 +78,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void processLocalCandidate(Candidate candidate);
 	void processRemoteDescription(Description description);
 	void processRemoteCandidate(Candidate candidate);
+	void setRemoteGatherDone();
 	string localBundleMid() const;
 
 	void setMediaHandler(shared_ptr<MediaHandler> handler);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -249,6 +249,12 @@ void PeerConnection::addRemoteCandidate(Candidate candidate) {
 	impl()->processRemoteCandidate(std::move(candidate));
 }
 
+void PeerConnection::setRemoteGatherDone() {
+	std::unique_lock signalingLock(impl()->signalingMutex);
+	PLOG_VERBOSE << "Remote gather is done";
+	impl()->setRemoteGatherDone();
+}
+
 void PeerConnection::setMediaHandler(shared_ptr<MediaHandler> handler) {
 	impl()->setMediaHandler(std::move(handler));
 };

--- a/test/benchmark.cpp
+++ b/test/benchmark.cpp
@@ -51,8 +51,11 @@ size_t benchmark(milliseconds duration) {
 	});
 
 	pc1.onStateChange([](PeerConnection::State state) { cout << "State 1: " << state << endl; });
-	pc1.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc1.onGatheringStateChange([&pc2](PeerConnection::GatheringState state) {
 		cout << "Gathering state 1: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc2.setRemoteGatherDone();
+		}
 	});
 
 	pc2.onLocalDescription([&pc1](Description sdp) {
@@ -66,8 +69,11 @@ size_t benchmark(milliseconds duration) {
 	});
 
 	pc2.onStateChange([](PeerConnection::State state) { cout << "State 2: " << state << endl; });
-	pc2.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc2.onGatheringStateChange([&pc1](PeerConnection::GatheringState state) {
 		cout << "Gathering state 2: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc1.setRemoteGatherDone();
+		}
 	});
 
 	const size_t messageSize = 65535;

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -64,6 +64,10 @@ static void RTC_API gatheringStateCallback(int pc, rtcGatheringState state, void
 	Peer *peer = (Peer *)ptr;
 	peer->gatheringState = state;
 	printf("Gathering state %d: %d\n", peer == peer1 ? 1 : 2, (int)state);
+	if (state == RTC_GATHERING_COMPLETE) {
+		Peer *other = peer == peer1 ? peer2 : peer1;
+		rtcSetRemoteGatherDone(other->pc);
+	}
 }
 
 static void RTC_API signalingStateCallback(int pc, rtcSignalingState state, void *ptr) {

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -58,6 +58,10 @@ static void RTC_API gatheringStateCallback(int pc, rtcGatheringState state, void
 	Peer *peer = (Peer *)ptr;
 	peer->gatheringState = state;
 	printf("Gathering state %d: %d\n", peer == peer1 ? 1 : 2, (int)state);
+	if (state == RTC_GATHERING_COMPLETE) {
+		Peer *other = peer == peer1 ? peer2 : peer1;
+		rtcSetRemoteGatherDone(other->pc);
+	}
 }
 
 static void RTC_API openCallback(int id, void *ptr) {

--- a/test/connectivity.cpp
+++ b/test/connectivity.cpp
@@ -71,8 +71,11 @@ void test_connectivity(bool signal_wrong_fingerprint) {
 		cout << "ICE state 1: " << state << endl;
 	});
 
-	pc1.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc1.onGatheringStateChange([&pc2](PeerConnection::GatheringState state) {
 		cout << "Gathering state 1: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc2.setRemoteGatherDone();
+		}
 	});
 
 	pc1.onSignalingStateChange([](PeerConnection::SignalingState state) {
@@ -95,8 +98,11 @@ void test_connectivity(bool signal_wrong_fingerprint) {
 		cout << "ICE state 2: " << state << endl;
 	});
 
-	pc2.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc2.onGatheringStateChange([&pc1](PeerConnection::GatheringState state) {
 		cout << "Gathering state 2: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc1.setRemoteGatherDone();
+		}
 	});
 
 	pc2.onSignalingStateChange([](PeerConnection::SignalingState state) {

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -49,8 +49,11 @@ void test_track() {
 
 	pc1.onStateChange([](PeerConnection::State state) { cout << "State 1: " << state << endl; });
 
-	pc1.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc1.onGatheringStateChange([&pc2](PeerConnection::GatheringState state) {
 		cout << "Gathering state 1: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc2.setRemoteGatherDone();
+		}
 	});
 
 	pc2.onLocalDescription([&pc1](Description sdp) {
@@ -65,8 +68,11 @@ void test_track() {
 
 	pc2.onStateChange([](PeerConnection::State state) { cout << "State 2: " << state << endl; });
 
-	pc2.onGatheringStateChange([](PeerConnection::GatheringState state) {
+	pc2.onGatheringStateChange([&pc1](PeerConnection::GatheringState state) {
 		cout << "Gathering state 2: " << state << endl;
+		if (state == PeerConnection::GatheringState::Complete) {
+			pc1.setRemoteGatherDone();
+		}
 	});
 
 	shared_ptr<Track> t2;


### PR DESCRIPTION
I was experimenting gathering complete signal. It seems juice_set_remote_gathering_done should be called at the end of candidate gathering phase.

The reason for this PR is issue https://github.com/paullouisageneau/libdatachannel/issues/1130. At this time I have no data to confirm that this PR fixes anything.