### PR TITLE
H264RtpDepacketizer: De-packetize access units rather than individual NALUs

### DIFF
--- a/include/rtc/h264rtpdepacketizer.hpp
+++ b/include/rtc/h264rtpdepacketizer.hpp
@@ -15,6 +15,7 @@
 #include "common.hpp"
 #include "mediahandler.hpp"
 #include "message.hpp"
+#include "nalunit.hpp"
 #include "rtp.hpp"
 
 #include <iterator>
@@ -24,14 +25,18 @@ namespace rtc {
 /// RTP depacketization for H264
 class RTC_CPP_EXPORT H264RtpDepacketizer : public MediaHandler {
 public:
-	H264RtpDepacketizer() = default;
+	using Separator = NalUnit::Separator;
+
+	H264RtpDepacketizer(Separator separator = Separator::LongStartSequence);
 	virtual ~H264RtpDepacketizer() = default;
 
 	void incoming(message_vector &messages, const message_callback &send) override;
 
 private:
 	std::vector<message_ptr> mRtpBuffer;
+	const NalUnit::Separator mSeparator;
 
+	void addSeparator(binary &accessUnit);
 	message_vector buildFrames(message_vector::iterator firstPkt, message_vector::iterator lastPkt,
 	                           uint8_t payloadType, uint32_t timestamp);
 };


### PR DESCRIPTION
This commit updates the `H264RtpDepacketizer` to accumulate the NALUs for a particular RTP timestamp into a single output message, rather than returning each NALU as an individual message. This helps decoders which may want to see the non-VCL SPS/PPS/etc. NALUs in the same access unit as a VCL NALU rather than as standalone messages.

Each NALU in the access unit buffer is prepended with an H.264 Annex B start code 0x00, 0x00, 0x01.