### PR TITLE
Fix `H264RtpDepacketizer` to handle empty payload RTP packet

### DIFF
--- a/src/h264rtpdepacketizer.cpp
+++ b/src/h264rtpdepacketizer.cpp
@@ -42,6 +42,12 @@ message_vector H264RtpDepacketizer::buildFrames(message_vector::iterator begin,
 		auto pktParsed = reinterpret_cast<const rtc::RtpHeader *>(pkt->data());
 		auto headerSize =
 		    sizeof(rtc::RtpHeader) + pktParsed->csrcCount() + pktParsed->getExtensionHeaderSize();
+
+		if (pkt->size() == headerSize) {
+			PLOG_VERBOSE << "H.264 RTP packet has empty payload";
+                	continue;
+		}
+
 		auto nalUnitHeader = NalUnitHeader{std::to_integer<uint8_t>(pkt->at(headerSize))};
 
 		if (fua_buffer.size() != 0 || nalUnitHeader.unitType() == naluTypeFUA) {

--- a/src/h264rtpdepacketizer.cpp
+++ b/src/h264rtpdepacketizer.cpp
@@ -42,10 +42,15 @@ message_vector H264RtpDepacketizer::buildFrames(message_vector::iterator begin,
 		auto pktParsed = reinterpret_cast<const rtc::RtpHeader *>(pkt->data());
 		auto headerSize =
 		    sizeof(rtc::RtpHeader) + pktParsed->csrcCount() + pktParsed->getExtensionHeaderSize();
+		auto paddingSize = 0;
 
-		if (pkt->size() == headerSize) {
+		if (pktParsed->padding()) {
+			paddingSize = std::to_integer<uint8_t>(pkt->at(pkt->size() - 1));
+		}
+
+		if (pkt->size() == headerSize + paddingSize) {
 			PLOG_VERBOSE << "H.264 RTP packet has empty payload";
-                	continue;
+			continue;
 		}
 
 		auto nalUnitHeader = NalUnitHeader{std::to_integer<uint8_t>(pkt->at(headerSize))};


### PR DESCRIPTION
This PR fixes an issue that `H264RtpDepacketizer` cannot handle empty payload RTP packets that could be sent by Chrome (please see [obs-studio#10353 comment](https://github.com/obsproject/obs-studio/pull/10353/files#r1529824073) for the detailed motivation).

## How to reproduce the issue

Please apply the following diff to `examples/media-receiver/main.cpp` file and build the command.

```diff
diff --git a/examples/media-receiver/main.cpp b/examples/media-receiver/main.cpp
index 81e0d1d0..b2fe13c7 100644
--- a/examples/media-receiver/main.cpp
+++ b/examples/media-receiver/main.cpp
@@ -40,8 +40,10 @@ int main() {
                        std::cout << "Gathering State: " << state << std::endl;
                        if (state == rtc::PeerConnection::GatheringState::Complete) {
                                auto description = pc->localDescription();
+                               auto sdp = std::string(description.value());
+                               sdp += "a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time\r\n";
                                json message = {{"type", description->typeString()},
-                                               {"sdp", std::string(description.value())}};
+                                               {"sdp", sdp}};
                                std::cout << message << std::endl;
                        }
                });
@@ -54,13 +56,13 @@ int main() {

                rtc::Description::Video media("video", rtc::Description::Direction::RecvOnly);
                media.addH264Codec(96);
-               media.setBitrate(
-                   3000); // Request 3Mbps (Browsers do not encode more than 2.5MBps from a webcam)

                auto track = pc->addTrack(media);

+               auto video_depacketizer = std::make_shared<rtc::H264RtpDepacketizer>();
                auto session = std::make_shared<rtc::RtcpReceivingSession>();
-               track->setMediaHandler(session);
+               video_depacketizer->addToChain(session);
+               track->setMediaHandler(video_depacketizer);

                track->onMessage(
                    [session, sock, addr](rtc::binary message) {
```

Execute `media-receiver` command and communicate with Chrome.
When `media-receiver` starts receiving video packets, it could emit the following error message:

```console
$ ./media-receiver
...
2024-03-27 14:46:16.535 ERROR [281897] [rtc::impl::DtlsTransport::doRecv@990] DTLS recv: Unknown H264 RTP Packetization
2024-03-27 14:46:16.537 INFO  [281897] [rtc::impl::DtlsTransport::doRecv@994] DTLS closed
```