### PR TITLE
Fix misaligned dereference in H264 and H265 packetizers

### DIFF
--- a/examples/streamer/h264fileparser.cpp
+++ b/examples/streamer/h264fileparser.cpp
@@ -11,6 +11,7 @@
 #include "rtc/rtc.hpp"
 
 #include <fstream>
+#include <cstring>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -29,7 +30,9 @@ void H264FileParser::loadNextSample() {
     while (i < sample.size()) {
         assert(i + 4 < sample.size());
         auto lengthPtr = (uint32_t *) (sample.data() + i);
-        uint32_t length = ntohl(*lengthPtr);
+        uint32_t length;
+        std::memcpy(&length, lengthPtr, sizeof(uint32_t));
+        length = ntohl(length);
         auto naluStartIndex = i + 4;
         auto naluEndIndex = naluStartIndex + length;
         assert(naluEndIndex <= sample.size());

--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -32,8 +32,9 @@ shared_ptr<NalUnits> H264RtpPacketizer::splitMessage(binary_ptr message) {
 				LOG_WARNING << "Invalid NAL Unit data (incomplete length), ignoring!";
 				break;
 			}
-			auto lengthPtr = (uint32_t *)(message->data() + index);
-			uint32_t length = ntohl(*lengthPtr);
+			uint32_t length;
+			std::memcpy(&length, message->data() + index, sizeof(uint32_t));
+			length = ntohl(length);
 			auto naluStartIndex = index + 4;
 			auto naluEndIndex = naluStartIndex + length;
 

--- a/src/h265rtppacketizer.cpp
+++ b/src/h265rtppacketizer.cpp
@@ -32,8 +32,9 @@ shared_ptr<H265NalUnits> H265RtpPacketizer::splitMessage(binary_ptr message) {
 				LOG_WARNING << "Invalid NAL Unit data (incomplete length), ignoring!";
 				break;
 			}
-			auto lengthPtr = (uint32_t *)(message->data() + index);
-			uint32_t length = ntohl(*lengthPtr);
+			uint32_t length;
+			std::memcpy(&length, message->data() + index, sizeof(uint32_t));
+			length = ntohl(length);
 			auto naluStartIndex = index + 4;
 			auto naluEndIndex = naluStartIndex + length;
 


### PR DESCRIPTION
Use memcpy instead of direct dereference to avoid
misaligned access.