### PR TITLE
Add option to disable fingerprint validation

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -77,7 +77,7 @@ struct RTC_CPP_EXPORT Configuration {
 	bool disableAutoNegotiation = false;
 	bool disableAutoGathering = false;
 	bool forceMediaTransport = false;
-	bool skipCheckFingerprint = false;
+	bool disableFingerprintVerification = false;
 
 	// Port range
 	uint16_t portRangeBegin = 1024;

--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -77,6 +77,7 @@ struct RTC_CPP_EXPORT Configuration {
 	bool disableAutoNegotiation = false;
 	bool disableAutoGathering = false;
 	bool forceMediaTransport = false;
+	bool skipCheckFingerprint = false;
 
 	// Port range
 	uint16_t portRangeBegin = 1024;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -426,6 +426,9 @@ bool PeerConnection::checkFingerprint(const std::string &fingerprint) const {
 	if (!mRemoteDescription || !mRemoteDescription->fingerprint())
 		return false;
 
+	if (config.skipCheckFingerprint)
+		return true;
+
 	auto expectedFingerprint = mRemoteDescription->fingerprint()->value;
 	if (expectedFingerprint  == fingerprint) {
 		PLOG_VERBOSE << "Valid fingerprint \"" << fingerprint << "\"";

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -426,7 +426,7 @@ bool PeerConnection::checkFingerprint(const std::string &fingerprint) const {
 	if (!mRemoteDescription || !mRemoteDescription->fingerprint())
 		return false;
 
-	if (config.skipCheckFingerprint)
+	if (config.disableFingerprintVerification)
 		return true;
 
 	auto expectedFingerprint = mRemoteDescription->fingerprint()->value;


### PR DESCRIPTION
In Peer B of the WebRTC Direct protocol, the certificate fingerprint of Peer A needs to be ignored in order to establish a handshake with Peer A when the real sdp is not known.