### PR TITLE
Fix missing algorithm header in h264rtppacketizer.cpp

### DIFF
--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -12,6 +12,7 @@
 
 #include "impl/internals.hpp"
 
+#include <algorithm>
 #include <cassert>
 
 #ifdef _WIN32


### PR DESCRIPTION
Fixes https://github.com/paullouisageneau/libdatachannel/issues/1173