### PR TITLE
Fix missing algorithm header in h264rtpdepacketizer.cpp

### DIFF
--- a/src/h264rtpdepacketizer.cpp
+++ b/src/h264rtpdepacketizer.cpp
@@ -13,6 +13,8 @@
 
 #include "impl/internals.hpp"
 
+#include <algorithm>
+
 namespace rtc {
 
 const binary naluLongStartCode = {byte{0}, byte{0}, byte{0}, byte{1}};


### PR DESCRIPTION
Fixes https://github.com/paullouisageneau/libdatachannel/issues/1173