### PR TITLE
Migrate session-level attributes to media-level

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -310,12 +310,7 @@ string Description::generateSdp(string_view eol) const {
 
 	// Session-level attributes
 	sdp << "a=msid-semantic:WMS *" << eol;
-	sdp << "a=setup:" << mRole << eol;
 
-	if (mIceUfrag)
-		sdp << "a=ice-ufrag:" << *mIceUfrag << eol;
-	if (mIcePwd)
-		sdp << "a=ice-pwd:" << *mIcePwd << eol;
 	if (!mIceOptions.empty())
 		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
 	if (mFingerprint)
@@ -338,6 +333,14 @@ string Description::generateSdp(string_view eol) const {
 	bool first = true;
 	for (const auto &entry : mEntries) {
 		sdp << entry->generateSdp(eol, addr, port);
+
+		// RFC 8829: Attributes that SDP permits to be at either the session level or the media level
+		// SHOULD generally be at the media level even if they are identical.
+		sdp << "a=setup:" << mRole << eol;
+		if (mIceUfrag)
+			sdp << "a=ice-ufrag:" << *mIceUfrag << eol;
+		if (mIcePwd)
+			sdp << "a=ice-pwd:" << *mIcePwd << eol;
 
 		if (!entry->isRemoved() && std::exchange(first, false)) {
 			// Candidates


### PR DESCRIPTION
Moves session-level attributes for `a=setup`, `a=ice-ufrag`, `a=ice-pwd`, `a=ice-options` and `a=fingerprint` to the media-level in `Description::generateSdp(...)`. The goal here is to have better general compatibility as RFC 8829 recommends using the media-level attributes even if the information is identical.

Another goal of this change was to not introduce breaking API changes, and the easiest way to accomplish this was to print out the information right after the entry SDP on the Description level. The "downside" of this approach is that it will appear at the end of the media entry, but I don't believe this will impact parsing as long as it is grouped with the media.

Let me know what you think, happy to make any changes!