### PR TITLE
Change conflicting names of capi and non capi copy paste examples

### DIFF
--- a/examples/copy-paste-capi/CMakeLists.txt
+++ b/examples/copy-paste-capi/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
-	OUTPUT_NAME offerer)
+	OUTPUT_NAME offerer-capi)
 
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.offerer)
@@ -44,7 +44,7 @@ else()
 endif()
 
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
-	OUTPUT_NAME answerer)
+	OUTPUT_NAME answerer-capi)
 
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.answerer)


### PR DESCRIPTION
This is causing me errors, the two output names are conflicting with each other.
The c-api example should have a different name than the non c-api example.