### PR TITLE
Fix a bug where packets retransmitted for NACK are encrypted with SRTP twice

### DIFF
--- a/src/rtcpnackresponder.cpp
+++ b/src/rtcpnackresponder.cpp
@@ -79,9 +79,13 @@ optional<binary_ptr> RtcpNackResponder::Storage::get(uint16_t sequenceNumber) {
 	                                 : nullopt;
 }
 
-void RtcpNackResponder::Storage::store(binary_ptr packet) {
-	if (!packet || packet->size() < sizeof(RtpHeader))
+void RtcpNackResponder::Storage::store(binary_ptr message) {
+	if (!message || message->size() < sizeof(RtpHeader))
 		return;
+
+	// We need to create a deep copy of the message binary here because the content
+	// of the binary will be modified by the srtp_protect() function when the message is sent.
+	auto packet = std::make_shared<binary>(message->begin(), message->end());
 
 	auto rtp = reinterpret_cast<RtpHeader *>(packet->data());
 	auto sequenceNumber = rtp->seqNumber();


### PR DESCRIPTION
Let me report a NACK handling bug and submit a PR to fix it.

I used OBS Studio (30.1.2) WHIP to publish a video stream to a WebRTC SFU server. 
When the network became unstable and NACK packets were sent from the server, the video stream appeared corrupted on the viewer’s side. 
After some debugging, it was discovered that the packet binaries stored in `RtcpNackResponder` were unintentionally modified by the `srtp_protect()` function when the messages were first sent. As a result, when the packets were re-sent to the server for NACK, they were encrypted twice.

This PR fixes the issue by deep copying messages before they are stored in `RtcpNackResponder`.
