### PR TITLE
Fix the compilation issue on the Windows platform.

### DIFF
--- a/examples/copy-paste-capi/CMakeLists.txt
+++ b/examples/copy-paste-capi/CMakeLists.txt
@@ -30,7 +30,7 @@ else()
 endif()
 
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
-	OUTPUT_NAME offerer)
+	OUTPUT_NAME offerer-capi)
 
 set_target_properties(datachannel-copy-paste-capi-offerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.offerer)
@@ -44,7 +44,7 @@ else()
 endif()
 
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
-	OUTPUT_NAME answerer)
+	OUTPUT_NAME answerer-capi)
 
 set_target_properties(datachannel-copy-paste-capi-answerer PROPERTIES
 	XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.examples.copypaste.capi.answerer)

--- a/include/rtc/av1rtppacketizer.hpp
+++ b/include/rtc/av1rtppacketizer.hpp
@@ -21,7 +21,7 @@ namespace rtc {
 class RTC_CPP_EXPORT AV1RtpPacketizer final : public RtpPacketizer {
 public:
 	// Default clock rate for AV1 in RTP
-	inline static const uint32_t defaultClockRate = 90 * 1000;
+	static const uint32_t defaultClockRate = 90 * 1000;
 
 	// Define how OBUs are seperated in a AV1 Sample
 	enum class Packetization {

--- a/include/rtc/h264rtppacketizer.hpp
+++ b/include/rtc/h264rtppacketizer.hpp
@@ -23,7 +23,7 @@ public:
 	using Separator = NalUnit::Separator;
 
 	/// Default clock rate for H264 in RTP
-	inline static const uint32_t defaultClockRate = 90 * 1000;
+	static const uint32_t defaultClockRate = 90 * 1000;
 
 	/// Constructs h264 payload packetizer with given RTP configuration.
 	/// @note RTP configuration is used in packetization process which may change some configuration

--- a/include/rtc/h265rtppacketizer.hpp
+++ b/include/rtc/h265rtppacketizer.hpp
@@ -22,7 +22,7 @@ public:
 	using Separator = NalUnit::Separator;
 
 	// Default clock rate for H265 in RTP
-	inline static const uint32_t defaultClockRate = 90 * 1000;
+	static const uint32_t defaultClockRate = 90 * 1000;
 
 	// Constructs h265 payload packetizer with given RTP configuration.
 	// @note RTP configuration is used in packetization process which may change some configuration

--- a/include/rtc/rtppacketizer.hpp
+++ b/include/rtc/rtppacketizer.hpp
@@ -49,8 +49,8 @@ private:
 template <uint32_t DEFAULT_CLOCK_RATE>
 class RTC_CPP_EXPORT AudioRtpPacketizer final : public RtpPacketizer {
 public:
-	inline static const uint32_t DefaultClockRate = DEFAULT_CLOCK_RATE;
-	inline static const uint32_t defaultClockRate [[deprecated("Use DefaultClockRate")]] =
+	static const uint32_t DefaultClockRate = DEFAULT_CLOCK_RATE;
+	static const uint32_t defaultClockRate [[deprecated("Use DefaultClockRate")]] =
 	    DEFAULT_CLOCK_RATE; // for backward compatibility
 
 	AudioRtpPacketizer(shared_ptr<RtpPacketizationConfig> rtpConfig)

--- a/include/rtc/rtppacketizer.hpp
+++ b/include/rtc/rtppacketizer.hpp
@@ -49,9 +49,16 @@ private:
 template <uint32_t DEFAULT_CLOCK_RATE>
 class RTC_CPP_EXPORT AudioRtpPacketizer final : public RtpPacketizer {
 public:
+#ifdef _WIN32
 	static const uint32_t DefaultClockRate = DEFAULT_CLOCK_RATE;
-	static const uint32_t defaultClockRate [[deprecated("Use DefaultClockRate")]] =
+	static const uint32_t defaultClockRate[[deprecated("Use DefaultClockRate")]] =
 	    DEFAULT_CLOCK_RATE; // for backward compatibility
+#else // not WIN32
+	inline static const uint32_t DefaultClockRate = DEFAULT_CLOCK_RATE;
+	inline static const uint32_t defaultClockRate[[deprecated("Use DefaultClockRate")]] =
+	    DEFAULT_CLOCK_RATE; // for backward compatibility
+#endif
+
 
 	AudioRtpPacketizer(shared_ptr<RtpPacketizationConfig> rtpConfig)
 	    : RtpPacketizer(std::move(rtpConfig)) {}

--- a/src/av1rtppacketizer.cpp
+++ b/src/av1rtppacketizer.cpp
@@ -9,7 +9,7 @@
 #if RTC_ENABLE_MEDIA
 
 #include "av1rtppacketizer.hpp"
-
+#include <algorithm>
 #include "impl/internals.hpp"
 
 namespace rtc {

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -310,7 +310,6 @@ string Description::generateSdp(string_view eol) const {
 
 	// Session-level attributes
 	sdp << "a=msid-semantic:WMS *" << eol;
-
 	if (!mIceOptions.empty())
 		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
 	if (mFingerprint)
@@ -372,27 +371,28 @@ string Description::generateApplicationSdp(string_view eol) const {
 	const uint16_t port =
 	    cand && cand->isResolved() ? *cand->port() : 9; // Port 9 is the discard protocol
 
+	// Session-level attributes
+	sdp << "a=msid-semantic:WMS *" << eol;
+	if (!mIceOptions.empty())
+		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
+
+	for (const auto &attr : mAttributes)
+		sdp << "a=" << attr << eol;
+
 	// Application
 	auto app = mApplication ? mApplication : std::make_shared<Application>();
 	sdp << app->generateSdp(eol, addr, port);
 
-	// Session-level attributes
-	sdp << "a=msid-semantic:WMS *" << eol;
+	// Media-level attributes
 	sdp << "a=setup:" << mRole << eol;
-
 	if (mIceUfrag)
 		sdp << "a=ice-ufrag:" << *mIceUfrag << eol;
 	if (mIcePwd)
 		sdp << "a=ice-pwd:" << *mIcePwd << eol;
-	if (!mIceOptions.empty())
-		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
 	if (mFingerprint)
 		sdp << "a=fingerprint:"
 		    << CertificateFingerprint::AlgorithmIdentifier(mFingerprint->algorithm) << " "
 		    << mFingerprint->value << eol;
-
-	for (const auto &attr : mAttributes)
-		sdp << "a=" << attr << eol;
 
 	// Candidates
 	for (const auto &candidate : mCandidates)

--- a/src/h264rtppacketizer.cpp
+++ b/src/h264rtppacketizer.cpp
@@ -81,7 +81,6 @@ shared_ptr<NalUnits> H264RtpPacketizer::splitMessage(binary_ptr message) {
 	}
 	return nalus;
 }
-
 H264RtpPacketizer::H264RtpPacketizer(shared_ptr<RtpPacketizationConfig> rtpConfig,
                                      uint16_t maxFragmentSize)
     : RtpPacketizer(std::move(rtpConfig)), maxFragmentSize(maxFragmentSize),

--- a/src/impl/certificate.hpp
+++ b/src/impl/certificate.hpp
@@ -34,8 +34,9 @@ public:
 	Certificate(shared_ptr<mbedtls_x509_crt> crt, shared_ptr<mbedtls_pk_context> pk);
 	std::tuple<shared_ptr<mbedtls_x509_crt>, shared_ptr<mbedtls_pk_context>> credentials() const;
 #else // OPENSSL
-	Certificate(shared_ptr<X509> x509, shared_ptr<EVP_PKEY> pkey);
+	Certificate(shared_ptr<X509> x509, shared_ptr<EVP_PKEY> pkey, std::vector<shared_ptr<X509>> chain = {});
 	std::tuple<X509 *, EVP_PKEY *> credentials() const;
+	std::vector<X509 *> chain() const;
 #endif
 
 	CertificateFingerprint fingerprint() const;
@@ -52,6 +53,7 @@ private:
 #else
 	const shared_ptr<X509> mX509;
 	const shared_ptr<EVP_PKEY> mPKey;
+	const std::vector<shared_ptr<X509>> mChain;
 #endif
 
 	const string mFingerprint;

--- a/src/impl/http.cpp
+++ b/src/impl/http.cpp
@@ -7,9 +7,8 @@
  */
 
 #include "http.hpp"
-
 #include <algorithm>
-
+#include <cctype>
 namespace rtc::impl {
 
 bool isHttpRequest(const byte *buffer, size_t size) {

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -603,6 +603,9 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 			auto [x509, pkey] = certificate->credentials();
 			SSL_CTX_use_certificate(mCtx, x509);
 			SSL_CTX_use_PrivateKey(mCtx, pkey);
+
+			for (auto c : certificate->chain())
+				SSL_CTX_add1_chain_cert(mCtx, c); // add1 increments reference count
 		}
 
 		SSL_CTX_set_options(mCtx, SSL_OP_NO_SSLv3 | SSL_OP_NO_RENEGOTIATION);

--- a/src/message.cpp
+++ b/src/message.cpp
@@ -7,7 +7,7 @@
  */
 
 #include "message.hpp"
-
+#include <algorithm>
 namespace rtc {
 
 message_ptr make_message(size_t size, Message::Type type, unsigned int stream,


### PR DESCRIPTION
1. Fix the compilation issue on the Windows platform by include parts of the standard library.
2. Fix the issue where exporting the "defaultClockRate" static variable in datachannel.lib/dll fails on the Windows platform.