### PR TITLE
Allow overriding ICE ufrag and pwd fields

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -93,6 +93,10 @@ struct RTC_CPP_EXPORT Configuration {
 	optional<string> certificatePemFile;
 	optional<string> keyPemFile;
 	optional<string> keyPemPass;
+
+	// Overriding ICE ufrag/pwd
+	optional<string> iceUfrag;
+	optional<string> icePwd;
 };
 
 #ifdef RTC_ENABLE_WEBSOCKET

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -130,9 +130,15 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	}
 
 	// Create agent
-	mAgent = decltype(mAgent)(juice_create(&jconfig), juice_destroy);
-	if (!mAgent)
+	auto agent = juice_create(&jconfig);
+	if (!agent)
 		throw std::runtime_error("Failed to create the ICE agent");
+
+	if (config.iceUfrag && config.icePwd) {
+		juice_set_local_ice_attributes(agent, (char*)config.iceUfrag->c_str(), (char*)config.icePwd->c_str());
+	}
+
+	mAgent = decltype(mAgent)(agent, juice_destroy);
 
 	// Add TURN servers
 	for (const auto &server : servers)

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -135,7 +135,7 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 		throw std::runtime_error("Failed to create the ICE agent");
 
 	if (config.iceUfrag && config.icePwd) {
-		juice_set_local_ice_attributes(agent, (char*)config.iceUfrag->c_str(), (char*)config.icePwd->c_str());
+		juice_set_local_ice_attributes(agent, config.iceUfrag->c_str(), config.icePwd->c_str());
 	}
 
 	mAgent = decltype(mAgent)(agent, juice_destroy);


### PR DESCRIPTION
Adds two new optional config keys - `iceUfrag` and `icePwd` which are passed to libjuice.

Needs a libjuice release with https://github.com/paullouisageneau/libjuice/pull/243

Refs: https://github.com/paullouisageneau/libdatachannel/issues/1166