### PR TITLE
feat: update current remote description with fingerprint

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -278,6 +278,24 @@ Return value: the length of the string copied in buffer (including the terminati
 
 If `buffer` is `NULL`, the description is not copied but the size is still returned.
 
+#### rtcGetCurrentRemoteDescription
+
+```
+int rtcGetCurrentRemoteDescription(int pc, char *buffer, int size)
+```
+
+Retrieves the currently negotiated remote description in SDP format.
+
+Arguments:
+
+- `pc`: the Peer Connection identifier
+- `buffer`: a user-supplied buffer to store the description
+- `size`: the size of `buffer`
+
+Return value: the length of the string copied in buffer (including the terminating null character) or a negative error code
+
+If `buffer` is `NULL`, the description is not copied but the size is still returned.
+
 #### rtcGetLocalDescriptionType
 
 ```

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -84,6 +84,7 @@ public:
 	bool hasMedia() const;
 	optional<Description> localDescription() const;
 	optional<Description> remoteDescription() const;
+	optional<Description> currentRemoteDescription() const;
 	size_t remoteMaxMessageSize() const;
 	optional<string> localAddress() const;
 	optional<string> remoteAddress() const;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -216,6 +216,7 @@ RTC_C_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid
 
 RTC_C_EXPORT int rtcGetLocalDescription(int pc, char *buffer, int size);
 RTC_C_EXPORT int rtcGetRemoteDescription(int pc, char *buffer, int size);
+RTC_C_EXPORT int rtcGetCurrentRemoteDescription(int pc, char *buffer, int size);
 
 RTC_C_EXPORT int rtcGetLocalDescriptionType(int pc, char *buffer, int size);
 RTC_C_EXPORT int rtcGetRemoteDescriptionType(int pc, char *buffer, int size);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -609,6 +609,17 @@ int rtcGetRemoteDescription(int pc, char *buffer, int size) {
 	});
 }
 
+int rtcGetCurrentRemoteDescription(int pc, char *buffer, int size) {
+	return wrap([&] {
+		auto peerConnection = getPeerConnection(pc);
+
+		if (auto desc = peerConnection->currentRemoteDescription())
+			return copyAndReturn(string(*desc), buffer, size);
+		else
+			return RTC_ERR_NOT_AVAIL;
+	});
+}
+
 int rtcGetLocalDescriptionType(int pc, char *buffer, int size) {
 	return wrap([&] {
 		auto peerConnection = getPeerConnection(pc);

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -41,6 +41,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	optional<Description> localDescription() const;
 	optional<Description> remoteDescription() const;
+	optional<Description> currentRemoteDescription() const;
 	size_t remoteMaxMessageSize() const;
 
 	shared_ptr<IceTransport> initIceTransport();
@@ -53,7 +54,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	void endLocalCandidates();
 	void rollbackLocalDescription();
-	bool checkFingerprint(const std::string &fingerprint) const;
+	bool checkFingerprint(const std::string &fingerprint, const CertificateFingerprint::Algorithm algorithm);
 	void forwardMessage(message_ptr message);
 	void forwardMedia(message_ptr message);
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
@@ -77,6 +78,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void processLocalDescription(Description description);
 	void processLocalCandidate(Candidate candidate);
 	void processRemoteDescription(Description description);
+	void processCurrentRemoteDescription(Description description);
 	void processRemoteCandidate(Candidate candidate);
 	string localBundleMid() const;
 
@@ -135,8 +137,8 @@ private:
 
 	Processor mProcessor;
 	optional<Description> mLocalDescription, mRemoteDescription;
-	optional<Description> mCurrentLocalDescription;
-	mutable std::mutex mLocalDescriptionMutex, mRemoteDescriptionMutex;
+	optional<Description> mCurrentLocalDescription, mCurrentRemoteDescription;
+	mutable std::mutex mLocalDescriptionMutex, mRemoteDescriptionMutex, mCurrentRemoteDescriptionMutex;
 
 	shared_ptr<MediaHandler> mMediaHandler;
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -69,6 +69,10 @@ optional<Description> PeerConnection::remoteDescription() const {
 	return impl()->remoteDescription();
 }
 
+optional<Description> PeerConnection::currentRemoteDescription() const {
+	return impl()->currentRemoteDescription();
+}
+
 size_t PeerConnection::remoteMaxMessageSize() const { return impl()->remoteMaxMessageSize(); }
 
 bool PeerConnection::hasMedia() const {
@@ -243,6 +247,7 @@ void PeerConnection::setRemoteDescription(Description description) {
 	iceTransport->setRemoteDescription(description); // ICE transport might reject the description
 
 	impl()->processRemoteDescription(std::move(description));
+	impl()->processCurrentRemoteDescription(std::move(description));
 	impl()->changeSignalingState(newSignalingState);
 	signalingLock.unlock();
 


### PR DESCRIPTION
Adds a `currentRemoteDescription` field to `PeerConnection` which can be updated independently of `remoteDescription`, the idea being the `remoteDescription` is the offer received from the remote peer and the `currentRemoteDescription` is what has actually been negotiated with them.

The `currentRemoteDescription` is initialised when the `remoteDescription` is set.

Currently the `checkFingerprint` method updates the certificate fingerprint used by the connection to the remote peer but I guess other modifications may be useful.

Exposes the `currentRemoteDescription` via a getter similar to `remoteDescription`.

Closes #1203
Refs #1166