### PR TITLE
feat: add remoteFingerprints method to PeerConnection

### DIFF
--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -35,6 +35,11 @@ struct RTC_CPP_EXPORT DataChannelInit {
 	string protocol = "";
 };
 
+struct RTC_CPP_EXPORT RemoteFingerprint {
+	string value;
+	CertificateFingerprint::Algorithm algorithm;
+};
+
 class RTC_CPP_EXPORT PeerConnection final : CheshireCat<impl::PeerConnection> {
 public:
 	enum class State : int {
@@ -113,6 +118,7 @@ public:
 	void onSignalingStateChange(std::function<void(SignalingState state)> callback);
 
 	void resetCallbacks();
+	std::vector<struct RemoteFingerprint> remoteFingerprints();
 
 	// Stats
 	void clearStats();

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -35,11 +35,6 @@ struct RTC_CPP_EXPORT DataChannelInit {
 	string protocol = "";
 };
 
-struct RTC_CPP_EXPORT RemoteFingerprint {
-	string value;
-	CertificateFingerprint::Algorithm algorithm;
-};
-
 class RTC_CPP_EXPORT PeerConnection final : CheshireCat<impl::PeerConnection> {
 public:
 	enum class State : int {
@@ -118,7 +113,7 @@ public:
 	void onSignalingStateChange(std::function<void(SignalingState state)> callback);
 
 	void resetCallbacks();
-	std::vector<struct RemoteFingerprint> remoteFingerprints();
+	CertificateFingerprint remoteFingerprint();
 
 	// Stats
 	void clearStats();

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -53,7 +53,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	void endLocalCandidates();
 	void rollbackLocalDescription();
-	bool checkFingerprint(const std::string &fingerprint) const;
+	bool checkFingerprint(const std::string &fingerprint, const CertificateFingerprint::Algorithm &algorithm);
 	void forwardMessage(message_ptr message);
 	void forwardMedia(message_ptr message);
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
@@ -98,6 +98,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	bool changeSignalingState(SignalingState newState);
 
 	void resetCallbacks();
+	std::vector<struct RemoteFingerprint> remoteFingerprints();
 
 	// Helper method for asynchronous callback invocation
 	template <typename... Args> void trigger(synchronized_callback<Args...> *cb, Args... args) {
@@ -129,6 +130,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 private:
 	void dispatchMedia(message_ptr message);
 	void updateTrackSsrcCache(const Description &description);
+	void storeRemoteFingerprint(const std::string &fingerprint, const CertificateFingerprint::Algorithm &algorithm);
 
 	const init_token mInitToken = Init::Instance().token();
 	future_certificate_ptr mCertificate;
@@ -157,6 +159,8 @@ private:
 
 	Queue<shared_ptr<DataChannel>> mPendingDataChannels;
 	Queue<shared_ptr<Track>> mPendingTracks;
+
+	std::vector<struct RemoteFingerprint> rFingerprints;
 };
 
 } // namespace rtc::impl

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -53,7 +53,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	void endLocalCandidates();
 	void rollbackLocalDescription();
-	bool checkFingerprint(const std::string &fingerprint, const CertificateFingerprint::Algorithm &algorithm);
+	bool checkFingerprint(const std::string &fingerprint);
 	void forwardMessage(message_ptr message);
 	void forwardMedia(message_ptr message);
 	void forwardBufferedAmount(uint16_t stream, size_t amount);
@@ -98,7 +98,7 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	bool changeSignalingState(SignalingState newState);
 
 	void resetCallbacks();
-	std::vector<struct RemoteFingerprint> remoteFingerprints();
+	CertificateFingerprint remoteFingerprint();
 
 	// Helper method for asynchronous callback invocation
 	template <typename... Args> void trigger(synchronized_callback<Args...> *cb, Args... args) {
@@ -130,7 +130,6 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 private:
 	void dispatchMedia(message_ptr message);
 	void updateTrackSsrcCache(const Description &description);
-	void storeRemoteFingerprint(const std::string &fingerprint, const CertificateFingerprint::Algorithm &algorithm);
 
 	const init_token mInitToken = Init::Instance().token();
 	future_certificate_ptr mCertificate;
@@ -160,7 +159,8 @@ private:
 	Queue<shared_ptr<DataChannel>> mPendingDataChannels;
 	Queue<shared_ptr<Track>> mPendingTracks;
 
-	std::vector<struct RemoteFingerprint> rFingerprints;
+	CertificateFingerprint::Algorithm mRemoteFingerprintAlgorithm = CertificateFingerprint::Algorithm::Sha256;
+	optional<string> mRemoteFingerprint;
 };
 
 } // namespace rtc::impl

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -367,8 +367,8 @@ optional<std::chrono::milliseconds> PeerConnection::rtt() {
 	return sctpTransport ? sctpTransport->rtt() : nullopt;
 }
 
-std::vector<struct RemoteFingerprint> PeerConnection::remoteFingerprints() {
-	return impl()->remoteFingerprints();
+CertificateFingerprint PeerConnection::remoteFingerprint() {
+	return impl()->remoteFingerprint();
 }
 
 std::ostream &operator<<(std::ostream &out, PeerConnection::State state) {

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -367,6 +367,10 @@ optional<std::chrono::milliseconds> PeerConnection::rtt() {
 	return sctpTransport ? sctpTransport->rtt() : nullopt;
 }
 
+std::vector<struct RemoteFingerprint> PeerConnection::remoteFingerprints() {
+	return impl()->remoteFingerprints();
+}
+
 std::ostream &operator<<(std::ostream &out, PeerConnection::State state) {
 	using State = PeerConnection::State;
 	const char *str;


### PR DESCRIPTION
Returns a vector that contains the certificate fingerprints used by the connection to the remote peer.

Fingerprints are deduplicated before adding to the vector as the verifyFingerprint method can be invoked multiple times during the connection lifecycle.

Closes #1203
Refs #1166