### PR TITLE
feat: pass custom ICE ufrag and pwd as local description init

### DIFF
--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -35,6 +35,11 @@ struct RTC_CPP_EXPORT DataChannelInit {
 	string protocol = "";
 };
 
+struct RTC_CPP_EXPORT LocalDescriptionInit {
+    optional<string> iceUfrag;
+    optional<string> icePwd;
+};
+
 class RTC_CPP_EXPORT PeerConnection final : CheshireCat<impl::PeerConnection> {
 public:
 	enum class State : int {
@@ -90,7 +95,7 @@ public:
 	uint16_t maxDataChannelId() const;
 	bool getSelectedCandidatePair(Candidate *local, Candidate *remote);
 
-	void setLocalDescription(Description::Type type = Description::Type::Unspec);
+	void setLocalDescription(Description::Type type = Description::Type::Unspec, LocalDescriptionInit init = {});
 	void setRemoteDescription(Description description);
 	void addRemoteCandidate(Candidate candidate);
 	void gatherLocalCandidates(std::vector<IceServer> additionalIceServers = {});

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -575,7 +575,7 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	                       RecvCallback, this);
 }
 
-void IceTransport::setIceAttributes(string, string) {
+void IceTransport::setIceAttributes([[maybe_unused]] string uFrag, [[maybe_unused]] string pwd) {
 	PLOG_WARNING << "Setting custom ICE attributes is not supported with libnice, please use libjuice";
 }
 

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -140,6 +140,12 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 			addIceServer(server);
 }
 
+void IceTransport::setIceAttributes(string uFrag, string pwd) {
+	if (juice_set_local_ice_attributes(mAgent.get(), uFrag.c_str(), pwd.c_str()) < 0) {
+		throw std::invalid_argument("Invalid ICE attributes");
+	}
+}
+
 void IceTransport::addIceServer(IceServer server) {
 	if (server.hostname.empty())
 		return;
@@ -567,6 +573,10 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 
 	nice_agent_attach_recv(mNiceAgent.get(), mStreamId, 1, g_main_loop_get_context(MainLoop.get()),
 	                       RecvCallback, this);
+}
+
+void IceTransport::setIceAttributes(string, string) {
+	PLOG_WARNING << "Setting custom ICE attributes is not supported with libnice, please use libjuice";
 }
 
 void IceTransport::addIceServer(IceServer server) {

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -51,6 +51,7 @@ public:
 	void setRemoteDescription(const Description &description);
 	bool addRemoteCandidate(const Candidate &candidate);
 	void gatherLocalCandidates(string mid, std::vector<IceServer> additionalIceServers = {});
+	void setIceAttributes(string uFrag, string pwd);
 
 	optional<string> getLocalAddress() const;
 	optional<string> getRemoteAddress() const;

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -76,7 +76,7 @@ bool PeerConnection::hasMedia() const {
 	return local && local->hasAudioOrVideo();
 }
 
-void PeerConnection::setLocalDescription(Description::Type type) {
+void PeerConnection::setLocalDescription(Description::Type type, LocalDescriptionInit init) {
 	std::unique_lock signalingLock(impl()->signalingMutex);
 	PLOG_VERBOSE << "Setting local description, type=" << Description::typeToString(type);
 
@@ -139,6 +139,11 @@ void PeerConnection::setLocalDescription(Description::Type type) {
 	auto iceTransport = impl()->initIceTransport();
 	if (!iceTransport)
 		return; // closed
+
+	if (init.iceUfrag && init.icePwd) {
+		PLOG_DEBUG << "Using custom ICE attributes, ufrag=\"" << init.iceUfrag.value() << "\", pwd=\"" << init.icePwd.value() << "\"";
+		iceTransport->setIceAttributes(init.iceUfrag.value(), init.icePwd.value());
+	}
 
 	Description local = iceTransport->getLocalDescription(type);
 	impl()->processLocalDescription(std::move(local));


### PR DESCRIPTION
Adds an optional second argument to `rtc::PeerConnection::setLocalDescription` that can contain an ICE ufrag and pwd that if passed will be used in place of the randomly generated versions.

Refs: #1166
Refs: https://github.com/paullouisageneau/libdatachannel/pull/1201#discussion_r1633621803