### PR TITLE
feat: add listener for unhandled STUN requests with ICE UDP mux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LIBDATACHANNEL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/configuration.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/datachannel.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/description.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/iceudpmuxlistener.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/mediahandler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/global.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/message.cpp
@@ -99,6 +100,7 @@ set(LIBDATACHANNEL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/configuration.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/datachannel.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/description.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/iceudpmuxlistener.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/mediahandler.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/rtcpreceivingsession.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/common.hpp
@@ -139,6 +141,7 @@ set(LIBDATACHANNEL_IMPL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/dtlssrtptransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/dtlstransport.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/icetransport.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/iceudpmuxlistener.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/init.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/peerconnection.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/logcounter.cpp
@@ -171,6 +174,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/dtlssrtptransport.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/dtlstransport.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/icetransport.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/iceudpmuxlistener.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/init.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/internals.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/impl/peerconnection.hpp

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -35,15 +35,20 @@ RTC_CPP_EXPORT void Preload();
 RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
 struct UnhandledStunRequest {
-	optional<std::string> localUfrag;
-	optional<std::string> remoteUfrag;
-	std::string address;
-	uint16_t port;
+	std::string localUfrag;
+	std::string remoteUfrag;
+	std::string remoteHost;
+	uint16_t remotePort;
 };
 
-RTC_CPP_EXPORT typedef std::function<void(UnhandledStunRequest request)> UnhandledStunRequestCallback;
+RTC_CPP_EXPORT typedef std::function<void(UnhandledStunRequest request, void* userPtr)> UnhandledStunRequestCallback;
 
-RTC_CPP_EXPORT void OnUnhandledStunRequest(std::string host, int port, UnhandledStunRequestCallback callback = nullptr);
+struct UnhandledStunRequestHandler {
+	UnhandledStunRequestCallback callback;
+	void *userPtr;
+};
+
+RTC_CPP_EXPORT void OnUnhandledStunRequest(std::string host, int port, UnhandledStunRequestCallback callback = nullptr, void *userPtr = nullptr);
 
 struct SctpSettings {
 	// For the following settings, not set means optimized default

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -34,17 +34,6 @@ RTC_CPP_EXPORT void InitLogger(LogLevel level, LogCallback callback = nullptr);
 RTC_CPP_EXPORT void Preload();
 RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
-struct IceUdpMuxRequest {
-	std::string localUfrag;
-	std::string remoteUfrag;
-	std::string remoteHost;
-	uint16_t remotePort;
-};
-
-RTC_CPP_EXPORT typedef std::function<void(IceUdpMuxRequest request)> IceUdpMuxCallback;
-
-RTC_CPP_EXPORT void ListenIceUdpMux (int port, IceUdpMuxCallback *callback, std::optional<std::string> bindAddress = nullptr);
-
 struct SctpSettings {
 	// For the following settings, not set means optimized default
 	optional<size_t> recvBufferSize;                // in bytes

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -34,21 +34,16 @@ RTC_CPP_EXPORT void InitLogger(LogLevel level, LogCallback callback = nullptr);
 RTC_CPP_EXPORT void Preload();
 RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
-struct UnhandledStunRequest {
+struct IceUdpMuxRequest {
 	std::string localUfrag;
 	std::string remoteUfrag;
 	std::string remoteHost;
 	uint16_t remotePort;
 };
 
-RTC_CPP_EXPORT typedef std::function<void(UnhandledStunRequest request, void* userPtr)> UnhandledStunRequestCallback;
+RTC_CPP_EXPORT typedef std::function<void(IceUdpMuxRequest request)> IceUdpMuxCallback;
 
-struct UnhandledStunRequestHandler {
-	UnhandledStunRequestCallback callback;
-	void *userPtr;
-};
-
-RTC_CPP_EXPORT void OnUnhandledStunRequest(std::string host, int port, UnhandledStunRequestCallback callback = nullptr, void *userPtr = nullptr);
+RTC_CPP_EXPORT void ListenIceUdpMux (int port, IceUdpMuxCallback *callback, std::optional<std::string> bindAddress = nullptr);
 
 struct SctpSettings {
 	// For the following settings, not set means optimized default

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -34,6 +34,17 @@ RTC_CPP_EXPORT void InitLogger(LogLevel level, LogCallback callback = nullptr);
 RTC_CPP_EXPORT void Preload();
 RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
+struct UnhandledStunRequest {
+	optional<std::string> localUfrag;
+	optional<std::string> remoteUfrag;
+	std::string address;
+	uint16_t port;
+};
+
+RTC_CPP_EXPORT typedef std::function<void(UnhandledStunRequest request)> UnhandledStunRequestCallback;
+
+RTC_CPP_EXPORT void OnUnhandledStunRequest(std::string host, int port, UnhandledStunRequestCallback callback = nullptr);
+
 struct SctpSettings {
 	// For the following settings, not set means optimized default
 	optional<size_t> recvBufferSize;                // in bytes

--- a/include/rtc/iceudpmuxlistener.hpp
+++ b/include/rtc/iceudpmuxlistener.hpp
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2025 Alex Potsides
+ * Copyright (c) 2025 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef RTC_ICE_UDP_MUX_LISTENER_H
+#define RTC_ICE_UDP_MUX_LISTENER_H
+
+#include "common.hpp"
+
+namespace rtc {
+
+namespace impl {
+
+struct IceUdpMuxListener;
+
+} // namespace impl
+
+struct IceUdpMuxRequest { // TODO change name
+	string localUfrag;
+	string remoteUfrag;
+	string remoteAddress;
+	uint16_t remotePort;
+};
+
+class RTC_CPP_EXPORT IceUdpMuxListener final : private CheshireCat<impl::IceUdpMuxListener> {
+public:
+	IceUdpMuxListener(uint16_t port, optional<string> bindAddress = nullopt);
+	~IceUdpMuxListener();
+
+	void stop();
+
+	uint16_t port() const;
+
+	void OnUnhandledStunRequest(std::function<void(IceUdpMuxRequest)> callback);
+
+private:
+	using CheshireCat<impl::IceUdpMuxListener>::impl;
+};
+
+} // namespace rtc
+
+#endif

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -172,6 +172,20 @@ typedef void(RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcPliHandlerCallbackFunc)(int tr, void *ptr);
 typedef void(RTC_API *rtcRembHandlerCallbackFunc)(int tr, unsigned int bitrate, void *ptr);
 
+// Handle STUN requests with unexpected ufrags
+
+typedef struct {
+	const char * ufrag;
+	const char * pwd;
+	uint8_t family;
+	const char * address;
+	uint16_t port;
+} rtcUnhandledStunRequest;
+
+typedef void(RTC_API *rtcUnhandledStunRequestCallbackFunc)(rtcUnhandledStunRequest request);
+
+RTC_C_EXPORT void rtcOnUnhandledStunRequest(const char *host, int port, rtcUnhandledStunRequestCallbackFunc callback);
+
 // Log
 
 // NULL cb on the first call will log to stdout

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -172,20 +172,6 @@ typedef void(RTC_API *rtcAvailableCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcPliHandlerCallbackFunc)(int tr, void *ptr);
 typedef void(RTC_API *rtcRembHandlerCallbackFunc)(int tr, unsigned int bitrate, void *ptr);
 
-// Handle STUN requests with unexpected ufrags
-
-typedef struct {
-	const char * ufrag;
-	const char * pwd;
-	uint8_t family;
-	const char * address;
-	uint16_t port;
-} rtcUnhandledStunRequest;
-
-typedef void(RTC_API *rtcUnhandledStunRequestCallbackFunc)(rtcUnhandledStunRequest request);
-
-RTC_C_EXPORT void rtcOnUnhandledStunRequest(const char *host, int port, rtcUnhandledStunRequestCallbackFunc callback);
-
 // Log
 
 // NULL cb on the first call will log to stdout

--- a/include/rtc/rtc.hpp
+++ b/include/rtc/rtc.hpp
@@ -16,6 +16,7 @@
 #include "datachannel.hpp"
 #include "peerconnection.hpp"
 #include "track.hpp"
+#include "iceudpmuxlistener.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -19,11 +19,6 @@
 #include "impl/init.hpp"
 
 #include <mutex>
-#include <map>
-
-#if !USE_NICE
-#include <juice/juice.h>
-#endif
 
 namespace {
 
@@ -93,54 +88,7 @@ std::shared_future<void> Cleanup() { return impl::Init::Instance().cleanup(); }
 
 void SetSctpSettings(SctpSettings s) { impl::Init::Instance().setSctpSettings(std::move(s)); }
 
-#if !USE_NICE
-
-void InvokeIceUdpMuxCallback (const juice_mux_binding_request *info, void *user_ptr) {
-	PLOG_DEBUG << "Invoking ICE UDP mux callback";
-
-	IceUdpMuxCallback *callback = (IceUdpMuxCallback*)user_ptr;
-
-	if (callback) {
-		(*callback)({
-			std::string(info->local_ufrag),
-			std::string(info->remote_ufrag),
-			std::string(info->address),
-			info->port
-		});
-	} else {
-		PLOG_DEBUG << "No ICE UDP mux callback configured for port " << info->port;
-	}
-}
-
-#endif
-
-void ListenIceUdpMux ([[maybe_unused]] int port, [[maybe_unused]] IceUdpMuxCallback *callback, [[maybe_unused]] std::optional<std::string> bindAddress) {
-	#if USE_NICE
-		PLOG_WARNING << "ListenIceUdpMux is not supported with libnice, please use libjuice";
-	#else
-	// NULL host binds to all available addresses
-	const char *host = bindAddress.has_value() ? bindAddress.value().c_str() : NULL;
-
-	if (callback == NULL) {
-		PLOG_DEBUG << "Removing ICE UDP mux callback for port " << port;
-
-		// call with NULL callback to remove the listener for the host/port
-		if (juice_mux_listen(host, port, NULL, NULL) < 0) {
-			throw std::runtime_error("Could not remove ICE UDP mux callback");
-		}
-
-		return;
-	}
-
-	PLOG_DEBUG << "Adding ICE UDP mux callback for port " << port;
-
-	if (juice_mux_listen(host, port, &InvokeIceUdpMuxCallback, callback) < 0) {
-		throw std::invalid_argument("Could not add ICE UDP mux callback");
-	}
-	#endif
-}
-
-RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, LogLevel level) {
+std::ostream &operator<<(std::ostream &out, LogLevel level) {
 	switch (level) {
 	case LogLevel::Fatal:
 		out << "fatal";

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -93,50 +93,57 @@ std::shared_future<void> Cleanup() { return impl::Init::Instance().cleanup(); }
 
 void SetSctpSettings(SctpSettings s) { impl::Init::Instance().setSctpSettings(std::move(s)); }
 
+std::map<int, UnhandledStunRequestHandler *> unboundStunCallbacks;
+
 #if !USE_NICE
 
-UnhandledStunRequestCallback unboundStunCallback;
-
 void InvokeUnhandledStunRequestCallback (const juice_mux_binding_request *info, void *user_ptr) {
-	PLOG_DEBUG << "Invoking Unbind STUN listener";
-	auto callback = static_cast<UnhandledStunRequestCallback *>(user_ptr);
+	PLOG_DEBUG << "Invoking unhandled STUN request callback";
 
-	(*callback)({
-		std::string(info->local_ufrag),
-		std::string(info->remote_ufrag),
-		std::string(info->address),
-		info->port
-	});
+	UnhandledStunRequestHandler *handler = (struct UnhandledStunRequestHandler*)user_ptr;
+
+	if (handler->callback) {
+		handler->callback({
+			std::string(info->local_ufrag),
+			std::string(info->remote_ufrag),
+			std::string(info->address),
+			info->port
+		}, handler->userPtr);
+	} else {
+		PLOG_DEBUG << "No unhandled STUN request callback configured for port " << info->port;
+	}
 }
 
 #endif
 
-void OnUnhandledStunRequest ([[maybe_unused]] std::string host, [[maybe_unused]] int port, [[maybe_unused]] UnhandledStunRequestCallback callback) {
+void OnUnhandledStunRequest ([[maybe_unused]] std::string host, [[maybe_unused]] int port, [[maybe_unused]] UnhandledStunRequestCallback callback, [[maybe_unused]] void *userPtr) {
 	#if USE_NICE
 		PLOG_WARNING << "BindStunListener is not supported with libnice, please use libjuice";
 	#else
 	if (callback == NULL) {
 		PLOG_DEBUG << "Removing unhandled STUN request listener";
 
+		free(unboundStunCallbacks.at(port));
+		unboundStunCallbacks.erase(port);
+
 		// call with NULL callback to unbind
 		if (juice_mux_listen(host.c_str(), port, NULL, NULL) < 0) {
 			throw std::runtime_error("Could not unbind STUN listener");
 		}
-		unboundStunCallback = NULL;
 
 		return;
 	}
 
 	PLOG_DEBUG << "Adding listener for unhandled STUN requests";
 
-	if (unboundStunCallback != NULL) {
-		throw std::runtime_error("Unhandled STUN request handler already present");
-	}
+	UnhandledStunRequestHandler *handler = (UnhandledStunRequestHandler*)calloc(1, sizeof(UnhandledStunRequestHandler));
+	handler->callback = std::move(callback);
+	handler->userPtr = userPtr;
 
-	unboundStunCallback = std::move(callback);
+	unboundStunCallbacks[port] = handler;
 
-	if (juice_mux_listen(host.c_str(), port, &InvokeUnhandledStunRequestCallback, &unboundStunCallback) < 0) {
-		throw std::invalid_argument("Could add listener for unhandled STUN requests");
+	if (juice_mux_listen(host.c_str(), port, &InvokeUnhandledStunRequestCallback, handler) < 0) {
+		throw std::invalid_argument("Could not add listener for unhandled STUN requests");
 	}
 	#endif
 }

--- a/src/iceudpmuxlistener.cpp
+++ b/src/iceudpmuxlistener.cpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2025 Alex Potsides
+ * Copyright (c) 2025 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "iceudpmuxlistener.hpp"
+
+#include "impl/iceudpmuxlistener.hpp"
+
+namespace rtc {
+
+IceUdpMuxListener::IceUdpMuxListener(uint16_t port, optional<string> bindAddress)
+    : CheshireCat<impl::IceUdpMuxListener>(port, std::move(bindAddress)) {}
+
+IceUdpMuxListener::~IceUdpMuxListener() {}
+
+void IceUdpMuxListener::stop() { impl()->stop(); }
+
+uint16_t IceUdpMuxListener::port() const { return impl()->port; }
+
+void IceUdpMuxListener::OnUnhandledStunRequest(std::function<void(IceUdpMuxRequest)> callback) {
+	impl()->unhandledStunRequestCallback = callback;
+}
+
+} // namespace rtc

--- a/src/impl/iceudpmuxlistener.cpp
+++ b/src/impl/iceudpmuxlistener.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2025 Alex Potsides
+ * Copyright (c) 2025 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "iceudpmuxlistener.hpp"
+#include "internals.hpp"
+
+namespace rtc::impl {
+
+#if !USE_NICE
+void IceUdpMuxListener::UnhandledStunRequestCallback(const juice_mux_binding_request *info,
+                                                     void *user_ptr) {
+	auto listener = static_cast<IceUdpMuxListener *>(user_ptr);
+	if (!listener)
+		return;
+
+	IceUdpMuxRequest request;
+	request.localUfrag = info->local_ufrag;
+	request.remoteUfrag = info->remote_ufrag;
+	request.remoteAddress = info->address;
+	request.remotePort = info->port;
+	listener->unhandledStunRequestCallback(std::move(request));
+}
+#endif
+
+IceUdpMuxListener::IceUdpMuxListener(uint16_t port, optional<string> bindAddress) : port(port) {
+	PLOG_VERBOSE << "Creating IceUdpMuxListener";
+
+#if !USE_NICE
+	PLOG_DEBUG << "Registering ICE UDP mux listener for port " << port;
+	if (juice_mux_listen(bindAddress ? bindAddress->c_str() : NULL, port,
+	                     IceUdpMuxListener::UnhandledStunRequestCallback, this) < 0) {
+		throw std::runtime_error("Failed to register ICE UDP mux listener");
+	}
+#else
+	PLOG_WARNING << "ICE UDP mux is not available with libnice";
+#endif
+}
+
+IceUdpMuxListener::~IceUdpMuxListener() {
+	PLOG_VERBOSE << "Destroying IceUdpMuxListener";
+	stop();
+}
+
+void IceUdpMuxListener::stop() {
+	if (mStopped.exchange(true))
+		return;
+
+#if !USE_NICE
+	PLOG_DEBUG << "Unregistering ICE UDP mux listener for port " << port;
+	if (juice_mux_listen(NULL, port, NULL, NULL) < 0) {
+		PLOG_ERROR << "Failed to unregister ICE UDP mux listener";
+	}
+#endif
+}
+
+} // namespace rtc::impl

--- a/src/impl/iceudpmuxlistener.cpp
+++ b/src/impl/iceudpmuxlistener.cpp
@@ -28,7 +28,7 @@ void IceUdpMuxListener::UnhandledStunRequestCallback(const juice_mux_binding_req
 }
 #endif
 
-IceUdpMuxListener::IceUdpMuxListener(uint16_t port, optional<string> bindAddress) : port(port) {
+IceUdpMuxListener::IceUdpMuxListener(uint16_t port, [[maybe_unused]] optional<string> bindAddress) : port(port) {
 	PLOG_VERBOSE << "Creating IceUdpMuxListener";
 
 #if !USE_NICE

--- a/src/impl/iceudpmuxlistener.hpp
+++ b/src/impl/iceudpmuxlistener.hpp
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2025 Alex Potsides
+ * Copyright (c) 2025 Paul-Louis Ageneau
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef RTC_IMPL_ICE_UDP_MUX_LISTENER_H
+#define RTC_IMPL_ICE_UDP_MUX_LISTENER_H
+
+#include "common.hpp"
+
+#include "rtc/iceudpmuxlistener.hpp"
+
+#if !USE_NICE
+#include <juice/juice.h>
+#endif
+
+#include <atomic>
+
+namespace rtc::impl {
+
+struct IceUdpMuxListener final {
+	IceUdpMuxListener(uint16_t port, optional<string> bindAddress = nullopt);
+    ~IceUdpMuxListener();
+
+	void stop();
+
+	const uint16_t port;
+	synchronized_callback<IceUdpMuxRequest> unhandledStunRequestCallback;
+
+private:
+#if !USE_NICE
+	static void UnhandledStunRequestCallback(const juice_mux_binding_request *info, void *user_ptr);
+#endif
+
+	std::atomic<bool> mStopped;
+};
+
+}
+
+#endif
+

--- a/src/impl/iceudpmuxlistener.hpp
+++ b/src/impl/iceudpmuxlistener.hpp
@@ -24,7 +24,7 @@ namespace rtc::impl {
 
 struct IceUdpMuxListener final {
 	IceUdpMuxListener(uint16_t port, optional<string> bindAddress = nullopt);
-    ~IceUdpMuxListener();
+	~IceUdpMuxListener();
 
 	void stop();
 


### PR DESCRIPTION
Calls the functions added to libjuice in https://github.com/paullouisageneau/libjuice/pull/248 (this needs to be merged & released before CI will pass here).

Exports a `OnUnhandledStunRequest` function that can be passed a callback that will be invoked when an incoming STUN message is received that has no corresponding agent for the ICE ufrag.

Refs #1166
