### PR TITLE
One shot REMB magic check

### DIFF
--- a/src/rembhandler.cpp
+++ b/src/rembhandler.cpp
@@ -27,7 +27,7 @@ namespace rtc {
 RembHandler::RembHandler(std::function<void(unsigned int)> onRemb) : mOnRemb(onRemb) {}
 
 void RembHandler::incoming(message_vector &messages, [[maybe_unused]] const message_callback &send) {
-	static uint32_t rembValue = makeEndianAgnosticValue('BMER');
+	static uint32_t rembValue = makeEndianAgnosticValue(0x424d4552); // BMER
 
 	for (const auto &message : messages) {
 		size_t offset = 0;


### PR DESCRIPTION
Proof of concept:
Test app:
```
#include <stdio.h>
#include <stdlib.h>
#include <stdint.h>

bool is_little_endian()
{
    uint16_t value = 0x0001;
    return *((uint8_t*)(&value)) == 0x01;
}

unsigned int to_endian_agnostic(unsigned int value)
{
    return ((uint8_t*)&value)[0] | (((uint8_t*)&value)[1] << 8) | (((uint8_t*)&value)[2] << 16) | (((uint8_t*)&value)[3] << 24);
}

int main (int argc, char *argv[])
{
    static unsigned int z = to_endian_agnostic('BMER');

    union
    {
      unsigned char c[4];
      unsigned int i;
    } y;

    y.c[0] = 'R';
    y.c[1] = 'E';
    y.c[2] = 'M';
    y.c[3] = 'B';

    printf("Hello ! %08x, %08x: little endian: %ld\n", y.i, z, is_little_endian());

    if (y.i == z) {
        printf("REMB\n");
    }

    return 0;
}
```

Build:
```
aarch64-linux-gnu-g++ -g main.cpp -o a_aarch64.out

# wget 'https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/armeb-linux-gnueabi/gcc-linaro-7.5.0-2019.12-x86_64_armeb-linux-gnueabi.tar.xz'
# wget 'https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/armeb-linux-gnueabi/runtime-gcc-linaro-7.5.0-2019.12-armeb-linux-gnueabi.tar.xz'
# wget 'https://releases.linaro.org/components/toolchain/binaries/7.5-2019.12/armeb-linux-gnueabi/sysroot-glibc-linaro-2.25-2019.12-armeb-linux-gnueabi.tar.xz'
./gcc-linaro-7.5.0-2019.12-x86_64_armeb-linux-gnueabi/bin/armeb-linux-gnueabi-g++ main.cpp -g -o a_armeb.out
g++ -g main.cpp -o a.out
```

Test:
x86: ./a.out
```
Hello ! 424d4552, 424d4552: little endian: 1
REMB
```

aarch64: qemu-aarch64 -L /usr/aarch64-linux-gnu ./a_aarch64.out
```
Hello ! 424d4552, 424d4552: little endian: 1
REMB
```

arm big endian: qemu-armeb -L $(pwd)/sysroot-glibc-linaro-2.25-2019.12-armeb-linux-gnueabi/ ./a_armeb.out
```
Hello ! 52454d42, 52454d42: little endian: 0
REMB
```