### PR TITLE
Fix SctpTransport::Instances leak

### DIFF
--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -82,7 +82,7 @@ private:
 	std::shared_mutex mMutex;
 };
 
-SctpTransport::InstancesSet *SctpTransport::Instances = new InstancesSet;
+std::unique_ptr<SctpTransport::InstancesSet> SctpTransport::Instances = std::make_unique<InstancesSet>();
 
 void SctpTransport::Init() {
 	usrsctp_init(0, SctpTransport::WriteCallback, SctpTransport::DebugCallback);

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -127,7 +127,7 @@ private:
 	static void DebugCallback(const char *format, ...);
 
 	class InstancesSet;
-	static InstancesSet *Instances;
+	static std::unique_ptr<InstancesSet> Instances;
 };
 
 } // namespace rtc::impl


### PR DESCRIPTION
SctpTransport::Instances was not being freed causing memory leak warnings