### PR TITLE
Shutdown race condition work-around

### DIFF
--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -462,6 +462,11 @@ void TcpTransport::process(PollService::Event event) {
 		PLOG_ERROR << e.what();
 	}
 
+	// Allow any received messages to be processed before we shut down and destroy the callbacks
+	// This should probably be a mutex or check of a queue size or something, but I can't figure out
+	// what to do that against and a 100ms delay seems to be plenty
+
+	usleep(100 * 1000);
 	PLOG_INFO << "TCP disconnected";
 	PollService::Instance().remove(mSock);
 	changeState(State::Disconnected);

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -465,8 +465,7 @@ void TcpTransport::process(PollService::Event event) {
 	// Allow any received messages to be processed before we shut down and destroy the callbacks
 	// This should probably be a mutex or check of a queue size or something, but I can't figure out
 	// what to do that against and a 100ms delay seems to be plenty
-
-	usleep(100 * 1000);
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
 	PLOG_INFO << "TCP disconnected";
 	PollService::Instance().remove(mSock);
 	changeState(State::Disconnected);


### PR DESCRIPTION
I doubt this is the best possible solution to the race condition, but I couldn't find anything else that was really viable, since we're waiting for the callback to get called by the main loop.

Adding a small delay (100ms) to TcpTransport::process allows the packets to get processed before we tear down the callbacks, etc.
