### PR TITLE
Fix possible race condition at exit with OpenSSL

### DIFF
--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -158,7 +158,11 @@ void init() {
 
 	std::lock_guard lock(mutex);
 	if (!std::exchange(done, true)) {
-		OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, nullptr);
+		uint64_t ssl_opts = OPENSSL_INIT_LOAD_SSL_STRINGS | OPENSSL_INIT_LOAD_CRYPTO_STRINGS;
+#ifdef OPENSSL_INIT_NO_ATEXIT
+		ssl_opts |= OPENSSL_INIT_NO_ATEXIT;
+#endif
+		OPENSSL_init_ssl(ssl_opts, nullptr);
 		OPENSSL_init_crypto(OPENSSL_INIT_LOAD_CRYPTO_STRINGS, nullptr);
 	}
 }


### PR DESCRIPTION
This PR disables the OpenSSL atexit handler to prevent a possible race condition.

Note the [OpenSSL documentation](https://docs.openssl.org/1.1.1/man3/OPENSSL_init_crypto/#description) discourages libraries from calling `OPENSSL_cleanup()` directly.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1299