### PR TITLE
Fix possible crash on program exit with libnice

### DIFF
--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -90,8 +90,17 @@ private:
 	static void RecvCallback(juice_agent_t *agent, const char *data, size_t size, void *user_ptr);
 	static void LogCallback(juice_log_level_t level, const char *message);
 #else
-	static unique_ptr<GMainLoop, void (*)(GMainLoop *)> MainLoop;
-	static std::thread MainLoopThread;
+	class MainLoopWrapper {
+	public:
+		MainLoopWrapper();
+		~MainLoopWrapper();
+		GMainLoop *get() const;
+
+	private:
+		unique_ptr<GMainLoop, void (*)(GMainLoop *)> mMainLoop;
+		std::thread mThread;
+	};
+	static MainLoopWrapper *MainLoop;
 
 	unique_ptr<NiceAgent, void (*)(NiceAgent *)> mNiceAgent;
 	uint32_t mStreamId = 0;


### PR DESCRIPTION
This PR fixes a possible crash with libnice at program exit depending on globals deallocation order. The issue was that the glib main loop thread could be destroyed before being joined.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1299