### PR TITLE
Fix double mutex lock with MbedTLS

### DIFF
--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -78,7 +78,7 @@ protected:
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
 
-	std::mutex mSslMutex;
+	std::recursive_mutex mSslMutex;
 
 	uint32_t mFinMs = 0, mIntMs = 0;
 	std::chrono::time_point<std::chrono::steady_clock> mTimerSetAt;

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -72,7 +72,7 @@ protected:
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
 
-	std::mutex mSslMutex;
+	std::recursive_mutex mSslMutex;
 	std::atomic<bool> mOutgoingResult = true;
 
 	message_ptr mIncomingMessage;


### PR DESCRIPTION
This PR makes the MbedTLS mutex recursive to fix a possible double lock issue.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1347