### PR TITLE
Fix the vector issue in AV1 fragment function

### DIFF
--- a/src/av1rtppacketizer.cpp
+++ b/src/av1rtppacketizer.cpp
@@ -99,7 +99,7 @@ std::vector<binary> AV1RtpPacketizer::fragment(binary data) {
 			auto fragments = fragmentObu(obu);
 			result.reserve(result.size() + fragments.size());
 			for(auto &fragment : fragments)
-				fragments.push_back(std::move(fragment));
+				result.push_back(std::move(fragment));
 		}
 		return result;
 	} else {


### PR DESCRIPTION
It seems that an incorrect porting was done during the refactoring of https://github.com/paullouisageneau/libdatachannel/commit/4c3fb5a592af0988c2c64682aa50fb71e7d0280b