### PR TITLE
TWCC extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,8 @@ set(LIBDATACHANNEL_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/src/plihandler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/pacinghandler.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/src/rembhandler.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/chaininterop.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/src/rtptwcchandler.cpp
 )
 
 set(LIBDATACHANNEL_HEADERS
@@ -132,6 +134,8 @@ set(LIBDATACHANNEL_HEADERS
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/pacinghandler.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/rembhandler.hpp
 	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/version.h
+	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/chaininterop.hpp
+	${CMAKE_CURRENT_SOURCE_DIR}/include/rtc/rtptwcchandler.hpp
 )
 
 set(LIBDATACHANNEL_IMPL_SOURCES

--- a/include/rtc/chaininterop.hpp
+++ b/include/rtc/chaininterop.hpp
@@ -1,0 +1,82 @@
+#ifndef RTC_CHAIN_INTEROP_H
+#define RTC_CHAIN_INTEROP_H
+
+#if RTC_ENABLE_MEDIA
+#include "common.hpp"
+#include <map>
+#include <deque>
+#include <vector>
+#include <chrono>
+// ChainInterop will be used for storing info about TWCC packets
+// RtpTwccHandler produces new entries inside ChainInterop as it is processing RTP packets.
+// GCC algorithm consumes it.
+namespace rtc {
+	struct RTC_CPP_EXPORT BitrateStats {
+		double txBitsPerSecond, rxBitsPerSecond, packetLoss;
+		BitrateStats() : txBitsPerSecond(0), rxBitsPerSecond(0), packetLoss(0) {}
+		BitrateStats(double tx, double rx, double loss) : txBitsPerSecond(tx), rxBitsPerSecond(rx), packetLoss(loss) {};
+	};
+	
+	struct PacketInfo {
+		bool isReceived;
+		bool isSent;
+		uint16_t numBytes;
+		std::chrono::microseconds arrivalDuration;
+		std::chrono::steady_clock::time_point departureTime;
+		PacketInfo(uint16_t numBytes);
+	};
+	// WholeFrameInfo is an internal representation for a video frame
+	class WholeFrameInfo {
+		std::chrono::steady_clock::time_point time;
+		uint16_t seqNumStart, seqNumEnd;
+	
+	public:
+		WholeFrameInfo(std::chrono::steady_clock::time_point time, uint16_t seqNumStart, uint16_t seqNumEnd);
+		std::chrono::steady_clock::time_point getTime() const;
+		uint16_t getSeqNumStart() const;
+		uint16_t getSeqNumEnd() const;
+	};
+	
+	struct RTC_CPP_EXPORT ArrivalGroup {
+		std::vector<PacketInfo> packets;
+		std::chrono::microseconds arrivalTime;
+		std::chrono::steady_clock::time_point departureTime;
+	
+		ArrivalGroup() = default;
+		ArrivalGroup(const ArrivalGroup &other);
+		ArrivalGroup(ArrivalGroup&& other) noexcept;
+		ArrivalGroup& operator=(const ArrivalGroup& other);
+		ArrivalGroup& operator=(ArrivalGroup&& other) noexcept;
+		void add(PacketInfo packet);	
+		void reset();
+	};
+	
+	class RTC_CPP_EXPORT ChainInterop {
+		using clock = std::chrono::steady_clock;
+		std::map<uint16_t, PacketInfo> packetInfo;
+		std::deque<WholeFrameInfo> wholeFrameInfo;
+		// timeThreshold should be at least 1000ms.
+		std::chrono::milliseconds timeThreshold;
+		std::mutex mapMutex;
+	
+	public:
+		ChainInterop(int thresholdMs);
+		void addPackets(uint16_t baseSeqNum, const std::vector<uint16_t> &numBytes);
+		void setSentInfo(const std::vector<uint16_t> &seqNums);
+		void setSentInfo(const std::vector<uint16_t> &seqNums, const std::vector<clock::time_point> &sendTimes);
+		size_t updateReceivedStatus(uint16_t baseSeqNum, const std::vector<bool> &statuses, const std::vector<std::chrono::microseconds> &arrivalTimesUs);
+		BitrateStats getBitrateStats(uint16_t seqnum, uint16_t packetCount);
+		void deleteOldFrames();
+		size_t getNumberOfFrames() const;
+		size_t getNumberOfFramesReceived() const;
+		std::vector<ArrivalGroup> runArrivalGroupAccumulator(uint16_t seqnum, uint16_t numPackets);
+	};
+	
+	std::chrono::microseconds interDepartureTimePkt(ArrivalGroup group, PacketInfo packet);
+	std::chrono::microseconds interArrivalTimePkt(ArrivalGroup group, PacketInfo packet);
+	std::chrono::microseconds interGroupDelayVariationPkt(ArrivalGroup group, PacketInfo packet);
+} // namespace rtc
+
+#endif /* RTC_ENABLE_MEDIA */
+
+#endif /* RTC_CHAIN_INTEROP_H */

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -356,6 +356,33 @@ struct RTC_CPP_EXPORT RtpRtx {
 	size_t copyTo(RtpHeader *dest, size_t totalSize, uint8_t originalPayloadType);
 };
 
+struct RTC_CPP_EXPORT RtcpTwcc {
+	RtcpFbHeader header;
+	uint16_t _baseSeqNum;
+	uint16_t _packetStatusCount;
+	uint8_t _referenceTime[3];
+	uint8_t _fbPacketCount;
+
+	[[nodiscard]] uint16_t getBaseSeqNum() const;
+	[[nodiscard]] uint16_t getPacketStatusCount() const;
+	[[nodiscard]] uint32_t getReferenceTime() const;
+	[[nodiscard]] uint8_t getFbPacketCount() const;
+	[[nodiscard]] char* getBody();
+};
+
+struct RTC_CPP_EXPORT RtpTwccExt {
+	RtpExtensionHeader header;
+	uint8_t _id;
+	uint16_t _twccSeqNum;
+	uint8_t _zeroPad;
+
+	void setExtId(uint8_t id);
+	void setTwccSeqNum(uint16_t seqNum);
+	void preparePacket(uint8_t extId);
+
+	[[nodiscard]] uint16_t getTwccSeqNum() const;
+};
+
 #pragma pack(pop)
 
 } // namespace rtc

--- a/include/rtc/rtptwcchandler.hpp
+++ b/include/rtc/rtptwcchandler.hpp
@@ -1,0 +1,25 @@
+#ifndef RTC_RTP_TWCC_HANDLER_H
+#define RTC_RTP_TWCC_HANDLER_H
+
+#if RTC_ENABLE_MEDIA
+
+#include "mediahandler.hpp"
+#include "rtp.hpp"
+namespace rtc {
+
+class RTC_CPP_EXPORT TwccHandler final : public MediaHandler {
+	RtpTwccExt twccHeader;
+	uint16_t twccSeqNum;
+	// Callback below is for recording TWCC seqNums
+	std::function<void(message_vector &)> processPacketsCallback;
+
+public:
+	TwccHandler(uint8_t extId, std::function<void(message_vector &)> processPacketsCallback);
+	void outgoing(message_vector &messages, const message_callback &send) override;
+};
+
+} // namespace rtc
+
+#endif /* RTC_ENABLE_MEDIA */
+
+#endif /* RTC_RTP_TWCC_HANDLER_H */

--- a/src/chaininterop.cpp
+++ b/src/chaininterop.cpp
@@ -1,0 +1,270 @@
+#if RTC_ENABLE_MEDIA
+
+#include "chaininterop.hpp"
+#include <cmath>
+#include <utility>
+
+namespace rtc {
+
+PacketInfo::PacketInfo(uint16_t numBytes)
+    : isReceived(false), isSent(false), numBytes(numBytes) {}
+
+WholeFrameInfo::WholeFrameInfo(std::chrono::steady_clock::time_point time, uint16_t seqNumStart, uint16_t seqNumEnd) 
+	: time(time), seqNumStart(seqNumStart), seqNumEnd(seqNumEnd) {}
+
+std::chrono::steady_clock::time_point WholeFrameInfo::getTime() const { return time; }
+
+uint16_t WholeFrameInfo::getSeqNumStart() const { return seqNumStart; }
+
+uint16_t WholeFrameInfo::getSeqNumEnd() const { return seqNumEnd; }
+
+ArrivalGroup::ArrivalGroup(const ArrivalGroup &other) : packets(other.packets),
+										  arrivalTime(other.arrivalTime),
+										  departureTime(other.departureTime) {}
+ArrivalGroup::ArrivalGroup(ArrivalGroup&& other) noexcept : packets(std::move(other.packets)),
+											  arrivalTime(std::move(other.arrivalTime)),
+											  departureTime(std::move(other.departureTime)) {}
+ArrivalGroup& ArrivalGroup::operator=(const ArrivalGroup& other) {
+	if (this != &other) {
+		packets = other.packets;
+		arrivalTime = other.arrivalTime;
+		departureTime = other.departureTime;
+	}
+	return *this;
+}
+
+ArrivalGroup& ArrivalGroup::operator=(ArrivalGroup&& other) noexcept {
+	if (this != &other) {
+		packets = std::move(other.packets);
+		arrivalTime = std::move(other.arrivalTime);
+		departureTime = std::move(other.departureTime);
+		other.reset();
+	}
+	return *this;
+}
+
+void ArrivalGroup::add(PacketInfo packet) {
+	packets.push_back(packet);
+	arrivalTime = packet.arrivalDuration;
+	departureTime = packet.departureTime;
+}
+
+void ArrivalGroup::reset() {
+	packets.clear();
+	arrivalTime = std::chrono::microseconds::zero();
+	departureTime = std::chrono::steady_clock::time_point();
+}
+
+ChainInterop::ChainInterop(int thresholdMs) {
+	timeThreshold = std::chrono::milliseconds(thresholdMs);
+}
+
+void ChainInterop::addPackets(uint16_t baseSeqNum, const std::vector<uint16_t> &numBytes) {
+	std::unique_lock<std::mutex> guard(mapMutex);
+	uint16_t numPackets = (uint16_t) numBytes.size();
+	wholeFrameInfo.emplace_back(clock::now(), baseSeqNum, baseSeqNum + numPackets);
+	for (const auto& bytes : numBytes) {
+		packetInfo.emplace(std::make_pair(baseSeqNum, PacketInfo(bytes)));
+		baseSeqNum++;
+	}
+}
+
+void ChainInterop::setSentInfo(const std::vector<uint16_t> &seqNums) {
+	std::unique_lock<std::mutex> guard(mapMutex);
+	clock::time_point now = std::chrono::steady_clock::now();
+	for (const auto &seqNum : seqNums) {
+		packetInfo.at(seqNum).isSent = true;
+		packetInfo.at(seqNum).departureTime = now;
+	}
+}
+
+void ChainInterop::setSentInfo(const std::vector<uint16_t> &seqNums,
+                               const std::vector<clock::time_point> &sendTimes) {
+	std::unique_lock<std::mutex> guard(mapMutex);
+	for (size_t i = 0; i < seqNums.size(); i++) {
+		packetInfo.at(seqNums.at(i)).isSent = true;
+		packetInfo.at(seqNums.at(i)).departureTime = sendTimes.at(i);
+	}
+}
+
+size_t ChainInterop::updateReceivedStatus(
+	uint16_t baseSeqNum,
+	const std::vector<bool> &statuses,
+	const std::vector<std::chrono::microseconds> &arrivalTimesUs) {
+
+	uint16_t seqNum = baseSeqNum;
+	size_t totalProcessedStatusCount = 0;
+
+	if (!packetInfo.empty()) {
+		size_t vectorIdx = 0;
+		while (vectorIdx < statuses.size()) {
+			auto it = packetInfo.find(seqNum);
+			if (it != packetInfo.end()) {
+				it->second.isReceived = statuses.at(vectorIdx);
+				it->second.arrivalDuration = arrivalTimesUs.at(vectorIdx);
+				totalProcessedStatusCount++;
+			}
+			vectorIdx++;
+			seqNum++;
+		}
+	}
+	return totalProcessedStatusCount;
+}
+
+BitrateStats ChainInterop::getBitrateStats(uint16_t seqnum, uint16_t packetCount) {
+	if (packetInfo.empty())
+		return BitrateStats();
+	std::unique_lock<std::mutex> guard(mapMutex);
+	const std::chrono::seconds oneSecond = std::chrono::seconds(1);
+	clock::time_point timeNow = std::chrono::steady_clock::now();
+	clock::time_point firstPacketTime = timeNow;
+
+	size_t receivedBytes = 0, receivedPackets = 0, notReceivedBytes = 0;
+	for (const auto &packet : packetInfo) {
+		// Packets might be sent later if we use Pacer
+		if (packet.second.isSent) {
+			if (timeNow - packet.second.departureTime < oneSecond) {
+				if (packet.second.departureTime < firstPacketTime) {
+					firstPacketTime = packet.second.departureTime;
+				}
+				if (packet.second.isReceived) {
+					receivedBytes += packet.second.numBytes;
+				} else {
+					notReceivedBytes += packet.second.numBytes;
+				}
+				
+			}
+		}
+	}
+	// Packet loss is calculated only for the reported packets
+	// Due to seqnum wraparound I did not want to merge both for loops
+	for (size_t i = 0; i < packetCount; i++)
+	{
+		auto packet = packetInfo.find(seqnum);
+		if (packet != packetInfo.end() && packet->second.isReceived) {
+			receivedPackets++;
+		}
+		seqnum++;
+	}
+	double elapsedSeconds =
+	    (double)std::chrono::duration_cast<std::chrono::milliseconds>(timeNow - firstPacketTime).count() / 1000.0;
+	double receivedBitrate = (double)receivedBytes * 8 / elapsedSeconds;
+	double sentBitrate = (double)(receivedBytes + notReceivedBytes) * 8 / elapsedSeconds;
+	if (!std::isfinite(receivedBitrate))
+		receivedBitrate = 0;
+	if (!std::isfinite(sentBitrate))
+		sentBitrate = 0;
+	double packetLoss = 1.0f - ((double)receivedPackets / packetCount);
+	return BitrateStats(sentBitrate, receivedBitrate, packetLoss);
+}
+
+void ChainInterop::deleteOldFrames() {
+	std::unique_lock<std::mutex> guard(mapMutex);
+	clock::time_point now = std::chrono::steady_clock::now();
+
+	while (!wholeFrameInfo.empty() && now - wholeFrameInfo.front().getTime() > timeThreshold) {
+		uint16_t seqNum = wholeFrameInfo.front().getSeqNumStart();
+		uint16_t seqNumEnd = wholeFrameInfo.front().getSeqNumEnd();
+		// Due to wraparound seqNum might be greater than seqNumEnd
+		while (seqNum != seqNumEnd) {
+			packetInfo.erase(seqNum);
+			seqNum++;
+		}
+		wholeFrameInfo.pop_front();
+	}
+}
+
+size_t ChainInterop::getNumberOfFrames() const { return wholeFrameInfo.size(); }
+
+size_t ChainInterop::getNumberOfFramesReceived() const {
+	size_t nReceived = 0;
+	bool frameReceived = true;
+	for (const auto &frame : wholeFrameInfo) {
+		uint16_t seqNum = frame.getSeqNumStart();
+		uint16_t seqNumEnd = frame.getSeqNumEnd();
+		while (seqNum < seqNumEnd) {
+			frameReceived = frameReceived && packetInfo.at(seqNum).isReceived;
+			seqNum++;
+		}
+		if (frameReceived) {
+			nReceived++;
+		}
+		frameReceived = true;
+	}
+	
+	return nReceived;
+}
+
+std::vector<ArrivalGroup> ChainInterop::runArrivalGroupAccumulator(uint16_t baseSeqnum, uint16_t numPackets) {
+	const std::chrono::microseconds interDepartureThreshold(5000);
+	const std::chrono::microseconds interArrivalThreshold(5000);
+	const std::chrono::microseconds interGroupDelayVariationThreshold(0);
+
+	bool init = false;
+	ArrivalGroup group;
+	std::vector<ArrivalGroup> groups;
+	uint16_t seqnum = baseSeqnum;
+	uint16_t lastAddedSeqnum = 0;
+	std::unique_lock<std::mutex> guard(mapMutex);
+	for (size_t i = 0; i < numPackets; i++, seqnum++) {
+		auto packet = packetInfo.find(seqnum);
+		if (packet == packetInfo.end()) {
+			continue;
+		}
+		if (!(packet->second.isSent && packet->second.isReceived)) {
+			continue;
+		}
+		if (!init) {
+			group.add(packet->second);
+			lastAddedSeqnum = seqnum;
+			init = true;
+			continue;
+		}
+		if (packet->second.arrivalDuration < group.arrivalTime) {
+			// ignores out of order arrivals
+			continue;
+		}
+		if (packet->second.departureTime >= group.departureTime) {
+			if (interDepartureTimePkt(group, packet->second) <= interDepartureThreshold) {
+				group.add(packet->second);
+				lastAddedSeqnum = seqnum;
+				continue;
+			}
+			if (interArrivalTimePkt(group, packet->second) <= interArrivalThreshold &&
+			    interGroupDelayVariationPkt(group, packet->second) < interGroupDelayVariationThreshold) {
+				group.add(packet->second);
+				lastAddedSeqnum = seqnum;
+				continue;
+			}
+			groups.push_back(std::move(group));
+			group.reset();
+			group.add(packet->second);
+			lastAddedSeqnum = seqnum;
+		}
+	}
+	if (lastAddedSeqnum == baseSeqnum + (numPackets - 1)) {
+		groups.push_back(std::move(group));
+	}
+	return groups;
+}
+
+std::chrono::microseconds interDepartureTimePkt(ArrivalGroup group, PacketInfo packet) {
+	if (group.packets.empty())
+		return std::chrono::microseconds::zero();
+
+	return std::chrono::duration_cast<std::chrono::microseconds>(
+	    packet.departureTime - group.packets.back().departureTime);
+}
+std::chrono::microseconds interArrivalTimePkt(ArrivalGroup group, PacketInfo packet) {
+	return packet.arrivalDuration - group.packets.back().arrivalDuration;
+}
+std::chrono::microseconds interGroupDelayVariationPkt(ArrivalGroup group, PacketInfo packet) {
+	auto interDeparture = std::chrono::duration_cast<std::chrono::microseconds>(
+	    packet.departureTime - group.departureTime);
+	auto interArrival = packet.arrivalDuration - group.arrivalTime;
+	return interArrival - interDeparture;
+}
+
+} // namespace rtc
+
+#endif

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -668,4 +668,33 @@ size_t RtpRtx::copyTo(RtpHeader *dest, size_t totalSize, uint8_t originalPayload
 	return totalSize;
 }
 
+uint16_t RtcpTwcc::getBaseSeqNum() const { return ntohs(_baseSeqNum); }
+
+uint16_t RtcpTwcc::getPacketStatusCount() const { return ntohs(_packetStatusCount); }
+
+uint32_t RtcpTwcc::getReferenceTime() const {
+	uint32_t refTime = ((uint32_t)_referenceTime[0] << 16) | ((uint32_t)_referenceTime[1] << 8) |
+	                   ((uint32_t)_referenceTime[2]);
+	return refTime;
+}
+
+uint8_t RtcpTwcc::getFbPacketCount() const { return _fbPacketCount; }
+
+char *RtcpTwcc::getBody() { return reinterpret_cast<char *>(&_fbPacketCount + 1) ; }
+
+void RtpTwccExt::setExtId(uint8_t id) { _id = (id << 4) | 0x01; }
+
+void RtpTwccExt::setTwccSeqNum(uint16_t seqNum) { _twccSeqNum = htons(seqNum); }
+
+void RtpTwccExt::preparePacket(uint8_t extId) {
+	const uint16_t profileId = (uint16_t)(0xBE << 8) | 0xDE;
+	header.setProfileSpecificId(profileId);
+	header.setHeaderLength(1);
+	setExtId(extId);
+	setTwccSeqNum(0);
+	_zeroPad = 0;
+}
+
+uint16_t RtpTwccExt::getTwccSeqNum() const { return ntohs(_twccSeqNum); }
+
 }; // namespace rtc

--- a/src/rtptwcchandler.cpp
+++ b/src/rtptwcchandler.cpp
@@ -1,0 +1,49 @@
+#if RTC_ENABLE_MEDIA
+
+#include "rtptwcchandler.hpp"
+#include <cassert>
+#include <cstring>
+
+namespace rtc {
+
+#define TWCC_EXT_HEADER_SIZE 8
+
+TwccHandler::TwccHandler(uint8_t extId,
+                         std::function<void(message_vector &)> processPacketsCallback)
+    : processPacketsCallback(processPacketsCallback) {
+	assert(extId < 16);
+	twccHeader.preparePacket(extId);
+	twccSeqNum = 0;
+}
+void TwccHandler::outgoing(message_vector &messages, [[maybe_unused]] const message_callback &send) {
+	message_vector outgoing;
+	outgoing.reserve(messages.size());
+	// Add TWCC exstension to RTP packets
+	for (unsigned int i = 0; i < messages.size(); i++) {
+		auto packet = messages[i];		
+		auto rtpHeader = reinterpret_cast<RtpHeader *>(packet->data());
+		outgoing.push_back(make_message(packet->size() + TWCC_EXT_HEADER_SIZE));
+		uint8_t *src = reinterpret_cast<uint8_t *>(packet->data());
+		uint8_t *dst = reinterpret_cast<uint8_t *>(outgoing.back()->data());
+		std::memcpy(dst, src, rtpHeader->getSize());
+		// set extension bit 1
+		dst[0] = (dst[0] & ~0x10) | (0x01 << 4);
+		src += rtpHeader->getSize();
+		dst += rtpHeader->getSize();
+
+		twccHeader.setTwccSeqNum(twccSeqNum++);
+		std::memcpy(dst, &twccHeader, TWCC_EXT_HEADER_SIZE);
+		dst += TWCC_EXT_HEADER_SIZE;
+		std::memcpy(dst, src, packet->size() - rtpHeader->getSize());
+	}
+	// We will record TWCC seqnums with the callback below
+	if (processPacketsCallback)
+		processPacketsCallback(outgoing);
+	
+	messages.swap(outgoing);
+}
+
+
+} // namespace rtc
+
+#endif


### PR DESCRIPTION
Hi Paul,

This is the first half of the congestion control (CC) algorithm. This PR adds two new packet types: RtpTwccExt, which will be inserted into the RTP packets and RtcpTwcc, which is the type of the report we will get back. 

TwccHandler is responsible for inserting the RtpTwccExt header. TWCC sequence numbers will be recorded via a callback inside TwccHandler using ChainInterop. It will add new entries to the ChainInterop.

ChainInterop will be consumed by CC as the TWCC reports arrive.

Looking forward to your review.