### PR TITLE
Fix TCP mutex deadlock

### DIFF
--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -324,9 +324,10 @@ void TcpTransport::configureSocket() {
 }
 
 void TcpTransport::setPoll(PollService::Direction direction) {
+	auto weakSelf = weak_from_this();
 	PollService::Instance().add(
 	    mSock, {direction, direction == PollService::Direction::In ? mReadTimeout : nullopt,
-	            std::bind(&TcpTransport::process, this, _1)});
+	    [weakSelf](PollService::Event event) { if (auto self = weakSelf.lock()) { self->process(event); } } });
 }
 
 void TcpTransport::close() {

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -470,7 +470,7 @@ void TcpTransport::processConnect(PollService::Event event) {
 		PollService::Instance().remove(mSock);
 		ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
 	}
-};
+}
 
 } // namespace rtc::impl
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -228,44 +228,9 @@ void TcpTransport::attempt() {
 		return;
 	}
 
-	// Poll out event callback
-	auto callback = [this](PollService::Event event) {
-		try {
-			if (event == PollService::Event::Error)
-				throw std::runtime_error("TCP connection failed");
-
-			if (event == PollService::Event::Timeout)
-				throw std::runtime_error("TCP connection timed out");
-
-			if (event != PollService::Event::Out)
-				return;
-
-			int err = 0;
-			socklen_t errlen = sizeof(err);
-			if (::getsockopt(mSock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&err),
-			                 &errlen) != 0)
-				throw std::runtime_error("Failed to get socket error code");
-
-			if (err != 0) {
-				std::ostringstream msg;
-				msg << "TCP connection failed, errno=" << err;
-				throw std::runtime_error(msg.str());
-			}
-
-			// Success
-			PLOG_INFO << "TCP connected";
-			changeState(State::Connected);
-			setPoll(PollService::Direction::In);
-
-		} catch (const std::exception &e) {
-			PLOG_DEBUG << e.what();
-			PollService::Instance().remove(mSock);
-			ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
-		}
-	};
-
 	const auto timeout = 10s;
-	PollService::Instance().add(mSock, {PollService::Direction::Out, timeout, std::move(callback)});
+	PollService::Instance().add(mSock, {PollService::Direction::Out, timeout, 
+	    weak_bind(&TcpTransport::processConnect, this, _1)});
 }
 
 void TcpTransport::createSocket(const struct sockaddr *addr, socklen_t addrlen) {
@@ -327,7 +292,7 @@ void TcpTransport::setPoll(PollService::Direction direction) {
 	auto weakSelf = weak_from_this();
 	PollService::Instance().add(
 	    mSock, {direction, direction == PollService::Direction::In ? mReadTimeout : nullopt,
-	    [weakSelf](PollService::Event event) { if (auto self = weakSelf.lock()) { self->process(event); } } });
+	            weak_bind(&TcpTransport::process, this, _1)});
 }
 
 void TcpTransport::close() {
@@ -471,6 +436,41 @@ void TcpTransport::process(PollService::Event event) {
 	changeState(State::Disconnected);
 	recv(nullptr);
 }
+
+void TcpTransport::processConnect(PollService::Event event) {
+	try {
+		if (event == PollService::Event::Error)
+			throw std::runtime_error("TCP connection failed");
+
+		if (event == PollService::Event::Timeout)
+			throw std::runtime_error("TCP connection timed out");
+
+		if (event != PollService::Event::Out)
+			return;
+
+		int err = 0;
+		socklen_t errlen = sizeof(err);
+		if (::getsockopt(mSock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&err),
+						 &errlen) != 0)
+			throw std::runtime_error("Failed to get socket error code");
+
+		if (err != 0) {
+			std::ostringstream msg;
+			msg << "TCP connection failed, errno=" << err;
+			throw std::runtime_error(msg.str());
+		}
+
+		// Success
+		PLOG_INFO << "TCP connected";
+		changeState(State::Connected);
+		setPoll(PollService::Direction::In);
+
+	} catch (const std::exception &e) {
+		PLOG_DEBUG << e.what();
+		PollService::Instance().remove(mSock);
+		ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
+	}
+};
 
 } // namespace rtc::impl
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -289,7 +289,6 @@ void TcpTransport::configureSocket() {
 }
 
 void TcpTransport::setPoll(PollService::Direction direction) {
-	auto weakSelf = weak_from_this();
 	PollService::Instance().add(
 	    mSock, {direction, direction == PollService::Direction::In ? mReadTimeout : nullopt,
 	            weak_bind(&TcpTransport::process, this, _1)});

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -59,6 +59,7 @@ private:
 	void triggerBufferedAmount(size_t amount);
 
 	void process(PollService::Event event);
+	void processConnect(PollService::Event event);
 
 	const bool mIsActive;
 	string mHostname, mService;


### PR DESCRIPTION
Resolves paullouisageneau/libdatachannel#1375

Switches PollService::process to using a todo list for the callbacks so they can be called without mMutex locked.
Updates TcpTransport::setPoll to grab a weak pointer ahead of time.