### PR TITLE
call resetcallbacks only after triggerClosed

### DIFF
--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -108,9 +108,8 @@ void DataChannel::close() {
 			transport->closeStream(mStream.value());
 
 		triggerClosed();
-	}
-
-	resetCallbacks();
+		resetCallbacks();
+	}	
 }
 
 void DataChannel::remoteClose() { close(); }

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -69,10 +69,11 @@ void Track::close() {
 	PLOG_VERBOSE << "Closing Track";
 
 	if (!mIsClosed.exchange(true))
+	{
 		triggerClosed();
-
-	setMediaHandler(nullptr);
-	resetCallbacks();
+		setMediaHandler(nullptr);
+		resetCallbacks();
+	}		
 }
 
 message_variant Track::trackMessageToVariant(message_ptr message) {


### PR DESCRIPTION
Sometimes resetting close callback before calling it.
Related issue:
https://github.com/murat-dogan/node-datachannel/issues/349

I have modified this code part like this, in order to catch the race condition:
```
void DataChannel::close() {
	PLOG_ERROR << "Closing DataChannel";

	shared_ptr<SctpTransport> transport;
	{
		std::shared_lock lock(mMutex);
		transport = mSctpTransport.lock();
	}

	PLOG_ERROR << "mIsClosed: " << mIsClosed << " closedCallback: " << (bool)closedCallback;
	if (!mIsClosed.exchange(true)) {
		if (transport && mStream.has_value())
			transport->closeStream(mStream.value());

		triggerClosed();
	}

	PLOG_ERROR << "calling resetCallbacks";
	resetCallbacks();
}
```

This is a normal call, without race condition:
```
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@106] mIsClosed: 0 closedCallback: 1
2025-05-03 17:15:12.552 ERROR [1053375] [DataChannelWrapper::onClosed@364] onClosed cb received from rtc: c-0
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 0
2025-05-03 17:15:12.552 ERROR [1053375] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.552 ERROR [1053393] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.553 ERROR [1053393] [rtc::impl::DataChannel::close@106] mIsClosed: 0 closedCallback: 1
2025-05-03 17:15:12.553 ERROR [1053393] [DataChannelWrapper::onClosed@364] onClosed cb received from rtc: c-0
2025-05-03 17:15:12.553 ERROR [1053393] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 0
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 0
2025-05-03 17:15:12.553 ERROR [1053375] [rtc::impl::DataChannel::close@114] calling resetCallbacks
```

This is the output when a race condition occurs:
```
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@106] mIsClosed: 0 closedCallback: 1
2025-05-03 17:15:12.729 ERROR [1053398] [DataChannelWrapper::onClosed@364] onClosed cb received from rtc: c-0
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 0
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@114] calling resetCallbacks
// Thread 1053412 entering close function
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@98] Closing DataChannel
// mIsClosed is 0 and closedCallback set
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@106] mIsClosed: 0 closedCallback: 1
// Thread 1053398 entering close function
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@98] Closing DataChannel
// mIsClosed is 1 (set by 1053412) and closedCallback is still set
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 1
// Thread 1053398 resetting callbacks before 1053412 call
2025-05-03 17:15:12.729 ERROR [1053398] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@114] calling resetCallbacks
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@98] Closing DataChannel
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@106] mIsClosed: 1 closedCallback: 0
2025-05-03 17:15:12.729 ERROR [1053412] [rtc::impl::DataChannel::close@114] calling resetCallbacks

-- channels
{
  "incoming-c-0": "open"
}

There are 4 handle(s) keeping the process running.

# TTYWRAP
index.js:7 - process.stdout.write('.....\n.....\n');

# ThreadSafeCallback callback
/home/murat/js/node-datachannel/dist/esm/polyfill/RTCDataChannel.mjs:45    - __privateGet(this, _dataChannel).onClosed(() => {
/home/murat/js/node-datachannel/dist/esm/polyfill/RTCPeerConnection.mjs:92 - const dc = new RTCDataChannel(channel);
```

This solution is working. 
Another solution could be that,  we can guard this part of the code .