### PR TITLE
Fix socket not getting closed in TcpTransport

### DIFF
--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -206,7 +206,7 @@ void TcpTransport::attempt() {
 		if (state() != State::Connecting)
 			return; // Cancelled
 
-		if (mSock == INVALID_SOCKET) {
+		if (mSock != INVALID_SOCKET) {
 			::closesocket(mSock);
 			mSock = INVALID_SOCKET;
 		}


### PR DESCRIPTION
I was hunting a file descriptor leak in a program repeatedly attempting and failing the `connect()` on the websocket. I noticed that two sockets seemed to get created for each failure, but only one was closed.

It seems like the if-clause was wrong, because it's different in all the other places in the class.