### PR TITLE
Fix X509 certificate version with OpenSSL

### DIFF
--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -515,7 +515,7 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 
 	if (!X509_gmtime_adj(X509_getm_notBefore(x509.get()), 3600 * -1) ||
 	    !X509_gmtime_adj(X509_getm_notAfter(x509.get()), 3600 * 24 * 365) ||
-	    !X509_set_version(x509.get(), 1) || !BN_rand(serial_number.get(), serialSize, 0, 0) ||
+	    !X509_set_version(x509.get(), X509_VERSION_1) || !BN_rand(serial_number.get(), serialSize, 0, 0) ||
 	    !BN_to_ASN1_INTEGER(serial_number.get(), X509_get_serialNumber(x509.get())) ||
 	    !X509_NAME_add_entry_by_NID(name.get(), NID_commonName, MBSTRING_UTF8, commonNameBytes, -1,
 	                                -1, 0) ||


### PR DESCRIPTION
This PR fixes X509 certificate version set to an incorrect value with OpenSSL. It solves a compatibility issue with aiortc.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1404