### PR TITLE
ci: Install latest OpenSSL via chocolatey on Windows

### DIFF
--- a/.github/workflows/build-nomedia.yml
+++ b/.github/workflows/build-nomedia.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1
     - name: install packages
-      run: choco install openssl --version=3.1.1
+      run: choco install openssl
     - name: submodules
       run: git submodule update --init --recursive --depth 1
     - name: cmake

--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1
     - name: install packages
-      run: choco install openssl --version=3.1.1
+      run: choco install openssl
     - name: submodules
       run: git submodule update --init --recursive --depth 1
     - name: cmake


### PR DESCRIPTION
Windows workflows were pinned to **OpenSSL 3.1.1** on (Jan 18, 2024) via commit: https://github.com/paullouisageneau/libdatachannel/commit/d9260f0206544ce2eda862ab44b61f66033f9bd3 (due to issues?!)

* OpenSSL 3.1.1 is **EOL**
* Install latest OpenSSL via Chocolatey (Currently - OpenSSL 3.5.0 (LTS))