### PR TITLE
Adds fraction and packet lost calculation in RR packets

### DIFF
--- a/include/rtc/rtcpreceivingsession.hpp
+++ b/include/rtc/rtcpreceivingsession.hpp
@@ -19,6 +19,8 @@
 
 #include <atomic>
 
+#define RTP_SEQ_MOD (1<<16)
+
 namespace rtc {
 
 // An RtcpSession can be plugged into a Track to handle the whole RTCP session
@@ -40,8 +42,22 @@ protected:
 	void pushRR(const message_callback &send,unsigned int lastSrDelay);
 	void pushPLI(const message_callback &send);
 
+	void initSeq(uint16_t seq);
+	bool updateSeq(uint16_t seq);
+	
 	SSRC mSsrc = 0;
 	uint32_t mGreatestSeqNo = 0;
+    uint16_t mMaxSeq = 0;			// highest seq. number seen
+    uint32_t mCycles = 0;			// shifted count of seq. number cycles
+	uint32_t mBaseSeq = 0;			// base seq number
+    uint32_t mBadSeq = 0;			// last 'bad' seq number + 1
+	uint32_t mProbation = 0;		// sequ. packets till source is valid
+    uint32_t mReceived = 0;			// packets received
+    uint32_t mExpectedPrior = 0;	// packet expected at last interval
+    uint32_t mReceivedPrior = 0;	// packet received at last interval
+	uint32_t mTransit = 0;			// relative trans time for prev pkt
+	uint32_t mJitter = 0;	
+	
 	uint64_t mSyncRTPTS, mSyncNTPTS;
 
 	std::atomic<unsigned int> mRequestedBitrate = 0;

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -102,7 +102,7 @@ struct RTC_CPP_EXPORT RtcpReportBlock {
 	[[nodiscard]] uint8_t getFractionLost() const;
 	[[nodiscard]] unsigned int getPacketsLostCount() const;
 
-	void preparePacket(SSRC in_ssrc, unsigned int packetsLost, unsigned int totalPackets,
+	void preparePacket(SSRC in_ssrc, uint8_t fraction, unsigned int totalPacketsLost,
 	                   uint16_t highestSeqNo, uint16_t seqNoCycles, uint32_t jitter,
 	                   uint64_t lastSR_NTP, uint64_t lastSR_DELAY);
 	void setSSRC(SSRC in_ssrc);

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -59,6 +59,9 @@ void RtcpReceivingSession::incoming(message_vector &messages, const message_call
 			}
 
 			mSsrc = rtp->ssrc();
+
+			updateSeq(rtp->seqNumber());
+
 			result.push_back(std::move(message));
 			break;
 		}
@@ -110,7 +113,31 @@ void RtcpReceivingSession::pushRR(const message_callback &send, unsigned int las
 	auto message = make_message(RtcpRr::SizeWithReportBlocks(1), Message::Control);
 	auto rr = reinterpret_cast<RtcpRr *>(message->data());
 	rr->preparePacket(mSsrc, 1);
-	rr->getReportBlock(0)->preparePacket(mSsrc, 0, 0, uint16_t(mGreatestSeqNo), 0, 0, mSyncNTPTS,
+
+	// calculate packets lost, packet expected, fraction
+	auto extended_max = mCycles + mMaxSeq;
+    auto expected = extended_max - mBaseSeq + 1;
+	auto lost = 0;
+	if (mReceived > 0) {
+		lost = expected - mReceived;
+	} 
+
+	auto expected_interval = expected - mExpectedPrior;
+    mExpectedPrior = expected;
+    auto received_interval = mReceived - mReceivedPrior;
+    mReceivedPrior = mReceived;
+    auto lost_interval = expected_interval - received_interval;
+
+	uint8_t fraction;
+
+	if (expected_interval == 0 || lost_interval <= 0) {  
+		fraction = 0;
+	}	
+	else { 
+		fraction = (lost_interval << 8) / expected_interval;
+	}
+
+	rr->getReportBlock(0)->preparePacket(mSsrc, fraction, lost, uint16_t(mGreatestSeqNo), mMaxSeq, 0, mSyncNTPTS,
 	                                     lastSrDelay);
 	rr->log();
 	send(message);
@@ -126,6 +153,69 @@ void RtcpReceivingSession::pushPLI(const message_callback &send) {
 	auto *pli = reinterpret_cast<RtcpPli *>(message->data());
 	pli->preparePacket(mSsrc);
 	send(message);
+}
+
+void RtcpReceivingSession::initSeq(uint16_t seq) {
+	mBaseSeq = seq;
+	mMaxSeq = seq;
+	mBadSeq = RTP_SEQ_MOD + 1;   /* so seq == bad_seq is false */
+	mCycles = 0;
+	mReceived = 0;
+	mReceivedPrior = 0;
+	mExpectedPrior = 0;
+}
+
+bool RtcpReceivingSession::updateSeq(uint16_t seq) {
+	uint16_t udelta = seq - mMaxSeq;
+	const int MAX_DROPOUT = 3000;
+	const int MAX_MISORDER = 100;
+	const int MIN_SEQUENTIAL = 2;
+
+	/*
+	* Source is not valid until MIN_SEQUENTIAL packets with
+	* sequential sequence numbers have been received.
+	*/
+	if (mProbation) {
+		/* packet is in sequence */
+		if (seq == mMaxSeq + 1) {
+			mProbation--;
+			mMaxSeq = seq;
+			if (mProbation == 0) {
+				initSeq(seq);
+				mReceived++;
+				return true;
+			}
+		} else {
+			mProbation = MIN_SEQUENTIAL - 1;
+			mMaxSeq = seq;
+		}
+		return false;
+	} else if (udelta < MAX_DROPOUT) {
+		/* in order, with permissible gap */
+		if (seq < mMaxSeq) {
+			/*
+			* Sequence number wrapped - count another 64K cycle.
+			*/
+			mCycles += RTP_SEQ_MOD;
+		}
+		mMaxSeq = seq;
+	} else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER) {
+		/* the sequence number made a very large jump */
+		if (seq == mBadSeq) {
+			/*
+			* Two sequential packets -- assume that the other side
+			* restarted without telling us so just re-sync
+			* (i.e., pretend this was the first packet).
+			*/
+			initSeq(seq);
+		}
+		else {
+			mBadSeq = (seq + 1) & (RTP_SEQ_MOD-1);
+			return false;
+		}
+	}
+	mReceived++;
+	return true;
 }
 
 } // namespace rtc


### PR DESCRIPTION
This PR adds the calculation of the fraction lost and total packet lost values in RR packets. The calculation algorithm is based on the algorithm from the RFC3550 (see [Appendix A.1 RTP Data Header Validity Check](https://datatracker.ietf.org/doc/html/rfc3550#appendix-A.1)).