### PR TITLE
Feature: Allow custom headers to be passed via WebSocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,44 @@ ws.onMessage([](std::variant<rtc::binary, rtc::string> message) {
 ws.open("wss://my.websocket/service");
 ```
 
+### WebSocket with Custom Headers
+
+```cpp
+rtc::WebSocket ws;
+
+// Send custom headers during handshake
+std::map<std::string, std::string> headers = {
+    {"Authorization", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"},
+    {"X-API-Key", "my-secret-api-key"},
+    {"User-Agent", "MyApp/1.0"}
+};
+
+ws.open("wss://my.websocket/service", headers);
+```
+
+### WebSocket Server with Header Access
+
+```cpp
+rtc::WebSocketServer server(config);
+
+server.onClient([](std::shared_ptr<rtc::WebSocket> client) {
+    // Access request headers sent by the client
+    auto requestHeaders = client->requestHeaders();
+
+    for (const auto& [name, value] : requestHeaders) {
+        std::cout << name << ": " << value << std::endl;
+    }
+
+    // Check for specific headers
+    auto authIt = std::find_if(requestHeaders.begin(), requestHeaders.end(),
+        [](const auto& header) { return header.first == "authorization"; });
+
+    if (authIt != requestHeaders.end()) {
+        std::cout << "Client authenticated with: " << authIt->second << std::endl;
+    }
+});
+```
+
 ## Compatibility
 
 The library implements the following communication protocols:

--- a/include/rtc/channel.hpp
+++ b/include/rtc/channel.hpp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <functional>
+#include <map>
 
 namespace rtc {
 

--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -45,7 +45,7 @@ public:
 	bool isClosed() const override;
 	size_t maxMessageSize() const override;
 
-	void open(const string &url);
+	void open(const string &url, const std::map<string, string> &headers = {});
 	void close() override;
 	void forceClose();
 	bool send(const message_variant data) override;
@@ -53,6 +53,7 @@ public:
 
 	optional<string> remoteAddress() const;
 	optional<string> path() const;
+	std::multimap<string, string> requestHeaders() const;
 
 private:
 	using CheshireCat<impl::WebSocket>::impl;

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1089,7 +1089,7 @@ int rtcAddTrackEx(int pc, const rtcTrackInit *init) {
 		case RTC_CODEC_OPUS:
 		case RTC_CODEC_PCMU:
 		case RTC_CODEC_PCMA:
-		case RTC_CODEC_AAC: 
+		case RTC_CODEC_AAC:
 		case RTC_CODEC_G722: {
 			auto audio = std::make_unique<Description::Audio>(mid, direction);
 			switch (init->codec) {

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -68,7 +68,7 @@ WebSocket::WebSocket(optional<Configuration> optConfig, certificate_ptr certific
 
 WebSocket::~WebSocket() { PLOG_VERBOSE << "Destroying WebSocket"; }
 
-void WebSocket::open(const string &url) {
+void WebSocket::open(const string &url, const std::map<string, string> &headers) {
 	PLOG_VERBOSE << "Opening WebSocket to URL: " << url;
 
 	if (state != State::Closed)
@@ -126,7 +126,7 @@ void WebSocket::open(const string &url) {
 
 	mHostname = hostname; // for TLS SNI and Proxy
 	mService = service;   // For proxy
-	std::atomic_store(&mWsHandshake, std::make_shared<WsHandshake>(host, path, config.protocols));
+	std::atomic_store(&mWsHandshake, std::make_shared<WsHandshake>(host, path, config.protocols, headers));
 
 	changeState(State::Connecting);
 

--- a/src/impl/websocket.hpp
+++ b/src/impl/websocket.hpp
@@ -35,7 +35,7 @@ struct WebSocket final : public Channel, public std::enable_shared_from_this<Web
 	WebSocket(optional<Configuration> optConfig = nullopt, certificate_ptr certificate = nullptr);
 	~WebSocket();
 
-	void open(const string &url);
+	void open(const string &url, const std::map<string, string> &headers = {});
 	void close();
 	void remoteClose();
 	bool outgoing(message_ptr message);

--- a/src/impl/wshandshake.hpp
+++ b/src/impl/wshandshake.hpp
@@ -23,11 +23,12 @@ namespace rtc::impl {
 class WsHandshake final {
 public:
 	WsHandshake();
-	WsHandshake(string host, string path = "/", std::vector<string> protocols = {});
+	WsHandshake(string host, string path = "/", std::vector<string> protocols = {}, std::map<string, string> headers = {});
 
 	string host() const;
 	string path() const;
 	std::vector<string> protocols() const;
+	std::multimap<string, string> requestHeaders() const;
 
 	string generateHttpRequest();
 	string generateHttpResponse();
@@ -57,6 +58,8 @@ private:
 	string mHost;
 	string mPath;
 	std::vector<string> mProtocols;
+	std::map<string, string> mCustomHeaders;
+	std::multimap<string, string> mRequestHeaders;
 	string mKey;
 	mutable std::mutex mMutex;
 };

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -43,7 +43,9 @@ bool WebSocket::isClosed() const { return impl()->state.load() == State::Closed;
 
 size_t WebSocket::maxMessageSize() const { return impl()->maxMessageSize(); }
 
-void WebSocket::open(const string &url) { impl()->open(url); }
+void WebSocket::open(const string &url, const std::map<string, string> &headers) {
+	impl()->open(url, headers);
+}
 
 void WebSocket::close() { impl()->close(); }
 
@@ -66,6 +68,12 @@ optional<string> WebSocket::path() const {
 	auto state = impl()->state.load();
 	auto handshake = impl()->getWsHandshake();
 	return state != State::Connecting && handshake ? make_optional(handshake->path()) : nullopt;
+}
+
+std::multimap<string, string> WebSocket::requestHeaders() const {
+	auto state = impl()->state.load();
+	auto handshake = impl()->getWsHandshake();
+	return state != State::Connecting && handshake ? handshake->requestHeaders() : std::multimap<string, string>{};
 }
 
 std::ostream &operator<<(std::ostream &out, WebSocket::State state) {


### PR DESCRIPTION
Implement functionality to send and access custom headers during WebSocket handshake and server communication. This enhancement improves authentication and client-server interactions.

Closes: #1342

To Do:
- [x] Update readme with new examples
- [x] Update websocket api to allow optional headers
- [x] Update websocket server to be able to handle headers
  - [x] Implement way to get the headers
- [x] Update Tests
- [ ] Update c-api (Can you please help implement this, not sure what would be best here, for the new functions / names)