### PR TITLE
Improve testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ compile_commands.json
 /tests
 .DS_Store
 .idea
-
+# clangd cache
+.cache

--- a/test/capi_connectivity.cpp
+++ b/test/capi_connectivity.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#include "test.hpp"
 #include <rtc/rtc.h>
 
 #include <cstdio>
@@ -392,7 +393,8 @@ error:
 
 #include <stdexcept>
 
-void test_capi_connectivity() {
+TestResult *test_capi_connectivity() {
 	if (test_capi_connectivity_main())
-		throw std::runtime_error("Connection failed");
+		return new TestResult(false, "Connection failed");
+	return new TestResult(true);
 }

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#include "test.hpp"
 #include <rtc/rtc.h>
 
 #include <cstdio>
@@ -238,7 +239,8 @@ error:
 
 #include <stdexcept>
 
-void test_capi_track() {
+TestResult *test_capi_track() {
 	if (test_capi_track_main())
-		throw std::runtime_error("Connection failed");
+		return new TestResult(false, "Connection failed");
+	return new TestResult(true);
 }

--- a/test/capi_websocketserver.cpp
+++ b/test/capi_websocketserver.cpp
@@ -6,6 +6,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#include "test.hpp"
 #include <rtc/rtc.h>
 
 #if RTC_ENABLE_WEBSOCKET
@@ -164,9 +165,10 @@ error:
 
 #include <stdexcept>
 
-void test_capi_websocketserver() {
+TestResult *test_capi_websocketserver() {
 	if (test_capi_websocketserver_main())
-		throw std::runtime_error("WebSocketServer test failed");
+		return new TestResult(false, "WebSocketServer test failed");
+	return new TestResult(true);
 }
 
 #endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -10,22 +10,29 @@
 #include <iostream>
 #include <thread>
 
+#include "test.hpp"
 #include <rtc/rtc.hpp>
 
 using namespace std;
 using namespace chrono_literals;
 
-void test_connectivity(bool signal_wrong_fingerprint);
-void test_pem();
-void test_negotiated();
-void test_reliability();
-void test_turn_connectivity();
-void test_track();
-void test_capi_connectivity();
-void test_capi_track();
-void test_websocket();
-void test_websocketserver();
-void test_capi_websocketserver();
+using chrono::duration_cast;
+using chrono::milliseconds;
+using chrono::seconds;
+using chrono::steady_clock;
+
+TestResult *test_connectivity();
+TestResult *test_connectivity_fail_on_wrong_fingerprint();
+TestResult *test_pem();
+TestResult *test_negotiated();
+TestResult *test_reliability();
+TestResult *test_turn_connectivity();
+TestResult *test_track();
+TestResult *test_capi_connectivity();
+TestResult *test_capi_track();
+TestResult *test_websocket();
+TestResult *test_websocketserver();
+TestResult *test_capi_websocketserver();
 size_t benchmark(chrono::milliseconds duration);
 
 void test_benchmark() {
@@ -39,149 +46,89 @@ void test_benchmark() {
 		throw runtime_error("Goodput is too low");
 }
 
-int main(int argc, char **argv) {
-	// C++ API tests
-	try {
-		cout << endl << "*** Running WebRTC connectivity test..." << endl;
-		test_connectivity(false);
-		cout << "*** Finished WebRTC connectivity test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC connectivity test failed: " << e.what() << endl;
-		return -1;
-	}
-	try {
-		cout << endl << "*** Running WebRTC broken fingerprint test..." << endl;
-		test_connectivity(true);
-		cerr << "WebRTC connectivity test failed to detect broken fingerprint" << endl;
-		return -1;
-	} catch (const exception &) {
-	}
-
-	try {
-		cout << endl << "*** Running pem test..." << endl;
-		test_pem();
-	} catch (const exception &e) {
-		cerr << "pem test failed: " << e.what() << endl;
-		return -1;
-	}
-
-// TODO: Temporarily disabled as the Open Relay TURN server is unreliable
-/*
-	try {
-		cout << endl << "*** Running WebRTC TURN connectivity test..." << endl;
-		test_turn_connectivity();
-		cout << "*** Finished WebRTC TURN connectivity test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC TURN connectivity test failed: " << e.what() << endl;
-		return -1;
-	}
-*/
-	try {
-		cout << endl << "*** Running WebRTC negotiated DataChannel test..." << endl;
-		test_negotiated();
-		cout << "*** Finished WebRTC negotiated DataChannel test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC negotiated DataChannel test failed: " << e.what() << endl;
-		return -1;
-	}
-	try {
-		cout << endl << "*** Running WebRTC reliability mode test..." << endl;
-		test_reliability();
-		cout << "*** Finished WebRTC reliaility mode test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC reliability test failed: " << e.what() << endl;
-		return -1;
-	}
-#if RTC_ENABLE_MEDIA
-	try {
-		cout << endl << "*** Running WebRTC Track test..." << endl;
-		test_track();
-		cout << "*** Finished WebRTC Track test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC Track test failed: " << e.what() << endl;
-		return -1;
-	}
-#endif
-#if RTC_ENABLE_WEBSOCKET
-// TODO: Temporarily disabled as the echo service is unreliable
-/*
-	try {
-		cout << endl << "*** Running WebSocket test..." << endl;
-		test_websocket();
-		cout << "*** Finished WebSocket test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebSocket test failed: " << e.what() << endl;
-		return -1;
-	}
-*/
-	try {
-		cout << endl << "*** Running WebSocketServer test..." << endl;
-		test_websocketserver();
-		cout << "*** Finished WebSocketServer test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebSocketServer test failed: " << e.what() << endl;
-		return -1;
-	}
-#endif
+TestResult *testCppCleanup() {
 	try {
 		// Every created object must have been destroyed, otherwise the wait will block
-		cout << endl << "*** Running cleanup..." << endl;
-		if(rtc::Cleanup().wait_for(10s) == future_status::timeout)
-			throw std::runtime_error("Timeout");
-		cout << "*** Finished cleanup..." << endl;
+		if (rtc::Cleanup().wait_for(10s) == future_status::timeout)
+			return new TestResult(false, "timeout");
+		return new TestResult(true);
 	} catch (const exception &e) {
-		cerr << "Cleanup failed: " << e.what() << endl;
-		return -1;
+		return new TestResult(false, e.what());
 	}
+}
 
-	// C API tests
+TestResult *testCCleanup() {
 	try {
-		cout << endl << "*** Running WebRTC C API connectivity test..." << endl;
-		test_capi_connectivity();
-		cout << "*** Finished WebRTC C API connectivity test" << endl;
+		rtcCleanup();
+		return new TestResult(true);
 	} catch (const exception &e) {
-		cerr << "WebRTC C API connectivity test failed: " << e.what() << endl;
-		return -1;
+		return new TestResult(false, e.what());
 	}
+}
+
+static const auto tests = {
+    // C++ API tests
+    new Test("WebRTC connectivity", test_connectivity),
+    new Test("WebRTC broken fingerprint", test_connectivity_fail_on_wrong_fingerprint),
+    new Test("pem", test_pem),
+    // TODO: Temporarily disabled as the Open Relay TURN server is unreliable
+    // new Test("WebRTC TURN connectivity", test_turn_connectivity),
+    new Test("WebRTC negotiated DataChannel", test_negotiated),
+    new Test("WebRTC reliability mode", test_reliability),
 #if RTC_ENABLE_MEDIA
-	try {
-		cout << endl << "*** Running WebRTC C API track test..." << endl;
-		test_capi_track();
-		cout << "*** Finished WebRTC C API track test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC C API track test failed: " << e.what() << endl;
-		return -1;
-	}
+    new Test("WebRTC track", test_track),
 #endif
 #if RTC_ENABLE_WEBSOCKET
-	try {
-		cout << endl << "*** Running WebSocketServer C API test..." << endl;
-		test_capi_websocketserver();
-		cout << "*** Finished WebSocketServer C API test" << endl;
-	} catch (const exception &e) {
-		cerr << "WebSocketServer C API test failed: " << e.what() << endl;
-		return -1;
-	}
+    // TODO: Temporarily disabled as the echo service is unreliable
+    // new Test("WebSocket", test_websocket),
+    new Test("WebSocketServer", test_websocketserver),
 #endif
-	try {
-		cout << endl << "*** Running C API cleanup..." << endl;
-		rtcCleanup();
-		cout << "*** Finished C API cleanup..." << endl;
-	} catch (const exception &e) {
-		cerr << "C API cleanup failed: " << e.what() << endl;
-		return -1;
+    new Test("WebRTC Cpp API cleanup", testCppCleanup),
+    // C API tests
+    new Test("WebRTC C API connectivity", test_capi_connectivity),
+#if RTC_ENABLE_MEDIA
+    new Test("WebRTC C API track", test_capi_track),
+#endif
+#if RTC_ENABLE_WEBSOCKET
+    new Test("WebSocketServer C API", test_capi_websocketserver),
+#endif
+    new Test("WebRTC C API cleanup", testCCleanup),
+};
+
+int main(int argc, char **argv) {
+	int success_tests = 0;
+	int failed_tests = 0;
+	steady_clock::time_point startTime, endTime;
+
+	startTime = steady_clock::now();
+
+	for (auto test : tests) {
+		auto res = test->run();
+		if (res->success) {
+			success_tests++;
+		} else {
+			failed_tests++;
+		}
 	}
-/*
-	// Benchmark
-	try {
-		cout << endl << "*** Running WebRTC benchmark..." << endl;
-		test_benchmark();
-		cout << "*** Finished WebRTC benchmark" << endl;
-	} catch (const exception &e) {
-		cerr << "WebRTC benchmark failed: " << e.what() << endl;
-		std::this_thread::sleep_for(2s);
-		return -1;
-	}
-*/
+
+	endTime = steady_clock::now();
+
+	auto durationMs = duration_cast<milliseconds>(endTime - startTime);
+	auto durationS = duration_cast<seconds>(endTime - startTime);
+	cout << "Finished " << success_tests + failed_tests << " tests in " << durationS.count()
+	     << "s (" << durationMs.count() << " ms). Succeeded: " << success_tests
+	     << ". Failed: " << failed_tests << "." << endl;
+	/*
+	    // Benchmark
+	    try {
+	        cout << endl << "*** Running WebRTC benchmark..." << endl;
+	        test_benchmark();
+	        cout << "*** Finished WebRTC benchmark" << endl;
+	    } catch (const exception &e) {
+	        cerr << "WebRTC benchmark failed: " << e.what() << endl;
+	        std::this_thread::sleep_for(2s);
+	        return -1;
+	    }
+	*/
 	return 0;
 }

--- a/test/negotiated.cpp
+++ b/test/negotiated.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rtc/rtc.hpp"
+#include "test.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -17,7 +18,7 @@
 using namespace rtc;
 using namespace std;
 
-void test_negotiated() {
+TestResult *test_negotiated() {
 	InitLogger(LogLevel::Debug);
 
 	Configuration config1;
@@ -66,10 +67,10 @@ void test_negotiated() {
 
 	if (pc1.state() != PeerConnection::State::Connected ||
 	    pc2.state() != PeerConnection::State::Connected)
-		throw runtime_error("PeerConnection is not connected");
+		return new TestResult(false, "PeerConnection is not connected");
 
 	if (!negotiated1->isOpen() || !negotiated2->isOpen())
-		throw runtime_error("Negotiated DataChannel is not open");
+		return new TestResult(false, "Negotiated DataChannel is not open");
 
 	std::atomic<bool> received = false;
 	negotiated2->onMessage([&received](const variant<binary, string> &message) {
@@ -87,7 +88,7 @@ void test_negotiated() {
 		this_thread::sleep_for(1s);
 
 	if (!received)
-		throw runtime_error("Negotiated DataChannel failed");
+		return new TestResult(false, "Negotiated DataChannel failed");
 
 	// Delay close of peer 2 to check closing works properly
 	pc1.close();
@@ -95,5 +96,5 @@ void test_negotiated() {
 	pc2.close();
 	this_thread::sleep_for(1s);
 
-	cout << "Success" << endl;
+	return new TestResult(true);
 }

--- a/test/reliability.cpp
+++ b/test/reliability.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rtc/rtc.hpp"
+#include "test.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -17,7 +18,7 @@
 using namespace rtc;
 using namespace std;
 
-void test_reliability() {
+TestResult *test_reliability() {
 	InitLogger(LogLevel::Debug);
 
 	Configuration config1;
@@ -114,15 +115,15 @@ void test_reliability() {
 
 	if (pc1.state() != PeerConnection::State::Connected ||
 	    pc2.state() != PeerConnection::State::Connected)
-		throw runtime_error("PeerConnection is not connected");
+		return new TestResult(false, "PeerConnection is not connected");
 
 	if (failed)
-		throw runtime_error("Incorrect reliability settings");
+		return new TestResult(false, "Incorrect reliability settings");
 
 	if (count != 4)
-		throw runtime_error("Some DataChannels are not open");
+		return new TestResult(false, "Some DataChannels are not open");
 
 	pc1.close();
 
-	cout << "Success" << endl;
+	return new TestResult(true);
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -1,0 +1,32 @@
+#include <functional>
+#include <iostream>
+
+using namespace std;
+
+class TestResult {
+public:
+	bool success;
+	string err_reason;
+
+	TestResult(bool success, string err_reason = "") : success(success), err_reason(err_reason) {}
+};
+
+class Test {
+public:
+	string name;
+	function<TestResult *(void)> f;
+
+	Test(string name, std::function<TestResult *(void)> testFunc) : name(name), f(testFunc) {}
+
+	TestResult *run() {
+		cout << endl << "*** Running " << name << " test" << endl;
+		TestResult *res = this->f();
+		if (res->success) {
+			cout << "*** Finished " << name << " test" << endl;
+		} else {
+			cerr << name << " test failed. Reason: " << res->err_reason << endl;
+		}
+
+		return res;
+	}
+};

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rtc/rtc.hpp"
+#include "test.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -19,7 +20,7 @@ using namespace std;
 
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
-void test_track() {
+TestResult *test_track() {
 	InitLogger(LogLevel::Debug);
 
 	Configuration config1;
@@ -99,7 +100,7 @@ void test_track() {
 	const auto mediaSdp2 = string(Description::Media(mediaSdp1));
 	if (mediaSdp2 != mediaSdp1) {
 		cout << mediaSdp2 << endl;
-		throw runtime_error("Media description parsing test failed");
+		return new TestResult(false, "Media description parsing test failed");
 	}
 
 	auto t1 = pc1.addTrack(media);
@@ -113,10 +114,10 @@ void test_track() {
 
 	if (pc1.state() != PeerConnection::State::Connected ||
 	    pc2.state() != PeerConnection::State::Connected)
-		throw runtime_error("PeerConnection is not connected");
+		return new TestResult(false, "PeerConnection is not connected");
 
 	if (!at2 || !at2->isOpen() || !t1->isOpen())
-		throw runtime_error("Track is not open");
+		return new TestResult(false, "Track is not open");
 
 	// Test renegotiation
 	newTrackMid = "added";
@@ -138,7 +139,7 @@ void test_track() {
 		this_thread::sleep_for(1s);
 
 	if (!at2 || !at2->isOpen() || !t1->isOpen())
-		throw runtime_error("Renegotiated track is not open");
+		return new TestResult(false, "Renegotiated track is not open");
 
 	// TODO: Test sending RTP packets in track
 
@@ -149,7 +150,7 @@ void test_track() {
 	this_thread::sleep_for(1s);
 
 	if (!t1->isClosed() || !t2->isClosed())
-		throw runtime_error("Track is not closed");
+		return new TestResult(false, "Track is not closed");
 
-	cout << "Success" << endl;
+	return new TestResult(true);
 }

--- a/test/websocket.cpp
+++ b/test/websocket.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rtc/rtc.hpp"
+#include "test.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -21,7 +22,7 @@ using namespace std;
 
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
-void test_websocket() {
+TestResult *test_websocket() {
 	InitLogger(LogLevel::Debug);
 
 	const string myMessage = "Hello world from libdatachannel";
@@ -57,15 +58,15 @@ void test_websocket() {
 		this_thread::sleep_for(1s);
 
 	if (!ws.isOpen())
-		throw runtime_error("WebSocket is not open");
+		return new TestResult(false, "WebSocket is not open");
 
 	if (!received)
-		throw runtime_error("Expected message not received");
+		return new TestResult(false, "Expected message not received");
 
 	ws.close();
 	this_thread::sleep_for(1s);
 
-	cout << "Success" << endl;
+	return new TestResult(true);
 }
 
 #endif

--- a/test/websocketserver.cpp
+++ b/test/websocketserver.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "rtc/rtc.hpp"
+#include "test.hpp"
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -21,7 +22,7 @@ using namespace std;
 
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
-void test_websocketserver() {
+TestResult *test_websocketserver() {
 	InitLogger(LogLevel::Debug);
 
 	WebSocketServer::Configuration serverConfig;
@@ -38,22 +39,20 @@ void test_websocketserver() {
 		cout << "WebSocketServer: Client connection received" << endl;
 		client = incoming;
 
-		if(auto addr = client->remoteAddress())
+		if (auto addr = client->remoteAddress())
 			cout << "WebSocketServer: Client remote address is " << *addr << endl;
 
 		client->onOpen([wclient = make_weak_ptr(client)]() {
 			cout << "WebSocketServer: Client connection open" << endl;
-			if(auto client = wclient.lock())
-				if(auto path = client->path())
+			if (auto client = wclient.lock())
+				if (auto path = client->path())
 					cout << "WebSocketServer: Requested path is " << *path << endl;
 		});
 
-		client->onClosed([]() {
-			cout << "WebSocketServer: Client connection closed" << endl;
-		});
+		client->onClosed([]() { cout << "WebSocketServer: Client connection closed" << endl; });
 
 		client->onMessage([wclient = make_weak_ptr(client)](variant<binary, string> message) {
-			if(auto client = wclient.lock())
+			if (auto client = wclient.lock())
 				client->send(std::move(message));
 		});
 	});
@@ -81,8 +80,7 @@ void test_websocketserver() {
 				cout << "WebSocket: Received expected message" << endl;
 			else
 				cout << "WebSocket: Received UNEXPECTED message" << endl;
-		}
-		else {
+		} else {
 			binary bin = std::move(get<binary>(message));
 			if ((maxSizeReceived = (bin.size() == 1000)))
 				cout << "WebSocket: Received large message truncated at max size" << endl;
@@ -98,10 +96,10 @@ void test_websocketserver() {
 		this_thread::sleep_for(1s);
 
 	if (!ws.isOpen())
-		throw runtime_error("WebSocket is not open");
+		return new TestResult(false, "WebSocket is not open");
 
 	if (!received || !maxSizeReceived)
-		throw runtime_error("Expected messages not received");
+		return new TestResult(false, "Expected messages not received");
 
 	ws.close();
 	this_thread::sleep_for(1s);
@@ -109,7 +107,7 @@ void test_websocketserver() {
 	server.stop();
 	this_thread::sleep_for(1s);
 
-	cout << "Success" << endl;
+	return new TestResult(true);
 }
 
 #endif


### PR DESCRIPTION
This PR adds a tiny abstraction for creating and executing tests. 

It adds a new `Test` class that takes a test name and a test function as arguments for its constructor.  `Test` instance can then be run with `run` method. 

This way we can:
* add new tests and remove old ones by just modify global tests array. We no longer need to copy/paste try/catch blocks
* count (un)successful tests 
* avoid halting tests execution when one of them fails
* make tests execution concurrent in the future

At the end, there is a short summary printed:

```
Finished 12 tests in 38s (38079 ms). Succeeded: 12. Failed: 0.
```

Possible next steps:
* make tests execution concurrent
* allow for logger configuration

