### PR TITLE
Fix useless wait in SctpTransport::sendReset()

### DIFF
--- a/.github/workflows/build-nomedia.yml
+++ b/.github/workflows/build-nomedia.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1
     - name: install packages
-      run: choco install openssl
+      run: choco install openssl --version=3.5.2
     - name: submodules
       run: git submodule update --init --recursive --depth 1
     - name: cmake

--- a/.github/workflows/build-openssl.yml
+++ b/.github/workflows/build-openssl.yml
@@ -41,7 +41,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ilammy/msvc-dev-cmd@v1
     - name: install packages
-      run: choco install openssl
+      run: choco install openssl --version=3.5.2
     - name: submodules
       run: git submodule update --init --recursive --depth 1
     - name: cmake


### PR DESCRIPTION
This PR removes waiting on the write condition variable in `SctpTransport::sendReset()`.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1437