### PR TITLE
Added color space extension support

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -352,6 +352,14 @@ typedef struct {
 	uint8_t playoutDelayId;
 	uint16_t playoutDelayMin;
 	uint16_t playoutDelayMax;
+
+	uint8_t colorSpaceId;
+	uint8_t colorChromaSitingHorz;
+	uint8_t colorChromaSitingVert;
+	uint8_t colorRange;
+	uint8_t colorPrimaries;
+	uint8_t colorTransfer;
+	uint8_t colorMatrix;
 } rtcPacketizerInit;
 
 // Deprecated, do not use

--- a/include/rtc/rtppacketizationconfig.hpp
+++ b/include/rtc/rtppacketizationconfig.hpp
@@ -74,6 +74,15 @@ public:
 	uint16_t playoutDelayMin = 0;
 	uint16_t playoutDelayMax = 0;
 
+	// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/color-space/
+	uint8_t colorSpaceId = 0;               // the negotiated ID of color space header extension
+	uint8_t colorChromaSitingHorz = 0;      // unspecified
+	uint8_t colorChromaSitingVert = 0;      // unspecified
+	uint8_t colorRange = 2;                 // full range
+	uint8_t colorPrimaries = 1;             // BT.709-6
+	uint8_t colorTransfer = 1;              // BT.709-6
+	uint8_t colorMatrix = 1;                // BT.709-6
+
 	/// Construct RTP configuration used in packetization process
 	/// @param ssrc SSRC of source
 	/// @param cname CNAME of source

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -278,6 +278,13 @@ createRtpPacketizationConfig(const rtcPacketizationHandlerInit *init) {
 	config->playoutDelayId = init->playoutDelayId;
 	config->playoutDelayMin = init->playoutDelayMin;
 	config->playoutDelayMax = init->playoutDelayMax;
+	config->colorSpaceId = init->colorSpaceId;
+	config->colorChromaSitingHorz = init->colorChromaSitingHorz;
+	config->colorChromaSitingVert = init->colorChromaSitingVert;
+	config->colorRange = init->colorRange;
+	config->colorPrimaries = init->colorPrimaries;
+	config->colorTransfer = init->colorTransfer;
+	config->colorMatrix = init->colorMatrix;
 	return config;
 }
 

--- a/src/rtppacketizer.cpp
+++ b/src/rtppacketizer.cpp
@@ -57,10 +57,14 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 		rtpExtHeaderSize += headerSize + 1;
 
 	const bool setPlayoutDelay = rtpConfig->playoutDelayId > 0;
+	const bool setColorSpace = rtpConfig->colorSpaceId > 0;
 
 	if (setPlayoutDelay)
 		rtpExtHeaderSize += headerSize + 3;
 
+	if (setColorSpace)
+		rtpExtHeaderSize += headerSize + 4;
+	
 	if (rtpConfig->mid.has_value())
 		rtpExtHeaderSize += headerSize + rtpConfig->mid->length();
 
@@ -138,6 +142,16 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 
 			offset += extHeader->writeHeader(
 			    twoByteHeader, offset, rtpConfig->playoutDelayId, data, 3);
+		}
+
+		if (setColorSpace) {
+			uint8_t range_chr = (rtpConfig->colorRange << 4) + (rtpConfig->colorChromaSitingHorz << 2) + rtpConfig->colorChromaSitingVert;
+
+			byte data[] = {byte(rtpConfig->colorPrimaries), byte(rtpConfig->colorTransfer),
+			               byte(rtpConfig->colorMatrix), byte(range_chr)};
+
+			offset += extHeader->writeHeader(
+			    twoByteHeader, offset, rtpConfig->playoutDelayId, data, 4);
 		}
 	}
 


### PR DESCRIPTION
Hello!

I had been using your codes well but I had a problem with handling h.264 video color. The color of decoded video was not the same as the original video. So I searched a lot to fix this problem and finally I found this.
https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/color-space/
I implemented codes based on the doc and the color issue was resolved! Since my video has no HDR metadata, I made **only** the RTP extension header without HDR metadata.

I think other people would need this color related feature so please review this PR.