### PR TITLE
Fix missing SSRC cache update breaking RTCP feedback handling

### DIFF
--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1042,6 +1042,9 @@ void PeerConnection::processLocalDescription(Description description) {
 	if (description.mediaCount() == 0)
 		throw std::logic_error("Local description has no media line");
 
+	// Update the SSRC cache
+	updateTrackSsrcCache(description);
+
 	{
 		// Set as local description
 		std::lock_guard lock(mLocalDescriptionMutex);


### PR DESCRIPTION
This PR fixes a missing SSRC cache update which breaks RTCP feedback handling on Chrome, in particular NACK and PLI. The issue was introduced by https://github.com/paullouisageneau/libdatachannel/pull/1320 in v0.23.0.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1442