### PR TITLE
Fix consent-freshness property handling for compatibility with older libnice versions

### DIFF
--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -451,7 +451,8 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	// has been deprecated in this specification.
 	// libnice defaults to aggressive nomation therefore we change to regular nomination.
 	// See https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/125
-	NiceAgentOption flags = NICE_AGENT_OPTION_REGULAR_NOMINATION;
+	// Enable RFC 7675 ICE consent freshness support (requires libnice 0.1.19)
+	NiceAgentOption flags = static_cast<NiceAgentOption>(NICE_AGENT_OPTION_REGULAR_NOMINATION | NICE_AGENT_OPTION_CONSENT_FRESHNESS);
 
 	// Create agent
 	mNiceAgent = decltype(mNiceAgent)(
@@ -481,10 +482,7 @@ IceTransport::IceTransport(const Configuration &config, candidate_callback candi
 	// the characteristics of the associated data.
 	g_object_set(G_OBJECT(mNiceAgent.get()), "stun-pacing-timer", 25, nullptr);
 
-	// Enable RFC 7675 ICE consent freshness support (requires libnice 0.1.19)
 	g_object_set(G_OBJECT(mNiceAgent.get()), "keepalive-conncheck", TRUE, nullptr);
-	g_object_set(G_OBJECT(mNiceAgent.get()), "consent-freshness", TRUE, nullptr);
-
 	g_object_set(G_OBJECT(mNiceAgent.get()), "upnp", FALSE, nullptr);
 	g_object_set(G_OBJECT(mNiceAgent.get()), "upnp-timeout", 200, nullptr);
 


### PR DESCRIPTION
This PR fixes the issue where the consent-freshness property was being set after NiceAgent construction, which caused the following warning in versions prior to commit [4c4a167240bec4dd2552f9c25e3773383ae9703b](https://gitlab.freedesktop.org/libnice/libnice/-/commit/4c4a167240bec4dd2552f9c25e3773383ae9703b):
```
GLib-GObject-CRITICAL **: g_object_set_is_valid_property: construct property "consent-freshness" for object 'NiceAgent' can't be set after construction
```
In versions prior to commit [4c4a167240bec4dd2552f9c25e3773383ae9703b](https://gitlab.freedesktop.org/libnice/libnice/-/commit/4c4a167240bec4dd2552f9c25e3773383ae9703b), the consent-freshness property was defined as construct-only, as specified by the G_PARAM_CONSTRUCT_ONLY flag in the following code:
```
g_object_class_install_property (gobject_class, PROP_CONSENT_FRESHNESS,
   g_param_spec_boolean (
     "consent-freshness",
     "Consent Freshness",
     "Whether to perform the consent freshness checks as specified in RFC 7675",
     FALSE,
     G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
```
To ensure compatibility with older versions of libnice, the consent-freshness property is now correctly set during the construction of the NiceAgent object. This resolves the warning and ensures proper handling of the consent-freshness property while maintaining backward compatibility.