### PR TITLE
Add NO_WEBRTC CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,18 @@ option(USE_SYSTEM_PLOG "Use system Plog" ${PREFER_SYSTEM_LIB})
 option(USE_SYSTEM_JSON "Use system Nlohmann JSON" ${PREFER_SYSTEM_LIB})
 option(NO_WEBSOCKET "Disable WebSocket support" OFF)
 option(NO_MEDIA "Disable media transport support" OFF)
+option(NO_WEBRTC "Disable WebRTC support" OFF)
 option(NO_EXAMPLES "Disable examples" OFF)
 option(NO_TESTS "Disable tests build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 option(SCTP_DEBUG "Enable SCTP debugging output to verbose log" OFF)
 option(RTC_UPDATE_VERSION_HEADER "Enable updating the version header" OFF)
+
+if(NO_WEBRTC)
+	message(STATUS "libdatachannel: Setting NO_MEDIA option due to NO_WEBRTC option")
+    set(NO_MEDIA ON CACHE BOOL "Disable media transport support" FORCE)
+endif()
 
 if(NOT NO_MEDIA AND NOT PREFER_SYSTEM_LIB)
 	# libsrtp2 v2.7.0 requires cmake >= v3.21.0
@@ -213,18 +219,21 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 
 set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/track.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/capi_connectivity.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/capi_track.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/websocket.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/websocketserver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/capi_websocketserver.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/benchmark.cpp
 )
+if(NOT NO_WEBRTC)
+	list(APPEND TESTS_SOURCES
+    	${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
+    	${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
+    	${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test/track.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test/capi_connectivity.cpp
+		${CMAKE_CURRENT_SOURCE_DIR}/test/capi_track.cpp
+    	${CMAKE_CURRENT_SOURCE_DIR}/test/benchmark.cpp)
+endif()
 
 set(TESTS_HEADERS 
 	${CMAKE_CURRENT_SOURCE_DIR}/test/test.hpp
@@ -311,28 +320,35 @@ if(SCTP_DEBUG)
 	add_definitions(-DSCTP_DEBUG)
 endif()
 
-if(USE_SYSTEM_USRSCTP)
-	find_package(Usrsctp REQUIRED)
+if(NO_WEBRTC)
+	target_compile_definitions(datachannel PUBLIC RTC_ENABLE_WEBRTC=0)
+	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_WEBRTC=0)
 else()
-	option(sctp_build_shared_lib OFF)
-	option(sctp_build_programs OFF)
-	option(sctp_inet OFF)
-	option(sctp_inet6 OFF)
-	option(sctp_werror OFF)
-	set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-	add_subdirectory(deps/usrsctp EXCLUDE_FROM_ALL)
-	if (MSYS OR MINGW)
-		target_compile_definitions(usrsctp PUBLIC -DSCTP_STDINT_INCLUDE=<stdint.h>)
-	endif()
-	add_library(Usrsctp::Usrsctp ALIAS usrsctp)
+	target_compile_definitions(datachannel PUBLIC RTC_ENABLE_WEBRTC=1)
+	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_WEBRTC=1)
+	if(USE_SYSTEM_USRSCTP)
+		find_package(Usrsctp REQUIRED)
+	else()
+		option(sctp_build_shared_lib OFF)
+		option(sctp_build_programs OFF)
+		option(sctp_inet OFF)
+		option(sctp_inet6 OFF)
+		option(sctp_werror OFF)
+		set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
+		add_subdirectory(deps/usrsctp EXCLUDE_FROM_ALL)
+		if (MSYS OR MINGW)
+			target_compile_definitions(usrsctp PUBLIC -DSCTP_STDINT_INCLUDE=<stdint.h>)
+		endif()
+		add_library(Usrsctp::Usrsctp ALIAS usrsctp)
 
-	if(INSTALL_DEPS_LIBS)
-		install(TARGETS usrsctp EXPORT LibDataChannelTargets)
-		# Fix directories
-		set_target_properties(usrsctp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
-		target_include_directories(usrsctp INTERFACE
-			$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/usrsctp/usrsctplib>
-			$<INSTALL_INTERFACE:>)
+		if(INSTALL_DEPS_LIBS)
+			install(TARGETS usrsctp EXPORT LibDataChannelTargets)
+			# Fix directories
+			set_target_properties(usrsctp PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "")
+			target_include_directories(usrsctp INTERFACE
+				$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/deps/usrsctp/usrsctplib>
+				$<INSTALL_INTERFACE:>)
+		endif()
 	endif()
 endif()
 
@@ -344,8 +360,10 @@ target_include_directories(datachannel PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(datachannel PRIVATE
 	Threads::Threads
-	Usrsctp::Usrsctp
 	$<BUILD_INTERFACE:plog::plog>)
+if(NOT NO_WEBRTC)
+	target_link_libraries(datachannel PRIVATE Usrsctp::Usrsctp)
+endif()
 
 target_include_directories(datachannel-static PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -355,8 +373,10 @@ target_include_directories(datachannel-static PRIVATE
 	${CMAKE_CURRENT_SOURCE_DIR}/src)
 target_link_libraries(datachannel-static PRIVATE
 	Threads::Threads
-	Usrsctp::Usrsctp
 	$<BUILD_INTERFACE:plog::plog>)
+if(NOT NO_WEBRTC)
+	target_link_libraries(datachannel-static PRIVATE Usrsctp::Usrsctp)
+endif()
 
 if(WIN32)
 	target_link_libraries(datachannel PUBLIC ws2_32) # winsock2
@@ -371,7 +391,7 @@ else()
 	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_WEBSOCKET=1)
 endif()
 
-if(NO_MEDIA)
+if(NO_MEDIA OR NO_WEBRTC)
 	target_compile_definitions(datachannel PUBLIC RTC_ENABLE_MEDIA=0)
 	target_compile_definitions(datachannel-static PUBLIC RTC_ENABLE_MEDIA=0)
 else()
@@ -572,24 +592,26 @@ if(NOT NO_TESTS)
 	target_link_libraries(datachannel-tests datachannel Threads::Threads)
 
 	# Benchmark
-	if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
-		# Add resource files needed for UWP apps.
-		add_executable(datachannel-benchmark test/benchmark.cpp ${BENCHMARK_UWP_RESOURCES})
-	else()
-		add_executable(datachannel-benchmark test/benchmark.cpp)
+	if(NOT NO_WEBRTC)
+		if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+			# Add resource files needed for UWP apps.
+			add_executable(datachannel-benchmark test/benchmark.cpp ${BENCHMARK_UWP_RESOURCES})
+		else()
+			add_executable(datachannel-benchmark test/benchmark.cpp)
+		endif()
+
+		set_target_properties(datachannel-benchmark PROPERTIES
+			VERSION ${PROJECT_VERSION}
+			CXX_STANDARD 17
+			OUTPUT_NAME benchmark)
+
+		set_target_properties(datachannel-benchmark PROPERTIES
+			XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.benchmark)
+
+		target_compile_definitions(datachannel-benchmark PRIVATE BENCHMARK_MAIN=1)
+		target_include_directories(datachannel-benchmark PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+		target_link_libraries(datachannel-benchmark datachannel Threads::Threads)
 	endif()
-
-	set_target_properties(datachannel-benchmark PROPERTIES
-		VERSION ${PROJECT_VERSION}
-		CXX_STANDARD 17
-		OUTPUT_NAME benchmark)
-
-	set_target_properties(datachannel-benchmark PROPERTIES
-		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.benchmark)
-
-	target_compile_definitions(datachannel-benchmark PRIVATE BENCHMARK_MAIN=1)
-	target_include_directories(datachannel-benchmark PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-	target_link_libraries(datachannel-benchmark datachannel Threads::Threads)
 endif()
 
 # Examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,8 @@ option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 option(SCTP_DEBUG "Enable SCTP debugging output to verbose log" OFF)
 option(RTC_UPDATE_VERSION_HEADER "Enable updating the version header" OFF)
 
-if(NO_WEBRTC)
-	message(STATUS "libdatachannel: Setting NO_MEDIA option due to NO_WEBRTC option")
+if(NO_WEBRTC AND NOT NO_MEDIA)
+	message(STATUS "libdatachannel: Forcing NO_MEDIA option due to NO_WEBRTC option")
     set(NO_MEDIA ON CACHE BOOL "Disable media transport support" FORCE)
 endif()
 

--- a/include/rtc/candidate.hpp
+++ b/include/rtc/candidate.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_CANDIDATE_H
 #define RTC_CANDIDATE_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "common.hpp"
 
 #include <string>
@@ -75,3 +77,5 @@ RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out,
 } // namespace rtc
 
 #endif
+
+#endif // RTC_CANDIDATE_H

--- a/include/rtc/datachannel.hpp
+++ b/include/rtc/datachannel.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_DATA_CHANNEL_H
 #define RTC_DATA_CHANNEL_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "channel.hpp"
 #include "common.hpp"
 #include "reliability.hpp"
@@ -78,3 +80,5 @@ template <typename Iterator> bool DataChannel::sendBuffer(Iterator first, Iterat
 } // namespace rtc
 
 #endif
+
+#endif // RTC_DATA_CHANNEL_H

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -75,6 +75,7 @@ public:
 	void addAttribute(string attr);
 	void removeAttribute(const string &attr);
 
+#if RTC_ENABLE_WEBRTC
 	std::vector<Candidate> candidates() const;
 	std::vector<Candidate> extractCandidates();
 	bool hasCandidate(const Candidate &candidate) const;
@@ -85,6 +86,7 @@ public:
 	operator string() const;
 	string generateSdp(string_view eol = "\r\n") const;
 	string generateApplicationSdp(string_view eol = "\r\n") const;
+#endif
 
 	class RTC_CPP_EXPORT Entry {
 	public:
@@ -294,7 +296,9 @@ public:
 	static string typeToString(Type type);
 
 private:
+#if RTC_ENABLE_WEBRTC
 	optional<Candidate> defaultCandidate() const;
+#endif
 	shared_ptr<Entry> createEntry(string mline, string mid, Direction dir);
 	void removeApplication();
 
@@ -314,7 +318,9 @@ private:
 	shared_ptr<Application> mApplication;
 
 	// Candidates
+#if RTC_ENABLE_WEBRTC
 	std::vector<Candidate> mCandidates;
+#endif
 	bool mEnded = false;
 };
 

--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -33,6 +33,7 @@ RTC_CPP_EXPORT void InitLogger(LogLevel level, LogCallback callback = nullptr);
 
 RTC_CPP_EXPORT void SetThreadPoolSize(unsigned int count); // 0: hardware concurrency
 
+#if RTC_ENABLE_WEBRTC
 struct SctpSettings {
 	// For the following settings, not set means optimized default
 	optional<size_t> recvBufferSize;                // in bytes
@@ -50,6 +51,7 @@ struct SctpSettings {
 };
 
 RTC_CPP_EXPORT void SetSctpSettings(SctpSettings s);
+#endif
 
 // Optional global preload and cleanup
 RTC_CPP_EXPORT void Preload();

--- a/include/rtc/peerconnection.hpp
+++ b/include/rtc/peerconnection.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_PEER_CONNECTION_H
 #define RTC_PEER_CONNECTION_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "candidate.hpp"
 #include "common.hpp"
 #include "configuration.hpp"
@@ -140,3 +142,5 @@ RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, PeerConnection::Signa
 } // namespace rtc
 
 #endif
+
+#endif // RTC_PEER_CONNECTION_H

--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_TRACK_H
 #define RTC_TRACK_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "channel.hpp"
 #include "common.hpp"
 #include "description.hpp"
@@ -63,3 +65,5 @@ private:
 } // namespace rtc
 
 #endif
+
+#endif // RTC_TRACK_H

--- a/src/candidate.cpp
+++ b/src/candidate.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "candidate.hpp"
 
 #include "impl/internals.hpp"
@@ -285,3 +287,5 @@ std::ostream &operator<<(std::ostream &out, const Candidate::TransportType &tran
 }
 
 } // namespace rtc
+
+#endif

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -25,12 +25,14 @@ using std::chrono::milliseconds;
 
 namespace {
 
+#if RTC_ENABLE_WEBRTC
 std::unordered_map<int, shared_ptr<PeerConnection>> peerConnectionMap;
 std::unordered_map<int, shared_ptr<DataChannel>> dataChannelMap;
 std::unordered_map<int, shared_ptr<Track>> trackMap;
 #if RTC_ENABLE_MEDIA
 std::unordered_map<int, shared_ptr<RtcpSrReporter>> rtcpSrReporterMap;
 std::unordered_map<int, shared_ptr<RtpPacketizationConfig>> rtpConfigMap;
+#endif
 #endif
 #if RTC_ENABLE_WEBSOCKET
 std::unordered_map<int, shared_ptr<WebSocket>> webSocketMap;
@@ -51,6 +53,7 @@ void setUserPointer(int i, void *ptr) {
 	userPointerMap[i] = ptr;
 }
 
+#if RTC_ENABLE_WEBRTC
 shared_ptr<PeerConnection> getPeerConnection(int id) {
 	std::lock_guard lock(mutex);
 	if (auto it = peerConnectionMap.find(id); it != peerConnectionMap.end())
@@ -123,10 +126,13 @@ void eraseTrack(int tr) {
 #endif
 	userPointerMap.erase(tr);
 }
+#endif
 
 size_t eraseAll() {
 	std::lock_guard lock(mutex);
-	size_t count = dataChannelMap.size() + trackMap.size() + peerConnectionMap.size();
+	size_t count = 0;
+#if RTC_ENABLE_WEBRTC
+	count += dataChannelMap.size() + trackMap.size() + peerConnectionMap.size();
 	dataChannelMap.clear();
 	trackMap.clear();
 	peerConnectionMap.clear();
@@ -135,21 +141,26 @@ size_t eraseAll() {
 	rtcpSrReporterMap.clear();
 	rtpConfigMap.clear();
 #endif
+#endif
 #if RTC_ENABLE_WEBSOCKET
 	count += webSocketMap.size() + webSocketServerMap.size();
 	webSocketMap.clear();
 	webSocketServerMap.clear();
 #endif
+#if RTC_ENABLE_WEBRTC
 	userPointerMap.clear();
+#endif
 	return count;
 }
 
 shared_ptr<Channel> getChannel(int id) {
 	std::lock_guard lock(mutex);
+#if RTC_ENABLE_WEBRTC
 	if (auto it = dataChannelMap.find(id); it != dataChannelMap.end())
 		return it->second;
 	if (auto it = trackMap.find(id); it != trackMap.end())
 		return it->second;
+#endif
 #if RTC_ENABLE_WEBSOCKET
 	if (auto it = webSocketMap.find(id); it != webSocketMap.end())
 		return it->second;
@@ -159,6 +170,7 @@ shared_ptr<Channel> getChannel(int id) {
 
 void eraseChannel(int id) {
 	std::lock_guard lock(mutex);
+#if RTC_ENABLE_WEBRTC
 	if (dataChannelMap.erase(id) != 0) {
 		userPointerMap.erase(id);
 		return;
@@ -171,6 +183,7 @@ void eraseChannel(int id) {
 #endif
 		return;
 	}
+#endif
 #if RTC_ENABLE_WEBSOCKET
 	if (webSocketMap.erase(id) != 0) {
 		userPointerMap.erase(id);
@@ -227,6 +240,7 @@ template <typename F> int wrap(F func) {
 	}
 }
 
+#if RTC_ENABLE_WEBRTC
 #if RTC_ENABLE_MEDIA
 
 string lowercased(string str) {
@@ -325,6 +339,7 @@ private:
 };
 
 #endif // RTC_ENABLE_MEDIA
+#endif // RTC_ENABLE_WEBRTC
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -392,6 +407,7 @@ void rtcSetUserPointer(int i, void *ptr) { setUserPointer(i, ptr); }
 
 void *rtcGetUserPointer(int i) { return getUserPointer(i).value_or(nullptr); }
 
+#if RTC_ENABLE_WEBRTC
 int rtcCreatePeerConnection(const rtcConfiguration *config) {
 	return wrap([config] {
 		Configuration c;
@@ -717,6 +733,7 @@ int rtcGetRemoteMaxMessageSize(int pc) {
 		return int(peerConnection->remoteMaxMessageSize());
 	});
 }
+#endif
 
 int rtcSetOpenCallback(int id, rtcOpenCallbackFunc cb) {
 	return wrap([&] {
@@ -923,6 +940,7 @@ int rtcReceiveMessage(int id, char *buffer, int *size) {
 	});
 }
 
+#if RTC_ENABLE_WEBRTC
 int rtcCreateDataChannel(int pc, const char *label) {
 	return rtcCreateDataChannelEx(pc, label, nullptr);
 }
@@ -935,7 +953,8 @@ int rtcCreateDataChannelEx(int pc, const char *label, const rtcDataChannelInit *
 			dci.reliability.unordered = reliability->unordered;
 			if (reliability->unreliable) {
 				if (reliability->maxPacketLifeTime > 0)
-					dci.reliability.maxPacketLifeTime.emplace(milliseconds(reliability->maxPacketLifeTime));
+					dci.reliability.maxPacketLifeTime.emplace(
+					    milliseconds(reliability->maxPacketLifeTime));
 				else
 					dci.reliability.maxRetransmits.emplace(reliability->maxRetransmits);
 			}
@@ -999,9 +1018,10 @@ int rtcGetDataChannelReliability(int dc, rtcReliability *reliability) {
 		Reliability dcr = dataChannel->reliability();
 		std::memset(reliability, 0, sizeof(*reliability));
 		reliability->unordered = dcr.unordered;
-		if(dcr.maxPacketLifeTime) {
+		if (dcr.maxPacketLifeTime) {
 			reliability->unreliable = true;
-			reliability->maxPacketLifeTime = static_cast<unsigned int>(dcr.maxPacketLifeTime->count());
+			reliability->maxPacketLifeTime =
+			    static_cast<unsigned int>(dcr.maxPacketLifeTime->count());
 		} else if (dcr.maxRetransmits) {
 			reliability->unreliable = true;
 			reliability->maxRetransmits = *dcr.maxRetransmits;
@@ -1191,7 +1211,9 @@ int rtcRequestBitrate(int tr, unsigned int bitrate) {
 		return RTC_ERR_SUCCESS;
 	});
 }
+#endif
 
+#if RTC_ENABLE_WEBRTC
 #if RTC_ENABLE_MEDIA
 
 void setSSRC(Description::Media *description, uint32_t ssrc, const char *_name, const char *_msid,
@@ -1256,8 +1278,8 @@ int rtcSetH264Packetizer(int tr, const rtcPacketizerInit *init) {
 		emplaceRtpConfig(rtpConfig, tr);
 		// create packetizer
 		auto nalSeparator = init ? init->nalSeparator : RTC_NAL_SEPARATOR_LENGTH;
-		auto maxFragmentSize = init && init->maxFragmentSize ? init->maxFragmentSize
-		                                                     : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
+		auto maxFragmentSize =
+		    init && init->maxFragmentSize ? init->maxFragmentSize : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
 		auto packetizer = std::make_shared<H264RtpPacketizer>(
 		    static_cast<rtc::NalUnit::Separator>(nalSeparator), rtpConfig, maxFragmentSize);
 		track->setMediaHandler(packetizer);
@@ -1273,8 +1295,8 @@ int rtcSetH265Packetizer(int tr, const rtcPacketizerInit *init) {
 		emplaceRtpConfig(rtpConfig, tr);
 		// create packetizer
 		auto nalSeparator = init ? init->nalSeparator : RTC_NAL_SEPARATOR_LENGTH;
-		auto maxFragmentSize = init && init->maxFragmentSize ? init->maxFragmentSize
-		                                                     : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
+		auto maxFragmentSize =
+		    init && init->maxFragmentSize ? init->maxFragmentSize : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
 		auto packetizer = std::make_shared<H265RtpPacketizer>(
 		    static_cast<rtc::NalUnit::Separator>(nalSeparator), rtpConfig, maxFragmentSize);
 		track->setMediaHandler(packetizer);
@@ -1289,8 +1311,8 @@ int rtcSetAV1Packetizer(int tr, const rtcPacketizerInit *init) {
 		auto rtpConfig = createRtpPacketizationConfig(init);
 		emplaceRtpConfig(rtpConfig, tr);
 		// create packetizer
-		auto maxFragmentSize = init && init->maxFragmentSize ? init->maxFragmentSize
-		                                                     : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
+		auto maxFragmentSize =
+		    init && init->maxFragmentSize ? init->maxFragmentSize : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
 		auto packetization = init->obuPacketization == RTC_OBU_PACKETIZED_TEMPORAL_UNIT
 		                         ? AV1RtpPacketizer::Packetization::TemporalUnit
 		                         : AV1RtpPacketizer::Packetization::Obu;
@@ -1549,6 +1571,7 @@ int rtcSetNeedsToSendRtcpSr(int) {
 }
 
 #endif // RTC_ENABLE_MEDIA
+#endif // RTC_ENABLE_WEBRTC
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -1592,7 +1615,7 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 		else if (config->maxOutstandingPings < 0)
 			c.maxOutstandingPings = 0; // setting to 0 disables, not setting keeps default
 
-		if(config->maxMessageSize > 0)
+		if (config->maxMessageSize > 0)
 			c.maxMessageSize = size_t(config->maxMessageSize);
 
 		auto webSocket = std::make_shared<WebSocket>(std::move(c));
@@ -1632,7 +1655,7 @@ int rtcGetWebSocketPath(int ws, char *buffer, int size) {
 }
 
 int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
-                                          rtcWebSocketClientCallbackFunc cb) {
+                             rtcWebSocketClientCallbackFunc cb) {
 	return wrap([&] {
 		if (!config)
 			throw std::invalid_argument("Unexpected null pointer for config");
@@ -1650,7 +1673,7 @@ int rtcCreateWebSocketServer(const rtcWsServerConfiguration *config,
 		c.keyPemPass = config->keyPemPass ? make_optional(string(config->keyPemPass)) : nullopt;
 		c.bindAddress = config->bindAddress ? make_optional(string(config->bindAddress)) : nullopt;
 
-		if(config->maxMessageSize > 0)
+		if (config->maxMessageSize > 0)
 			c.maxMessageSize = size_t(config->maxMessageSize);
 
 		auto webSocketServer = std::make_shared<WebSocketServer>(std::move(c));
@@ -1694,6 +1717,7 @@ int rtcSetThreadPoolSize(unsigned int count) {
 	});
 }
 
+#if RTC_ENABLE_WEBRTC
 int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 	return wrap([&] {
 		SctpSettings s = {};
@@ -1742,6 +1766,7 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 		return RTC_ERR_SUCCESS;
 	});
 }
+#endif
 
 void rtcPreload() {
 	try {
@@ -1766,4 +1791,3 @@ void rtcCleanup() {
 		PLOG_ERROR << e.what();
 	}
 }
-

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "datachannel.hpp"
 #include "common.hpp"
 #include "peerconnection.hpp"
@@ -55,3 +57,5 @@ bool DataChannel::send(const byte *data, size_t size) {
 }
 
 } // namespace rtc
+
+#endif

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -158,8 +158,10 @@ Description::Description(const string &sdp, Type type, Role role)
 				// attribute.
 				if (mIceOptions.empty())
 					mIceOptions = utils::explode(string(value), ',');
+#if RTC_ENABLE_WEBRTC
 			} else if (key == "candidate") {
 				addCandidate(Candidate(attr, bundleMid()));
+#endif
 			} else if (key == "end-of-candidates") {
 				mEnded = true;
 			} else if (current) {
@@ -256,6 +258,7 @@ void Description::Entry::removeAttribute(const string &attr) {
 	    mAttributes.end());
 }
 
+#if RTC_ENABLE_WEBRTC
 std::vector<Candidate> Description::candidates() const { return mCandidates; }
 
 std::vector<Candidate> Description::extractCandidates() {
@@ -423,6 +426,7 @@ optional<Candidate> Description::defaultCandidate() const {
 	}
 	return result;
 }
+#endif
 
 shared_ptr<Description::Entry> Description::createEntry(string mline, string mid, Direction dir) {
 	string type = mline.substr(0, mline.find(' '));
@@ -1374,9 +1378,11 @@ bool CertificateFingerprint::isValid() const {
 	return true;
 }
 
+#if RTC_ENABLE_WEBRTC
 std::ostream &operator<<(std::ostream &out, const Description &description) {
 	return out << string(description);
 }
+#endif
 
 std::ostream &operator<<(std::ostream &out, Description::Type type) {
 	return out << Description::typeToString(type);

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -84,7 +84,9 @@ void InitLogger(plog::Severity severity, plog::IAppender *appender) {
 }
 
 void SetThreadPoolSize(unsigned int count) { impl::Init::Instance().setThreadPoolSize(count); }
+#if RTC_ENABLE_WEBRTC
 void SetSctpSettings(SctpSettings s) { impl::Init::Instance().setSctpSettings(std::move(s)); }
+#endif
 
 void Preload() { impl::Init::Instance().preload(); }
 std::shared_future<void> Cleanup() { return impl::Init::Instance().cleanup(); }

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -6,15 +6,17 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "datachannel.hpp"
 #include "common.hpp"
 #include "internals.hpp"
 #include "logcounter.hpp"
 #include "peerconnection.hpp"
-#include "sctptransport.hpp"
-#include "utils.hpp"
 #include "rtc/datachannel.hpp"
 #include "rtc/track.hpp"
+#include "sctptransport.hpp"
+#include "utils.hpp"
 
 #include <algorithm>
 
@@ -79,10 +81,10 @@ DataChannel::DataChannel(weak_ptr<PeerConnection> pc, string label, string proto
     : mPeerConnection(pc), mLabel(std::move(label)), mProtocol(std::move(protocol)),
       mRecvQueue(RECV_QUEUE_LIMIT, message_size_func) {
 
-	if(reliability.maxPacketLifeTime && reliability.maxRetransmits)
+	if (reliability.maxPacketLifeTime && reliability.maxRetransmits)
 		throw std::invalid_argument("Both maxPacketLifeTime and maxRetransmits are set");
 
-    mReliability = std::make_shared<Reliability>(std::move(reliability));
+	mReliability = std::make_shared<Reliability>(std::move(reliability));
 }
 
 DataChannel::~DataChannel() {
@@ -109,7 +111,7 @@ void DataChannel::close() {
 
 		triggerClosed();
 		resetCallbacks();
-	}	
+	}
 }
 
 void DataChannel::remoteClose() { close(); }
@@ -393,3 +395,5 @@ void IncomingDataChannel::processOpenMessage(message_ptr message) {
 }
 
 } // namespace rtc::impl
+
+#endif

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_IMPL_DATA_CHANNEL_H
 #define RTC_IMPL_DATA_CHANNEL_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "channel.hpp"
 #include "common.hpp"
 #include "message.hpp"
@@ -91,3 +93,5 @@ struct IncomingDataChannel final : public DataChannel {
 } // namespace rtc::impl
 
 #endif
+
+#endif // RTC_IMPL_DATA_CHANNEL_H

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "dtlstransport.hpp"
 #include "dtlssrtptransport.hpp"
 #include "icetransport.hpp"
@@ -401,10 +403,11 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 		mbedtls::check(mbedtls_ctr_drbg_seed(&mDrbg, mbedtls_entropy_func, &mEntropy, NULL, 0));
 
 		mbedtls::check(mbedtls_ssl_config_defaults(
-		                   &mConf, mIsClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
-		                   MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT));
+		    &mConf, mIsClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
+		    MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT));
 
-		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
+		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3,
+		                             MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
 		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_OPTIONAL);
 		mbedtls_ssl_conf_verify(&mConf, DtlsTransport::CertificateCallback, this);
 		mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, &mDrbg);
@@ -763,8 +766,11 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 		                   CertificateCallback);
 		SSL_CTX_set_verify_depth(mCtx, 1);
 
-		openssl::check(SSL_CTX_set_cipher_list(mCtx, "ALL:!SHA256:!SHA384:!aPSK:!ECDSA+SHA1:!ADH:!LOW:!EXP:!MD5:!3DES:!SSLv3:!TLSv1"),
-		               "Failed to set SSL priorities");
+		openssl::check(
+		    SSL_CTX_set_cipher_list(
+		        mCtx,
+		        "ALL:!SHA256:!SHA384:!aPSK:!ECDSA+SHA1:!ADH:!LOW:!EXP:!MD5:!3DES:!SSLv3:!TLSv1"),
+		    "Failed to set SSL priorities");
 
 #if OPENSSL_VERSION_NUMBER >= 0x30000000
 		openssl::check(SSL_CTX_set1_groups_list(mCtx, "P-256"), "Failed to set SSL groups");
@@ -1099,3 +1105,5 @@ long DtlsTransport::BioMethodCtrl(BIO * /*bio*/, int cmd, long /*num*/, void * /
 #endif
 
 } // namespace rtc::impl
+
+#endif

--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_IMPL_DTLS_TRANSPORT_H
 #define RTC_IMPL_DTLS_TRANSPORT_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "certificate.hpp"
 #include "common.hpp"
 #include "queue.hpp"
@@ -123,3 +125,5 @@ protected:
 } // namespace rtc::impl
 
 #endif
+
+#endif // RTC_IMPL_DTLS_TRANSPORT_H

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "icetransport.hpp"
 #include "configuration.hpp"
 #include "internals.hpp"
@@ -945,3 +947,5 @@ bool IceTransport::getSelectedCandidatePair(Candidate *local, Candidate *remote)
 #endif
 
 } // namespace rtc::impl
+
+#endif

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_IMPL_ICE_TRANSPORT_H
 #define RTC_IMPL_ICE_TRANSPORT_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "candidate.hpp"
 #include "common.hpp"
 #include "configuration.hpp"
@@ -125,3 +127,5 @@ private:
 } // namespace rtc::impl
 
 #endif
+
+#endif // RTC_IMPL_ICE_TRANSPORT_H

--- a/src/impl/init.hpp
+++ b/src/impl/init.hpp
@@ -34,7 +34,9 @@ public:
 	std::shared_future<void> cleanup();
 
 	void setThreadPoolSize(unsigned int count);
+#if RTC_ENABLE_WEBRTC
 	void setSctpSettings(SctpSettings s);
+#endif
 
 private:
 	Init();
@@ -46,7 +48,9 @@ private:
 	std::optional<shared_ptr<void>> mGlobal;
 	weak_ptr<void> mWeak;
 	bool mInitialized = false;
+#if RTC_ENABLE_WEBRTC
 	SctpSettings mCurrentSctpSettings = {};
+#endif
 	unsigned int mThreadPoolSize = 0;
 	std::mutex mMutex;
 	std::shared_future<void> mCleanupFuture;

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -7,6 +7,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "peerconnection.hpp"
 #include "certificate.hpp"
 #include "dtlstransport.hpp"
@@ -1427,3 +1429,5 @@ void PeerConnection::updateTrackSsrcCache(const Description &description) {
 }
 
 } // namespace rtc::impl
+
+#endif

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_IMPL_PEER_CONNECTION_H
 #define RTC_IMPL_PEER_CONNECTION_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "common.hpp"
 #include "datachannel.hpp"
 #include "dtlstransport.hpp"
@@ -171,3 +173,5 @@ private:
 } // namespace rtc::impl
 
 #endif
+
+#endif // RTC_IMPL_PEER_CONNECTION_H

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -9,6 +9,8 @@
 #ifndef RTC_IMPL_SCTP_TRANSPORT_H
 #define RTC_IMPL_SCTP_TRANSPORT_H
 
+#if RTC_ENABLE_WEBRTC
+
 #include "common.hpp"
 #include "configuration.hpp"
 #include "global.hpp"
@@ -127,9 +129,11 @@ private:
 	static void DebugCallback(const char *format, ...);
 
 	class InstancesSet;
-	static InstancesSet* Instances;
+	static InstancesSet *Instances;
 };
 
 } // namespace rtc::impl
 
 #endif
+
+#endif // RTC_IMPL_SCTP_TRANSPORT_H

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "track.hpp"
 #include "internals.hpp"
 #include "logcounter.hpp"
@@ -264,3 +266,5 @@ void Track::flushPendingMessages() {
 }
 
 } // namespace rtc::impl
+
+#endif

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -7,6 +7,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "peerconnection.hpp"
 #include "common.hpp"
 #include "rtp.hpp"
@@ -520,3 +522,5 @@ std::ostream &operator<<(std::ostream &out, PeerConnection::SignalingState state
 }
 
 } // namespace rtc
+
+#endif

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -6,6 +6,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+#if RTC_ENABLE_WEBRTC
+
 #include "track.hpp"
 
 #include "impl/internals.hpp"
@@ -84,3 +86,5 @@ bool Track::requestBitrate(unsigned int bitrate) {
 shared_ptr<MediaHandler> Track::getMediaHandler() { return impl()->getMediaHandler(); }
 
 } // namespace rtc
+
+#endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -33,6 +33,8 @@ TestResult test_capi_track();
 TestResult test_websocket();
 TestResult test_websocketserver();
 TestResult test_capi_websocketserver();
+
+#if RTC_ENABLE_WEBRTC
 size_t benchmark(chrono::milliseconds duration);
 
 void test_benchmark() {
@@ -45,6 +47,7 @@ void test_benchmark() {
 	if (goodput < threshold)
 		throw runtime_error("Goodput is too low");
 }
+#endif
 
 TestResult test_cleanup() {
 	try {
@@ -67,6 +70,7 @@ TestResult test_capi_cleanup() {
 }
 
 static const vector<Test> tests = {
+#if RTC_ENABLE_WEBRTC
     // C++ API tests
     Test("WebRTC connectivity", test_connectivity),
     Test("WebRTC broken fingerprint", test_connectivity_fail_on_wrong_fingerprint),
@@ -78,16 +82,19 @@ static const vector<Test> tests = {
 #if RTC_ENABLE_MEDIA
     Test("WebRTC track", test_track),
 #endif
+#endif
 #if RTC_ENABLE_WEBSOCKET
     // TODO: Temporarily disabled as the echo service is unreliable
     // new Test("WebSocket", test_websocket),
     Test("WebSocketServer", test_websocketserver),
 #endif
     Test("Cleanup", test_cleanup),
+#if RTC_ENABLE_WEBRTC
     // C API tests
     Test("WebRTC C API connectivity", test_capi_connectivity),
 #if RTC_ENABLE_MEDIA
     Test("WebRTC C API track", test_capi_track),
+#endif
 #endif
 #if RTC_ENABLE_WEBSOCKET
     Test("WebSocketServer C API", test_capi_websocketserver),


### PR DESCRIPTION
This is very rudimentary and likely needs the following improvements:
- [ ] Switch from `#ifdef RTC_ENABLE_WEBRTC` guards for almost every source file to simply excluding the source files with CMake. This would also reduce build times
- [ ] Exclude more source files/data types that are only relevant for WebRTC

For my purposes it works for now, so I'll mark this PR as a draft. If anyone would like to build upon it, feel free to use it as a starting point.

Implements #1490