### PR TITLE
Return whether preload performed initialization

### DIFF
--- a/include/rtc/global.hpp
+++ b/include/rtc/global.hpp
@@ -52,7 +52,7 @@ struct SctpSettings {
 RTC_CPP_EXPORT void SetSctpSettings(SctpSettings s);
 
 // Optional global preload and cleanup
-RTC_CPP_EXPORT void Preload();
+RTC_CPP_EXPORT bool Preload();
 RTC_CPP_EXPORT std::shared_future<void> Cleanup();
 
 RTC_CPP_EXPORT std::ostream &operator<<(std::ostream &out, LogLevel level);

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -537,7 +537,7 @@ typedef struct {
 RTC_C_EXPORT int rtcSetSctpSettings(const rtcSctpSettings *settings);
 
 // Optional global preload and cleanup
-RTC_C_EXPORT void rtcPreload(void);
+RTC_C_EXPORT bool rtcPreload(void);
 RTC_C_EXPORT void rtcCleanup(void);
 
 #ifdef __cplusplus

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1743,11 +1743,12 @@ int rtcSetSctpSettings(const rtcSctpSettings *settings) {
 	});
 }
 
-void rtcPreload() {
+bool rtcPreload() {
 	try {
-		rtc::Preload();
+		return rtc::Preload();
 	} catch (const std::exception &e) {
 		PLOG_ERROR << e.what();
+		return false;
 	}
 }
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -86,7 +86,7 @@ void InitLogger(plog::Severity severity, plog::IAppender *appender) {
 void SetThreadPoolSize(unsigned int count) { impl::Init::Instance().setThreadPoolSize(count); }
 void SetSctpSettings(SctpSettings s) { impl::Init::Instance().setSctpSettings(std::move(s)); }
 
-void Preload() { impl::Init::Instance().preload(); }
+bool Preload() { return impl::Init::Instance().preload(); }
 std::shared_future<void> Cleanup() { return impl::Init::Instance().cleanup(); }
 
 std::ostream &operator<<(std::ostream &out, LogLevel level) {

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -82,12 +82,14 @@ init_token Init::token() {
 	return *mGlobal;
 }
 
-void Init::preload() {
+bool Init::preload() {
 	std::lock_guard lock(mMutex);
 	if (!mGlobal) {
 		mGlobal = std::make_shared<TokenPayload>(&mCleanupFuture);
 		mWeak = *mGlobal;
+		return true;
 	}
+	return false;
 }
 
 std::shared_future<void> Init::cleanup() {

--- a/src/impl/init.hpp
+++ b/src/impl/init.hpp
@@ -30,7 +30,7 @@ public:
 	Init &operator=(Init &&) = delete;
 
 	init_token token();
-	void preload();
+	bool preload();
 	std::shared_future<void> cleanup();
 
 	void setThreadPoolSize(unsigned int count);


### PR DESCRIPTION
I think it would be a good addition to return a boolean from the global `Preload` method that indicates whether or not the function actually performed the initialization of the RTC library. This will give certainty that configuration through functions like `rtc::SetThreadPoolSize(n)` was actually applied. In the case of this function the thread pool size is not actually set, if initialization was already performed beforehand, which can be the case when creating an `rtc::WebSocket` instance, which silently calls `Init::Instance().token()` (which in turn triggers global library initialization).

Here's a usage example: https://github.com/ungive/loon/commit/2a7427a57ed08dcf0686eb9d5b7dbd5dc20943d9