### PR TITLE
Fix AV1 RTP packetizer to handle frames without temporal unit delimiters

### DIFF
--- a/src/av1rtppacketizer.cpp
+++ b/src/av1rtppacketizer.cpp
@@ -48,12 +48,16 @@ AV1RtpPacketizer::AV1RtpPacketizer(Packetization packetization,
 std::vector<binary> AV1RtpPacketizer::extractTemporalUnitObus(const binary &data) {
 	std::vector<binary> obus;
 
-	if (data.size() <= 2 || (data.at(0) != obuTemporalUnitDelimiter.at(0)) ||
-	    (data.at(1) != obuTemporalUnitDelimiter.at(1))) {
+	if (data.size() == 0) {
 		return {};
 	}
 
-	size_t index = 2;
+	// VAAPI doesn't seem to include delimiters
+	size_t index = 0;
+	if (data.size() > 2 && (data.at(0) == obuTemporalUnitDelimiter.at(0)) &&
+	    (data.at(1) == obuTemporalUnitDelimiter.at(1))) {
+		index = 2;
+	}
 	while (index < data.size()) {
 		if ((data.at(index) & obuHasSizeMask) == byte(0)) {
 			return obus;


### PR DESCRIPTION
This one took me quite a while since I have no notable C++ experience and also no experience with video encoding. I wanted to stream using my new AMD card and AV1 codec with OBS to Broadcast-box however it has not worked for a while. Since nothing was happening to fix it, I figured I'd debug it myself which threw me down this rabbit hole. After debugging I did see that OBS didn't send any video packets over the network interface when I used whip to stream AV1 with VAAPI. This in the end pointed me to this library and this patch fixes it for me. 

It seems that these delimiters are the issue and VAAPI doesn't include them with AV1 encoding.

As mentioned I have not so much experience with c++ and therefore I am not certain this is the correct way to fix it. So I am open to someone throwing this code away and making a better fix. 