### PR TITLE
Add support for PEM CA certificates

### DIFF
--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -89,6 +89,8 @@ bool check_error(int err, const string &message = "OpenSSL error");
 
 BIO *BIO_new_from_file(const string &filename);
 
+void SSL_CTX_add_cert_to_store_from_pem(SSL_CTX *ctx, const string &pem);
+
 } // namespace rtc::openssl
 
 #endif


### PR DESCRIPTION
This PR adds support for CA certificates in PEM format for `VerifiedTlsTransport` when using OpenSSL. This allows `WebSocketConfiguration::caCertificatePemFile` to contain a PEM string instead of enforcing a file path. The PEM certificate is parsed and all x509 certificates and CRLs are added to the VerifiedTlsTransport's SSL_CTX.

I'm not the most experienced with OpenSSL, so I'd appreciate it if someone looked over my code.