### PR TITLE
Improve PacingHandler

### DIFF
--- a/include/rtc/pacinghandler.hpp
+++ b/include/rtc/pacinghandler.hpp
@@ -23,11 +23,13 @@ namespace rtc {
 // and delivers them in a smoother manner by sending a fixed size of them on an interval
 class RTC_CPP_EXPORT PacingHandler : public MediaHandler {
 public:
-	PacingHandler(double bitsPerSecond, std::chrono::milliseconds sendInterval, size_t maxQueueSize=0, std::function<void(void)> onOverflowCallback=nullptr);
+	PacingHandler(double bitsPerSecond, std::chrono::milliseconds sendInterval, size_t maxQueueSize=0);
 
 	void setBitrate(double bitsPerSecond);
 
-	void setMaxQueueSize(size_t maxQueueSize);
+	void setMaxQueueAmount(size_t maxQueueAmount);
+
+	void onOverflow(std::function<void()> callback);
 
 	void outgoing(message_vector &messages, const message_callback &send) override;
 
@@ -40,13 +42,13 @@ private:
 	std::chrono::milliseconds mSendInterval;
 	std::chrono::time_point<std::chrono::high_resolution_clock> mLastRun;
 
-	size_t mMaxQueueSize;
+	size_t mMaxQueueAmount;
 
 	std::mutex mParamsMutex;
 	std::mutex mMutex;
 	std::queue<message_ptr> mRtpBuffer;
 
-	std::function<void(void)> mOnOverflowCallback;
+	synchronized_callback<> mOverflowCallback;
 
 	void schedule(const message_callback &send, std::chrono::milliseconds scheduleInterval);
 	void run(const message_callback &send);

--- a/src/pacinghandler.cpp
+++ b/src/pacinghandler.cpp
@@ -17,17 +17,21 @@
 
 namespace rtc {
 
-PacingHandler::PacingHandler(double bitsPerSecond, std::chrono::milliseconds sendInterval, size_t maxQueueSize, std::function<void(void)> onOverflowCallback)
-    : mBytesPerSecond(bitsPerSecond / 8), mBudget(0.), mSendInterval(sendInterval), mMaxQueueSize(maxQueueSize), mOnOverflowCallback(onOverflowCallback) {};
+PacingHandler::PacingHandler(double bitsPerSecond, std::chrono::milliseconds sendInterval, size_t maxQueueAmount)
+    : mBytesPerSecond(bitsPerSecond / 8), mBudget(0.), mSendInterval(sendInterval), mMaxQueueAmount(maxQueueAmount) {}
 
 void PacingHandler::setBitrate(double bitsPerSecond) {
 	std::lock_guard<std::mutex> lock(mParamsMutex);
     mBytesPerSecond = bitsPerSecond / 8;
 }
 
-void PacingHandler::setMaxQueueSize(size_t maxQueueSize) {
+void PacingHandler::setMaxQueueAmount(size_t maxQueueAmount) {
 	std::lock_guard<std::mutex> lock(mParamsMutex);
-    mMaxQueueSize = maxQueueSize;
+    mMaxQueueAmount = maxQueueAmount;
+}
+
+void PacingHandler::onOverflow(std::function<void()> callback) {
+	mOverflowCallback = std::move(callback);
 }
 
 void PacingHandler::schedule(const message_callback &send, std::chrono::milliseconds scheduleInterval) {
@@ -72,28 +76,18 @@ void PacingHandler::outgoing(message_vector &messages, const message_callback &s
 
 	std::lock_guard<std::mutex> lock(mMutex);
 
-	size_t maxQueueSize;
+	size_t maxQueueAmount;
     {
         std::lock_guard<std::mutex> lockParams(mParamsMutex);
-        maxQueueSize = mMaxQueueSize;
+        maxQueueAmount = mMaxQueueAmount;
     }
-	
-    size_t messagesSize = messages.size();
-	if (maxQueueSize > 0) {
-		size_t currentSize = mRtpBuffer.size();
-		if (currentSize + messagesSize > maxQueueSize) {
-			mRtpBuffer = {};
-			if (mOnOverflowCallback) {
-				mOnOverflowCallback();
-			}
+
+	for (auto& m : messages) {
+		if (maxQueueAmount != 0 && mRtpBuffer.size() >= maxQueueAmount) {
+			mOverflowCallback();
+			break;
 		}
-	}
-	if (maxQueueSize == 0 || messagesSize <= maxQueueSize) {
-		if (messages.size() <= maxQueueSize) {
-			for (auto &m : messages) {
-				mRtpBuffer.push(std::move(m));
-			}
-		}
+		mRtpBuffer.push(std::move(m));
 	}
 	messages.clear();
 


### PR DESCRIPTION
Changes:
* Add `setBitrate` setter for dynamic bitrate limit change
* Add `setMaxQueueSize` setter (also size can be set in ctor). There is a problem that buffer is unlimited and can grow indefinitely leading to long send delays. Now you can set queue size limit and drop queue if it is full. Also there is an option to set `onOverflowCallback`. By default queue is unlimited
* Change send interval calculation. Sending packets takes time, but this is not considered when scheduling further sends, although it is included in budget calculation