### PR TITLE
Fix REMB SSRC

### DIFF
--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -269,7 +269,7 @@ struct RTC_CPP_EXPORT RtcpRemb {
 
 	char _id[4];       // Unique identifier ('R' 'E' 'M' 'B')
 	uint32_t _bitrate; // Num SSRC, Br Exp, Br Mantissa (bit mask)
-	SSRC _ssrcs;
+	SSRC _ssrcs[1];
 
 	[[nodiscard]] static size_t SizeWithSSRCs(int count);
 
@@ -277,10 +277,10 @@ struct RTC_CPP_EXPORT RtcpRemb {
 
 	void preparePacket(SSRC senderSSRC, unsigned int numSSRC, unsigned int in_bitrate);
 	void setBitrate(unsigned int numSSRC, unsigned int in_bitrate);
-	SSRC getSsrc(int num) const;
-	void setSsrc(int num, SSRC newSsrc);
-	unsigned int getNumSSRC();
-	unsigned int getBitrate();
+	SSRC getSSRC(int num) const;
+	void setSSRC(int num, SSRC newSsrc);
+	unsigned int getNumSSRC() const;
+	unsigned int getBitrate() const;
 };
 
 struct RTC_CPP_EXPORT RtcpPli {

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -269,7 +269,7 @@ struct RTC_CPP_EXPORT RtcpRemb {
 
 	char _id[4];       // Unique identifier ('R' 'E' 'M' 'B')
 	uint32_t _bitrate; // Num SSRC, Br Exp, Br Mantissa (bit mask)
-	SSRC _ssrc[1];
+	SSRC _ssrcs;
 
 	[[nodiscard]] static size_t SizeWithSSRCs(int count);
 
@@ -277,7 +277,8 @@ struct RTC_CPP_EXPORT RtcpRemb {
 
 	void preparePacket(SSRC senderSSRC, unsigned int numSSRC, unsigned int in_bitrate);
 	void setBitrate(unsigned int numSSRC, unsigned int in_bitrate);
-	void setSsrc(int iterator, SSRC newSssrc);
+	SSRC getSsrc(int num) const;
+	void setSsrc(int num, SSRC newSsrc);
 	unsigned int getNumSSRC();
 	unsigned int getBitrate();
 };

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -584,7 +584,7 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 			} else if (header->payloadType() == 206) {
 				auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
 				ssrcs.insert(rtcpfb->packetSenderSSRC());
-				if (header->reportCount() == 15 && header->lengthInBytes() == sizeof(RtcpRemb)) {
+				if (header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
 					auto remb = reinterpret_cast<RtcpRemb *>(header);
 					if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
                     	unsigned numSsrc = remb->getNumSSRC();

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -589,7 +589,7 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 					if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
                     	unsigned numSsrc = remb->getNumSSRC();
 						for (unsigned i = 0; i < numSsrc; i++) {
-							ssrcs.insert(remb->getSsrc(i));
+							ssrcs.insert(remb->getSSRC(i));
 						}
 						continue;
 					}

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -586,6 +586,9 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 				ssrcs.insert(rtcpfb->packetSenderSSRC());
 				if (header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
 					auto remb = reinterpret_cast<RtcpRemb *>(header);
+					if (remb->getSize() > message->size() + header->lengthInBytes() - offset) {
+						continue;
+					}
 					if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
                     	unsigned numSsrc = remb->getNumSSRC();
 						for (unsigned i = 0; i < numSsrc; i++) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -586,11 +586,11 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 				ssrcs.insert(rtcpfb->packetSenderSSRC());
 				if (header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
 					auto remb = reinterpret_cast<RtcpRemb *>(header);
-					if (remb->getSize() > message->size() + header->lengthInBytes() - offset) {
+					unsigned numSsrc = remb->getNumSSRC();
+					if (RtcpRemb::SizeWithSSRCs(numSsrc) > message->size() + header->lengthInBytes() - offset) {
 						continue;
 					}
 					if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
-                    	unsigned numSsrc = remb->getNumSSRC();
 						for (unsigned i = 0; i < numSsrc; i++) {
 							ssrcs.insert(remb->getSSRC(i));
 						}

--- a/src/rembhandler.cpp
+++ b/src/rembhandler.cpp
@@ -28,7 +28,7 @@ void RembHandler::incoming(message_vector &messages, [[maybe_unused]] const mess
 			auto header = reinterpret_cast<RtcpHeader *>(message->data() + offset);
 			uint8_t payload_type = header->payloadType();
 
-			if (payload_type == 206 && header->reportCount() == 15 && header->lengthInBytes() == sizeof(RtcpRemb)) {
+			if (payload_type == 206 && header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
 				auto remb = reinterpret_cast<RtcpRemb *>(message->data() + offset);
 
 				if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {

--- a/src/rtcpreceivingsession.cpp
+++ b/src/rtcpreceivingsession.cpp
@@ -114,7 +114,7 @@ void RtcpReceivingSession::pushREMB(const message_callback &send, unsigned int b
 	auto message = make_message(RtcpRemb::SizeWithSSRCs(1), Message::Control);
 	auto remb = reinterpret_cast<RtcpRemb *>(message->data());
 	remb->preparePacket(mSsrc, 1, bitrate);
-	remb->setSsrc(0, mSsrc);
+	remb->setSSRC(0, mSsrc);
 	send(message);
 }
 

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -581,13 +581,20 @@ void RtcpRemb::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
 	_bitrate = htonl((numSSRC << (32u - 8u)) | (exp << (32u - 8u - 6u)) | in_bitrate);
 }
 
-SSRC RtcpRemb::getSsrc(int num) const { return ntohl(*(&_ssrcs + num)); }
+SSRC RtcpRemb::getSSRC(int num) const { 
+    if (num < 0 || static_cast<unsigned>(num) >= getNumSSRC())
+        throw std::out_of_range("SSRC num out of range");
+    return ntohl(_ssrcs[num]);
+}
+void RtcpRemb::setSSRC(int num, SSRC newSsrc) {
+    if (num < 0 || static_cast<unsigned>(num) >= getNumSSRC())
+        throw std::out_of_range("SSRC num out of range");
+    _ssrcs[num] = htonl(newSsrc);
+}
 
-void RtcpRemb::setSsrc(int num, SSRC newSsrc) { *(&_ssrcs + num) = htonl(newSsrc); }
+unsigned int RtcpRemb::getNumSSRC() const { return ntohl(_bitrate) >> 24u; }
 
-unsigned int RtcpRemb::getNumSSRC() { return ntohl(_bitrate) >> 24u; }
-
-unsigned int RtcpRemb::getBitrate() {
+unsigned int RtcpRemb::getBitrate() const {
 	uint32_t br = ntohl(_bitrate);
 	uint8_t exp = (br << 8u) >> 26u;
 	return (br & 0x3FFFF) * static_cast<unsigned int>(pow(2, exp));

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -576,12 +576,14 @@ void RtcpRemb::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
 	}
 
 	// "length" in packet is one less than the number of 32 bit words in the packet.
-	header.header.setLength(uint16_t((offsetof(RtcpRemb, _ssrc) / sizeof(uint32_t)) - 1 + numSSRC));
+	header.header.setLength(uint16_t((offsetof(RtcpRemb, _ssrcs) / sizeof(uint32_t)) - 1 + numSSRC));
 
 	_bitrate = htonl((numSSRC << (32u - 8u)) | (exp << (32u - 8u - 6u)) | in_bitrate);
 }
 
-void RtcpRemb::setSsrc(int iterator, SSRC newSssrc) { _ssrc[iterator] = htonl(newSssrc); }
+SSRC RtcpRemb::getSsrc(int num) const { return ntohl(*(&_ssrcs + num)); }
+
+void RtcpRemb::setSsrc(int num, SSRC newSsrc) { *(&_ssrcs + num) = htonl(newSsrc); }
 
 unsigned int RtcpRemb::getNumSSRC() { return ntohl(_bitrate) >> 24u; }
 


### PR DESCRIPTION
According to [REMB RFC](https://datatracker.ietf.org/doc/html/draft-alvestrand-rmcat-remb-03):

> SSRC of media source (32 bits): Always 0; this is the same convention as in [RFC5104] section 4.2.2.2 (TMMBN).
> ...
> SSRC feedback (32 bits) Consists of one or more SSRC entries which this feedback message applies to.

So `SSRC feedback` should be taken, not `SSRC of media source`
Also the number of `SSRC feedback` entries can be greater than 1