### PR TITLE
Fix build with libcxx 20.1.8

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -10,6 +10,7 @@
 
 #include "impl/utils.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <regex>
 


### PR DESCRIPTION
This include is required for `transform` since libcxx about version 20.1.8.
Error:
```
/root/src/configuration.cpp:30:7: error: no member named 'transform' in namespace 'std'
   30 |         std::transform(m.begin(), m.end(), result.begin(), [](const auto &sm) {
      |         ~~~~~^
1 error generated.

```