### PR TITLE
Fix candidate race condition on ICE transport destruction with libnice

### DIFF
--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -655,8 +655,17 @@ void IceTransport::addIceServer(IceServer server) {
 
 IceTransport::~IceTransport() {
 	PLOG_DEBUG << "Destroying ICE transport";
+
+	g_signal_handlers_disconnect_by_func(G_OBJECT(mNiceAgent.get()),
+	                 (gpointer)StateChangeCallback, this);
+	g_signal_handlers_disconnect_by_func(G_OBJECT(mNiceAgent.get()),
+	                 (gpointer)CandidateCallback, this);
+	g_signal_handlers_disconnect_by_func(G_OBJECT(mNiceAgent.get()),
+	                 (gpointer)GatheringDoneCallback, this);
+
 	nice_agent_attach_recv(mNiceAgent.get(), mStreamId, 1, g_main_loop_get_context(MainLoop->get()),
 	                       NULL, NULL);
+
 	nice_agent_remove_stream(mNiceAgent.get(), mStreamId);
 	mNiceAgent.reset();
 


### PR DESCRIPTION
This PR disconnect signal handers on ICE transport destruction with libnice. It should fix a race condition where the candidate callback is called after destruction.

Should fix https://github.com/paullouisageneau/libdatachannel/issues/1525