### PR TITLE
Parse simulcast layers (rids) including RFC 8851 attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,8 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_generation.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_parsing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/track.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/video_layers_allocation.cpp

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -153,8 +153,10 @@ public:
 		std::vector<string> attributes() const;
 		void addAttribute(string attr);
 		void removeAttribute(const string &attr);
-		void addRid(string rid);		// Just the name
-		void addRid(Rid rid);	// With RFC 8851 attributes
+		void addRid(string rid);	// Just the name
+		void addRid(Rid rid);		// With RFC 8851 attributes
+
+		std::vector<Rid> rids() const;
 
 		struct RTC_CPP_EXPORT ExtMap {
 			static int parseId(string_view description);

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -57,30 +57,8 @@ inline std::pair<string_view, string_view> parse_pair(string_view attr) {
 	return std::make_pair(std::move(key), std::move(value));
 }
 
-inline std::vector<string_view> split_into_list(string_view value, char ch) {
-	std::vector<string_view> result;
-
-	size_t pos = 0;
-	size_t end = value.size();
-	while (pos < end) {
-		auto i = value.find(ch, pos);
-		if (i == string_view::npos) {
-			i = end;
-		}
-
-		const auto substr = value.substr(pos, i - pos);
-		if (!substr.empty()) {
-			result.push_back(substr);
-		}
-
-		pos = i + 1;
-	}
-
-	return result;
-}
-
-inline std::vector<std::pair<string_view, string_view>> parse_attr_list(string_view attr_list) {
-	std::vector<std::pair<string_view, string_view>> attrs;
+inline std::vector<std::pair<string, string>> parse_attr_list(const string& attr_list) {
+	std::vector<std::pair<string, string>> attrs;
 
 	size_t pos = 0;
 	size_t end = attr_list.size();
@@ -96,7 +74,7 @@ inline std::vector<std::pair<string_view, string_view>> parse_attr_list(string_v
 			const auto key = key_value.substr(0, j);
 			const auto value = key_value.substr(j + 1);
 			if (!key.empty() && !value.empty()) {
-				attrs.push_back(std::make_pair(key, value));
+				attrs.emplace_back(key, value);
 			}
 		}
 
@@ -865,17 +843,17 @@ void Description::Entry::parseSdpLine(string_view line) {
 			mIsRemoved = false;
 		} else if (key == "rid") {
 			// "a:rid=foo send" or optionally "a:rid=foo send abc=def;x=y;m=n"
-			const auto list = split_into_list(value, ' ');
-			if (list.size() < 2 || list.size() > 3) {
+			const auto list = utils::explode(string(value), ' ');
+			if (list.size() < 2) {
 				throw std::invalid_argument("Invalid rid line \"" + string(line) + "\" in description");
 			}
 
-			const auto rid = list[0];
-			const auto direction = list[1];
+			const auto& rid = list[0];
+			const auto& direction = list[1];
 
-			auto builder = RidBuilder(string(rid));
+			auto builder = RidBuilder(rid);
 
-			if (list.size() == 3) {
+			if (list.size() >= 3) {
 				const auto attr_list_parsed = parse_attr_list(list[2]);
 				for (const auto& [attr_key, attr_value] : attr_list_parsed) {
 					if (attr_key == "max-width") {
@@ -887,7 +865,7 @@ void Description::Entry::parseSdpLine(string_view line) {
 					} else if (attr_key == "max-fps") {
 						builder.max_fps(to_integer<uint32_t>(attr_value));
 					} else {
-						builder.custom(string(attr_key), string(attr_value));
+						builder.custom(attr_key, attr_value);
 					}
 				}
 			}

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -57,6 +57,56 @@ inline std::pair<string_view, string_view> parse_pair(string_view attr) {
 	return std::make_pair(std::move(key), std::move(value));
 }
 
+inline std::vector<string_view> split_into_list(string_view value, char ch) {
+	std::vector<string_view> result;
+
+
+	size_t pos = 0;
+	size_t end = value.size();
+	while (pos < end) {
+		auto i = value.find(ch, pos);
+		if (i == string_view::npos) {
+			i = end;
+		}
+
+		const auto substr = value.substr(pos, i - pos);
+		if (!substr.empty()) {
+			result.push_back(substr);
+		}
+
+		pos = i + 1;
+	}
+
+	return result;
+}
+
+inline std::vector<std::pair<string_view, string_view>> parse_attr_list(string_view attr_list) {
+	std::vector<std::pair<string_view, string_view>> attrs;
+
+	size_t pos = 0;
+	size_t end = attr_list.size();
+	while (pos < end) {
+		auto i = attr_list.find(';', pos);
+		if (i == string_view::npos) {
+			i = end;
+		}
+
+		const auto key_value = attr_list.substr(pos, i - pos);
+		const auto j = key_value.find('=');
+		if (j != string_view::npos) {
+			const auto key = key_value.substr(0, j);
+			const auto value = key_value.substr(j + 1);
+			if (!key.empty() && !value.empty()) {
+				attrs.push_back(std::make_pair(key, value));
+			}
+		}
+
+		pos = i + 1;
+	}
+
+	return attrs;
+}
+
 template <typename T> T to_integer(string_view s) {
 	const string str(s);
 	try {
@@ -659,6 +709,10 @@ void Description::Entry::addRid(Rid rid) {
 	mRids.emplace_back(std::move(rid));
 }
 
+std::vector<Description::Rid> Description::Entry::rids() const {
+	return mRids;
+}
+
 void Description::removeAttribute(const string &attr) {
 	mAttributes.erase(
 	    std::remove_if(mAttributes.begin(), mAttributes.end(),
@@ -810,6 +864,40 @@ void Description::Entry::parseSdpLine(string_view line) {
 			// a bundled "m=" section from a BUNDLE group, the offerer [...] MUST NOT assign an SDP
 			// 'bundle-only' attribute to the "m=" section.
 			mIsRemoved = false;
+		} else if (key == "rid") {
+			// "a:rid=foo send" or optionally "a:rid=foo send abc=def;x=y;m=n"
+			const auto list = split_into_list(value, ' ');
+			if (list.size() < 2 || list.size() > 3) {
+				throw std::invalid_argument("Invalid rid line \"" + string(line) + "\" in description");
+			}
+
+			const auto rid = list[0];
+			const auto direction = list[1];
+			const auto attr_list = list.size() >= 3 ? list[2] : "";
+
+			auto builder = RidBuilder(string(rid));
+
+			if (!attr_list.empty()) {
+				const auto attr_list_parsed = parse_attr_list(attr_list);
+				for (const auto& [attr_key, attr_value] : attr_list_parsed) {
+					if (attr_key == "max-width") {
+						builder.max_width(to_integer<uint32_t>(attr_value));
+					} else if (attr_key == "max-height") {
+						builder.max_height(to_integer<uint32_t>(attr_value));
+					} else if (attr_key == "max-br") {
+						builder.max_br(to_integer<uint32_t>(attr_value));
+					} else if (attr_key == "max-fps") {
+						builder.max_fps(to_integer<uint32_t>(attr_value));
+					} else {
+						builder.custom(string(attr_key), string(attr_value));
+					}
+				}
+			}
+
+			// TODO - we don't store direction anywhere for now
+			(void) direction;
+
+			addRid(builder.build());
 		} else {
 			mAttributes.emplace_back(attr);
 		}

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -872,12 +872,11 @@ void Description::Entry::parseSdpLine(string_view line) {
 
 			const auto rid = list[0];
 			const auto direction = list[1];
-			const auto attr_list = list.size() >= 3 ? list[2] : "";
 
 			auto builder = RidBuilder(string(rid));
 
-			if (!attr_list.empty()) {
-				const auto attr_list_parsed = parse_attr_list(attr_list);
+			if (list.size() == 3) {
+				const auto attr_list_parsed = parse_attr_list(list[2]);
 				for (const auto& [attr_key, attr_value] : attr_list_parsed) {
 					if (attr_key == "max-width") {
 						builder.max_width(to_integer<uint32_t>(attr_value));

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -60,7 +60,6 @@ inline std::pair<string_view, string_view> parse_pair(string_view attr) {
 inline std::vector<string_view> split_into_list(string_view value, char ch) {
 	std::vector<string_view> result;
 
-
 	size_t pos = 0;
 	size_t end = value.size();
 	while (pos < end) {

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -26,7 +26,8 @@ TestResult test_connectivity_fail_on_wrong_fingerprint();
 TestResult test_pem();
 TestResult test_negotiated();
 TestResult test_reliability();
-TestResult test_simulcast_sdp();
+TestResult test_simulcast_sdp_generation();
+TestResult test_simulcast_sdp_parsing();
 TestResult test_turn_connectivity();
 TestResult test_track();
 TestResult test_video_layers_allocation();
@@ -77,7 +78,8 @@ static const vector<Test> tests = {
     // new Test("WebRTC TURN connectivity", test_turn_connectivity),
     Test("WebRTC negotiated DataChannel", test_negotiated),
     Test("WebRTC reliability mode", test_reliability),
-    Test("WebRTC simulcast SDP", test_simulcast_sdp),
+    Test("WebRTC simulcast SDP generation", test_simulcast_sdp_generation),
+    Test("WebRTC simulcast SDP parsing", test_simulcast_sdp_parsing),
 #if RTC_ENABLE_MEDIA
     Test("WebRTC track", test_track),
 	Test("WebRTC video layers allocation", test_video_layers_allocation),

--- a/test/simulcast_sdp_generation.cpp
+++ b/test/simulcast_sdp_generation.cpp
@@ -5,7 +5,7 @@
 using namespace rtc;
 using namespace std;
 
-TestResult test_simulcast_sdp() {
+TestResult test_simulcast_sdp_generation() {
 	InitLogger(LogLevel::Debug);
 
 	// Without attributes

--- a/test/simulcast_sdp_parsing.cpp
+++ b/test/simulcast_sdp_parsing.cpp
@@ -1,0 +1,96 @@
+#include "rtc/global.hpp"
+#include "rtc/description.hpp"
+#include "test.hpp"
+
+using namespace rtc;
+using namespace std;
+
+namespace {
+
+bool check_attribute(const std::vector<Description::RidAttribute>& attrs, string_view key, string_view value) {
+	return std::find_if(attrs.begin(), attrs.end(), [key, value](const Description::RidAttribute& attr) {
+		return attr.name() == key && attr.value() == value;
+	}) != attrs.end();
+}
+
+}
+
+TestResult test_simulcast_sdp_parsing() {
+	InitLogger(LogLevel::Debug);
+
+	// Simple
+	{
+		Description::Video video0("video0");
+		video0.parseSdpLine("a=rid:layer0 send");
+		video0.parseSdpLine("a=rid:layer1 send");
+		video0.parseSdpLine("a=rid:layer2 send");
+
+		const auto rid_list = video0.rids();
+		if (rid_list.size() != 3) {
+			return {false, "invalid rid list size"};
+		}
+
+		const auto& rid0 = rid_list[0];
+		if (rid0.rid() != "layer0") {
+			return {false, "rid does not have layer0"};
+		}
+		if (!rid0.attributes().empty()) {
+			return {false, "rid layer0 should not have attributes"};
+		}
+
+		const auto& rid1 = rid_list[1];
+		if (rid1.rid() != "layer1") {
+			return {false, "rid does not have layer1"};
+		}
+		if (!rid1.attributes().empty()) {
+			return {false, "rid layer1 should not have attributes"};
+		}
+
+		const auto& rid2 = rid_list[2];
+		if (rid2.rid() != "layer2") {
+			return {false, "rid does not have layer2"};
+		}
+		if (!rid2.attributes().empty()) {
+			return {false, "rid layer2 should not have attributes"};
+		}
+	}
+
+	// With attributes
+	{
+		Description::Video video0("video0");
+		video0.parseSdpLine("a=rid:layer0 send max-width=1920;max-height=1080;max-fps=60");
+		video0.parseSdpLine("a=rid:layer1 send max-height=720;max-fps=30;max-br=1500000;foo=bar");
+
+		const auto rid_list = video0.rids();
+		if (rid_list.size() != 2) {
+			return {false, "invalid rid list size"};
+		}
+
+		const auto& rid0 = rid_list[0];
+		if (rid0.rid() != "layer0") {
+			return {false, "rid does not have layer0"};
+		}
+		const auto& attrs0 = rid0.attributes();
+		if (attrs0.size() != 3 ||
+			!check_attribute(attrs0, "max-width", "1920") ||
+			!check_attribute(attrs0, "max-height", "1080") ||
+			!check_attribute(attrs0, "max-fps", "60")) {
+			return {false, "rid layer0 has invalid attributes"};
+		}
+
+		const auto& rid1 = rid_list[1];
+		if (rid1.rid() != "layer1") {
+			return {false, "rid does not have layer1"};
+		}
+		const auto& attrs1 = rid1.attributes();
+		if (attrs1.size() != 4 ||
+			!check_attribute(attrs1, "max-height", "720") ||
+			!check_attribute(attrs1, "max-fps", "30") ||
+			!check_attribute(attrs1, "max-br", "1500000") ||
+			!check_attribute(attrs1, "foo", "bar")) {
+			return {false, "rid layer1 has invalid attributes"};
+		}
+	}
+
+	return {true};
+}

--- a/test/simulcast_sdp_parsing.cpp
+++ b/test/simulcast_sdp_parsing.cpp
@@ -59,7 +59,7 @@ TestResult test_simulcast_sdp_parsing() {
 	{
 		Description::Video video0("video0");
 		video0.parseSdpLine("a=rid:layer0 send max-width=1920;max-height=1080;max-fps=60");
-		video0.parseSdpLine("a=rid:layer1 send max-height=720;max-fps=30;max-br=1500000;foo=bar");
+		video0.parseSdpLine("a=rid:layer1 send max-height=720;max-fps=20;max-fps=30;max-br=1500000;foo=bar");
 
 		const auto rid_list = video0.rids();
 		if (rid_list.size() != 2) {


### PR DESCRIPTION
As of now, `a=rid:foo` lines are parsed a generic attributes.

But `Description` now has a class to represent rid's, so we can use that.

This PR adds:

- Parsing simulcast rid's into `Rid` objects
- With RFC 8851 attributes (if present)

There are tests too.
