### PR TITLE
Fix compiling on gcc13 when -pedantic is used

### DIFF
--- a/include/rtc/frameinfo.hpp
+++ b/include/rtc/frameinfo.hpp
@@ -17,7 +17,7 @@ namespace rtc {
 
 struct RTC_CPP_EXPORT FrameInfo {
 	FrameInfo(uint32_t timestamp) : timestamp(timestamp) {};
-	template<typename Period = std::ratio<1>> FrameInfo(std::chrono::duration<double, Period> timestamp) : timestampSeconds(timestamp) {};
+	template<typename Period = std::ratio<1>> FrameInfo(std::chrono::duration<double, Period> timestamp) : timestampSeconds(timestamp) {}
 
 	[[deprecated]] FrameInfo(uint8_t payloadType, uint32_t timestamp) : timestamp(timestamp), payloadType(payloadType) {};
 


### PR DESCRIPTION
The template definition has an extra semicolon on it and gcc13 (as included in ubuntu 24.04) complains when this file is included in application code compiled with -pedantic