### PR TITLE
Added support for WebSocket to be passed a file descriptor

### DIFF
--- a/include/rtc/websocket.hpp
+++ b/include/rtc/websocket.hpp
@@ -54,6 +54,7 @@ public:
 	void forceClose();
 	bool send(const message_variant data) override;
 	bool send(const byte *data, size_t size) override;
+	void setSocket(int incomingSock);
 
 	optional<string> remoteAddress() const;
 	optional<string> path() const;

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -175,6 +175,7 @@ optional<message_variant> WebSocket::peek() {
 	return next ? std::make_optional(to_variant(std::move(**next))) : nullopt;
 }
 
+
 size_t WebSocket::availableAmount() const { return mRecvQueue.amount(); }
 
 bool WebSocket::changeState(State newState) { return state.exchange(newState) != newState; }
@@ -199,6 +200,15 @@ void WebSocket::incoming(message_ptr message) {
 		mRecvQueue.push(message);
 		triggerAvailable(mRecvQueue.size());
 	}
+}
+
+void WebSocket::setSocket(socket_t incomingSock) {
+	PLOG_VERBOSE << "Setting socket";
+
+	auto incoming = std::make_shared<TcpTransport>(incomingSock, nullptr);
+
+	changeState(WebSocket::State::Connecting);
+	setTcpTransport(incoming);
 }
 
 // Helper for WebSocket::initXTransport methods: start and emplace the transport

--- a/src/impl/websocket.hpp
+++ b/src/impl/websocket.hpp
@@ -40,6 +40,7 @@ struct WebSocket final : public Channel, public std::enable_shared_from_this<Web
 	void remoteClose();
 	bool outgoing(message_ptr message);
 	void incoming(message_ptr message);
+	void setSocket(socket_t incomingSock);
 
 	optional<message_variant> receive() override;
 	optional<message_variant> peek() override;

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -12,6 +12,7 @@
 #include "common.hpp"
 
 #include "impl/internals.hpp"
+#include "impl/socket.hpp"
 #include "impl/websocket.hpp"
 
 namespace rtc {
@@ -58,6 +59,8 @@ bool WebSocket::send(message_variant data) {
 bool WebSocket::send(const byte *data, size_t size) {
 	return impl()->outgoing(make_message(data, data + size, Message::Binary));
 }
+
+void WebSocket::setSocket(int incomingSock) { return impl()->setSocket(static_cast<socket_t>(incomingSock)); }
 
 optional<string> WebSocket::remoteAddress() const {
 	auto tcpTransport = impl()->getTcpTransport();


### PR DESCRIPTION
- Added a WebSocket::setSocket(int fd) method that allows an already-connected TCP socket to be handed directly to a WebSocket instance

The purpose of this function would be to support accepting WebSocket connections outside of WebSocketServer.  My use case for this would be to have a single program accepting connections then handing the file descriptor off to another process for promotion to a WebSocket.

How it works:
setSocket(int fd) wraps the provided file descriptor in a TcpTransport, sets the WebSocket state to Connecting, and registers it via the existing setTcpTransport() path. This reuses the same transport initialization used by WebSocketServer.