### PR TITLE
Update code to work with OpenSSL 4.0 which deprecated some functions.

### DIFF
--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -622,8 +622,11 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 
 		if (mIsClient && mHost) {
 			SSL_set_hostflags(mSsl, 0);
+#if OPENSSL_VERSION_NUMBER >= 0x40000000
+			openssl::check(SSL_set1_dnsname(mSsl, mHost->c_str()), "Failed to set SSL dnsname");
+#else
 			openssl::check(SSL_set1_host(mSsl, mHost->c_str()), "Failed to set SSL host");
-
+#endif
 			PLOG_VERBOSE << "Server Name Indication: " << *mHost;
 			SSL_set_tlsext_host_name(mSsl, mHost->c_str());
 		}


### PR DESCRIPTION
OpenSSL 4.0 deprecates SSL_set1_host in favor of SSL_set1_dnsname, so put a conditional version check and use the new one if using 4.0 or newer

* CI on Windows switched to using OpenSSL 4.0 since it got released and this fails all builds.