### PR TITLE
Fix race between DTLS ClientHello and registerIncoming()

### DIFF
--- a/src/impl/transport.cpp
+++ b/src/impl/transport.cpp
@@ -38,7 +38,24 @@ void Transport::unregisterIncoming() {
 
 Transport::State Transport::state() const { return mState; }
 
-void Transport::onRecv(message_callback callback) { mRecvCallback = std::move(callback); }
+void Transport::onRecv(message_callback callback) {
+	std::vector<message_ptr> pending;
+	{
+		std::lock_guard lock(mPendingMutex);
+		mRecvCallback = std::move(callback);
+		if (mRecvCallback)
+			pending = std::move(mPendingRecv);
+		else
+			mPendingRecv.clear();
+	}
+	for (auto &msg : pending) {
+		try {
+			mRecvCallback(msg);
+		} catch (const std::exception &e) {
+			PLOG_WARNING << e.what();
+		}
+	}
+}
 
 void Transport::onStateChange(state_callback callback) {
 	mStateChangeCallback = std::move(callback);
@@ -52,6 +69,17 @@ bool Transport::send(message_ptr message) { return outgoing(message); }
 
 void Transport::recv(message_ptr message) {
 	try {
+		std::unique_lock lock(mPendingMutex);
+		if (!mRecvCallback) {
+			// No callback registered yet; buffer the message for replay when
+			// onRecv() is called.  Bounded to avoid unbounded growth.
+			if (mPendingRecv.size() < 8)
+				mPendingRecv.push_back(std::move(message));
+			else
+				PLOG_WARNING << "dropping incoming message, no receive callback";
+			return;
+		}
+		lock.unlock();
 		mRecvCallback(message);
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();

--- a/src/impl/transport.hpp
+++ b/src/impl/transport.hpp
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <vector>
 
 namespace rtc::impl {
 
@@ -53,6 +55,13 @@ private:
 	synchronized_callback<message_ptr> mRecvCallback;
 
 	std::atomic<State> mState = State::Disconnected;
+
+	// Packets received before a callback is registered are held here and
+	// replayed when onRecv() is first called with a non-null callback.
+	// This prevents the ICE->DTLS and DTLS->SCTP races where one side
+	// sends its first packet before the other side has called registerIncoming().
+	std::mutex mPendingMutex;
+	std::vector<message_ptr> mPendingRecv;
 };
 
 } // namespace rtc::impl


### PR DESCRIPTION
## Problem

When two peers connect, the DTLS client can send its ClientHello before the remote peer has registered its incoming callback, causing the packet to be silently dropped. The connection then stalls until the DTLS retransmit timer fires (~1 second later).

This was discovered while building a fuzzer for RTC connections in libtorrent. In the fuzzer the message is reliably dropped, so every connection attempt incurred a 1-second delay before the handshake could proceed.

## Root cause

Each transport layer is created and started only after the layer below it completes its own handshake. The sequence for a WebRTC connection is:

  1. ICE handshake completes on both peers simultaneously
  2. Each peer's ICE state-change callback fires -> initDtlsTransport() is called -> `DtlsTransport::start()` -> `registerIncoming()` sets `IceTransport::onRecv`

The race lives in (2) ICE connecting on both peers is a concurrent event. The DTLS client peer (the offerer) calls `SSL_do_handshake()` / `gnutls_handshake()` and sends a ClientHello the moment its ICE connects. That ClientHello is a UDP datagram that can arrive at the DTLS server peer's `IceTransport::recv()` before the server peer has had a chance to create its DtlsTransport and call `registerIncoming()`.

## Fix

Queue any message that arrives in `Transport::recv()` when no handler is registered. When `onRecv()` is called, drain the queue before returning. A `std::mutex` guards the queue and the callback pointer together, preventing the A-B/B-A interleaving where a message is queued after the drain has already run.