### PR TITLE
Add size checks for REMB parsing and RTCP dispatching

### DIFF
--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -279,12 +279,14 @@ struct RTC_CPP_EXPORT RtcpRemb {
 	void setBitrate(unsigned int numSSRC, unsigned int in_bitrate);
 	SSRC getSSRC(int num) const;
 	void setSSRC(int num, SSRC newSsrc);
-	unsigned int getNumSSRC() const;
+	bool hasValidId() const;
+	int getSSRCCount() const;
 	unsigned int getBitrate() const;
 
 	// Deprecated
-	[[deprecated("Use setSSRC")]] void setSsrc(int num, SSRC newSssrc);
-	unsigned int getNumSSRC();
+	[[deprecated("use setSSRC")]] void setSsrc(int num, SSRC newSssrc);
+	[[deprecated("use getSSRCCount")]] unsigned int getNumSSRC() const;
+	[[deprecated("use getSSRCCount")]] unsigned int getNumSSRC();
 	unsigned int getBitrate();
 };
 

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -570,13 +570,13 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 	if (message->type == Message::Control) {
 		std::set<uint32_t> ssrcs;
 		size_t offset = 0;
-		while ((sizeof(RtcpHeader) + offset) <= message->size()) {
+		while (offset + sizeof(RtcpHeader) <= message->size()) {
 			auto header = reinterpret_cast<RtcpHeader *>(message->data() + offset);
-			if (header->lengthInBytes() > message->size() - offset) {
+			size_t length = header->lengthInBytes();
+			if (offset + length > message->size()) {
 				COUNTER_MEDIA_TRUNCATED++;
 				break;
 			}
-			offset += header->lengthInBytes();
 			if (header->payloadType() == 205) {
 				auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
 				ssrcs.insert(rtcpfb->packetSenderSSRC());
@@ -584,20 +584,15 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 			} else if (header->payloadType() == 206) {
 				auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
 				ssrcs.insert(rtcpfb->packetSenderSSRC());
-				if (header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
+				ssrcs.insert(rtcpfb->mediaSourceSSRC());
+				if (header->reportCount() == 15 && length >= sizeof(RtcpRemb)) {
 					auto remb = reinterpret_cast<RtcpRemb *>(header);
-					unsigned numSsrc = remb->getNumSSRC();
-					if (RtcpRemb::SizeWithSSRCs(numSsrc) > message->size() + header->lengthInBytes() - offset) {
-						continue;
-					}
-					if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
-						for (unsigned i = 0; i < numSsrc; i++) {
+					if (remb->hasValidId()) {
+						for (int i = 0; i < remb->getSSRCCount(); ++i) {
 							ssrcs.insert(remb->getSSRC(i));
 						}
-						continue;
 					}
 				}
-				ssrcs.insert(rtcpfb->mediaSourceSSRC());
 			} else if (header->payloadType() == 200) {
 				auto rtcpsr = reinterpret_cast<RtcpSr *>(header);
 				ssrcs.insert(rtcpsr->senderSSRC());
@@ -629,6 +624,7 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 					COUNTER_UNKNOWN_PACKET_TYPE++;
 				}
 			}
+			offset += header->lengthInBytes();
 		}
 
 		if (!ssrcs.empty()) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -577,45 +577,59 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 				COUNTER_MEDIA_TRUNCATED++;
 				break;
 			}
-			if (header->payloadType() == 205) {
-				auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
-				ssrcs.insert(rtcpfb->packetSenderSSRC());
-				ssrcs.insert(rtcpfb->mediaSourceSSRC());
-			} else if (header->payloadType() == 206) {
-				auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
-				ssrcs.insert(rtcpfb->packetSenderSSRC());
-				ssrcs.insert(rtcpfb->mediaSourceSSRC());
-				if (header->reportCount() == 15 && length >= sizeof(RtcpRemb)) {
-					auto remb = reinterpret_cast<RtcpRemb *>(header);
-					if (remb->hasValidId()) {
-						for (int i = 0; i < remb->getSSRCCount(); ++i) {
-							ssrcs.insert(remb->getSSRC(i));
-						}
+			switch(header->payloadType()) {
+			case 200: // SR
+				if (length >= sizeof(RtcpSr)) {
+					auto rtcpsr = reinterpret_cast<RtcpSr *>(header);
+					ssrcs.insert(rtcpsr->senderSSRC());
+					for (int i = 0; i < rtcpsr->header.reportCount(); ++i)
+						if (const auto *reportBlock = rtcpsr->getReportBlock(i))
+							ssrcs.insert(reportBlock->getSSRC());
+				}
+				break;
+
+			case 201: // RR
+				if (length >= sizeof(RtcpRr)) {
+					auto rtcprr = reinterpret_cast<RtcpRr *>(header);
+					ssrcs.insert(rtcprr->senderSSRC());
+					for (int i = 0; i < rtcprr->header.reportCount(); ++i)
+						if (const auto *reportBlock = rtcprr->getReportBlock(i))
+							ssrcs.insert(reportBlock->getSSRC());
+				}
+				break;
+
+			case 202: // SDES
+				if (length >= sizeof(RtcpSdes)) {
+					auto sdes = reinterpret_cast<RtcpSdes *>(header);
+					if (!sdes->isValid()) {
+						PLOG_WARNING << "RTCP SDES packet is invalid";
+						continue;
+					}
+					for (unsigned int i = 0; i < sdes->chunksCount(); i++) {
+						auto chunk = sdes->getChunk(i);
+						ssrcs.insert(chunk->ssrc());
 					}
 				}
-			} else if (header->payloadType() == 200) {
-				auto rtcpsr = reinterpret_cast<RtcpSr *>(header);
-				ssrcs.insert(rtcpsr->senderSSRC());
-				for (int i = 0; i < rtcpsr->header.reportCount(); ++i)
-					if (const auto *reportBlock = rtcpsr->getReportBlock(i))
-						ssrcs.insert(reportBlock->getSSRC());
-			} else if (header->payloadType() == 201) {
-				auto rtcprr = reinterpret_cast<RtcpRr *>(header);
-				ssrcs.insert(rtcprr->senderSSRC());
-				for (int i = 0; i < rtcprr->header.reportCount(); ++i)
-					if (const auto *reportBlock = rtcprr->getReportBlock(i))
-						ssrcs.insert(reportBlock->getSSRC());
-			} else if (header->payloadType() == 202) {
-				auto sdes = reinterpret_cast<RtcpSdes *>(header);
-				if (!sdes->isValid()) {
-					PLOG_WARNING << "RTCP SDES packet is invalid";
-					continue;
+				break;
+
+
+			case 205: // FB
+			case 206:
+				if (length >= sizeof(RtcpFbHeader)) {
+					auto rtcpfb = reinterpret_cast<RtcpFbHeader *>(header);
+					ssrcs.insert(rtcpfb->packetSenderSSRC());
+					ssrcs.insert(rtcpfb->mediaSourceSSRC());
+					if (header->payloadType() == 206 && header->reportCount() == 15 &&
+						length >= sizeof(RtcpRemb)) {
+						auto remb = reinterpret_cast<RtcpRemb *>(header);
+						if (remb->hasValidId())
+							for (int i = 0; i < remb->getSSRCCount(); ++i)
+								ssrcs.insert(remb->getSSRC(i));
+					}
 				}
-				for (unsigned int i = 0; i < sdes->chunksCount(); i++) {
-					auto chunk = sdes->getChunk(i);
-					ssrcs.insert(chunk->ssrc());
-				}
-			} else {
+				break;
+
+			default:
 				// PT=203 == Goodbye
 				// PT=204 == Application Specific
 				// PT=207 == Extended Report
@@ -623,6 +637,7 @@ void PeerConnection::dispatchMedia([[maybe_unused]] message_ptr message) {
 				    header->payloadType() != 207) {
 					COUNTER_UNKNOWN_PACKET_TYPE++;
 				}
+				break;
 			}
 			offset += header->lengthInBytes();
 		}

--- a/src/rembhandler.cpp
+++ b/src/rembhandler.cpp
@@ -24,17 +24,18 @@ RembHandler::RembHandler(std::function<void(unsigned int)> onRemb) : mOnRemb(onR
 void RembHandler::incoming(message_vector &messages, [[maybe_unused]] const message_callback &send) {
 	for (const auto &message : messages) {
 		size_t offset = 0;
-		while ((sizeof(RtcpHeader) + offset) <= message->size()) {
+		while (offset + sizeof(RtcpHeader) <= message->size()) {
 			auto header = reinterpret_cast<RtcpHeader *>(message->data() + offset);
-			uint8_t payload_type = header->payloadType();
+			size_t length = header->lengthInBytes();
+			if (offset + length > message->size())
+				break;
 
-			if (payload_type == 206 && header->reportCount() == 15 && header->lengthInBytes() >= sizeof(RtcpRemb)) {
+			if (header->payloadType() == 206 && header->reportCount() == 15 && length >= sizeof(RtcpRemb)) {
 				if (offset + sizeof(RtcpRemb) > message->size())
 					break;
 
 				auto remb = reinterpret_cast<RtcpRemb *>(message->data() + offset);
-
-				if (remb->_id[0] == 'R' && remb->_id[1] == 'E' && remb->_id[2] == 'M' && remb->_id[3] == 'B') {
+				if (remb->hasValidId()) {
 					mOnRemb(remb->getBitrate());
 					break;
 				}

--- a/src/rembhandler.cpp
+++ b/src/rembhandler.cpp
@@ -9,6 +9,8 @@
 #include "rembhandler.hpp"
 #include "rtp.hpp"
 
+#include "impl/internals.hpp"
+
 #ifdef _WIN32
 #include <winsock2.h>
 #else
@@ -36,7 +38,9 @@ void RembHandler::incoming(message_vector &messages, [[maybe_unused]] const mess
 
 				auto remb = reinterpret_cast<RtcpRemb *>(message->data() + offset);
 				if (remb->hasValidId()) {
-					mOnRemb(remb->getBitrate());
+					unsigned int bitrate = remb->getBitrate();
+					PLOG_DEBUG << "Got REMB, bitrate=" << bitrate;
+					mOnRemb(bitrate);
 					break;
 				}
 			}

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -597,23 +597,31 @@ void RtcpRemb::setBitrate(unsigned int numSSRC, unsigned int in_bitrate) {
 	}
 
 	// "length" in packet is one less than the number of 32 bit words in the packet.
-	header.header.setLength(uint16_t((offsetof(RtcpRemb, _ssrcs) / sizeof(uint32_t)) - 1 + numSSRC));
+	header.header.setLength(uint16_t((offsetof(RtcpRemb, _ssrcs) / sizeof(uint32_t)) + numSSRC - 1));
 
 	_bitrate = htonl((numSSRC << (32u - 8u)) | (exp << (32u - 8u - 6u)) | in_bitrate);
 }
 
 SSRC RtcpRemb::getSSRC(int num) const {
-    if (num < 0 || static_cast<unsigned>(num) >= getNumSSRC())
+    if (num < 0 || num >= getSSRCCount())
         throw std::out_of_range("SSRC num out of range");
     return ntohl(_ssrcs[num]);
 }
 void RtcpRemb::setSSRC(int num, SSRC newSsrc) {
-    if (num < 0 || static_cast<unsigned>(num) >= getNumSSRC())
+    if (num < 0 || num >= getSSRCCount())
         throw std::out_of_range("SSRC num out of range");
     _ssrcs[num] = htonl(newSsrc);
 }
 
-unsigned int RtcpRemb::getNumSSRC() const { return ntohl(_bitrate) >> 24u; }
+bool RtcpRemb::hasValidId() const {
+	return _id[0] == 'R' && _id[1] == 'E' && _id[2] == 'M' && _id[3] == 'B';
+}
+
+int RtcpRemb::getSSRCCount() const {
+	return std::min(
+		int(ntohl(_bitrate) >> 24u),
+		std::max(int(header.header.length() + 1 - offsetof(RtcpRemb, _ssrcs) / sizeof(uint32_t)), 0));
+}
 
 unsigned int RtcpRemb::getBitrate() const {
 	uint32_t br = ntohl(_bitrate);
@@ -622,13 +630,17 @@ unsigned int RtcpRemb::getBitrate() const {
 }
 
 void RtcpRemb::setSsrc(int num, SSRC newSsrc) {
-	if (num < 0 || static_cast<unsigned>(num) >= getNumSSRC())
+    if (num < 0 || num >= getSSRCCount())
 		throw std::out_of_range("SSRC num out of range");
     _ssrcs[num] = htonl(newSsrc);
 }
 
+unsigned int RtcpRemb::getNumSSRC() const {
+	return unsigned(getSSRCCount());
+}
+
 unsigned int RtcpRemb::getNumSSRC() {
-	return std::as_const(*this).getNumSSRC();
+	return unsigned(getSSRCCount());
 }
 
 unsigned int RtcpRemb::getBitrate() {

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -137,8 +137,8 @@ TestResult test_track() {
 	media2.setBitrate(3000);
 	media2.addSSRC(2468, "video-send");
 
-	// NOTE: Overwriting the old shared_ptr for t1 will cause it's respective
-	//       track to be dropped (so it's SSRCs won't be on the description next time)
+	// NOTE: Overwriting the old shared_ptr for t1 will cause the respective
+	//       track to be dropped (so its SSRCs won't be on the description next time)
 	t1 = pc1.addTrack(media2);
 
 	pc1.setLocalDescription();
@@ -151,14 +151,16 @@ TestResult test_track() {
 	if (!at2 || !at2->isOpen() || !t1->isOpen())
 		return TestResult(false, "Renegotiated track is not open");
 
+#if RTC_ENABLE_MEDIA
+	// RTP test
 	std::vector<std::byte> payload = {std::byte{0}, std::byte{1}, std::byte{2}, std::byte{3}};
 	std::vector<std::byte> rtpRaw(sizeof(RtpHeader) + payload.size());
 	auto *rtp = reinterpret_cast<RtpHeader *>(rtpRaw.data());
+	rtp->preparePacket();
 	rtp->setPayloadType(96);
 	rtp->setSeqNumber(1);
 	rtp->setTimestamp(3000);
 	rtp->setSsrc(2468);
-	rtp->preparePacket();
 	std::memcpy(rtpRaw.data() + sizeof(RtpHeader), payload.data(), payload.size());
 
 	if (!t1->send(rtpRaw.data(), rtpRaw.size())) {
@@ -167,7 +169,7 @@ TestResult test_track() {
 
 	// wait for an RTP packet to be received
 	auto future = recvRtpPromise.get_future();
-	if (future.wait_for(5s) == std::future_status::timeout) {
+	if (future.wait_for(2s) == std::future_status::timeout) {
 		throw runtime_error("Didn't receive RTP packet on pc2");
 	}
 
@@ -180,6 +182,32 @@ TestResult test_track() {
 	    memcmp(receivedRtpRaw.data(), rtpRaw.data(), rtpRaw.size()) != 0) {
 		throw runtime_error("Received RTP packet is different than the packet that was sent");
 	}
+
+	// RTCP REMB test
+	std::promise<unsigned int> rembPromise;
+	t1->setMediaHandler(make_shared<RembHandler>([&rembPromise](unsigned int bitrate) {
+		rembPromise.set_value(bitrate);
+	}));
+
+	std::vector<std::byte> rtcpRembRaw(RtcpRemb::SizeWithSSRCs(2));
+	auto *rtcpRemb = reinterpret_cast<RtcpRemb*>(rtcpRembRaw.data());
+	rtcpRemb->preparePacket(6666, 2, 1000000);
+	rtcpRemb->setSSRC(0, 2468);
+	rtcpRemb->setSSRC(1, 2469);
+	if (!t2->send(rtcpRembRaw.data(), rtcpRembRaw.size())) {
+		throw runtime_error("Couldn't send RTCP REMB message");
+	}
+
+	auto rembFuture = rembPromise.get_future();
+	if (rembFuture.wait_for(2s) == std::future_status::timeout) {
+		throw runtime_error("Didn't receive REMB message");
+	}
+
+	unsigned int bitrate = rembFuture.get();
+	if (bitrate != 1000000) {
+		throw runtime_error("Incorrect bitrate in REMB message");
+	}
+#endif
 
 	// Delay close of peer 2 to check closing works properly
 	pc1.close();


### PR DESCRIPTION
This PR adds size checks to REMB parsing (after #1500) and RTCP dispatching. It also refactors things a bit and adds a test for REMB.