### PR TITLE
Add abs-capture-time RTP header extension

### DIFF
--- a/include/rtc/frameinfo.hpp
+++ b/include/rtc/frameinfo.hpp
@@ -27,6 +27,16 @@ struct RTC_CPP_EXPORT FrameInfo {
 	optional<std::chrono::duration<double>> timestampSeconds;
 
 	bool isKeyFrame = false;	// Set by the application
+
+	/// Absolute capture timestamp in NTP-format (high 32 bits seconds since
+	/// the NTP epoch 1900-01-01 UTC; low 32 bits fractional seconds). When
+	/// set alongside an RtpPacketizationConfig with absCaptureTimeId > 0,
+	/// the RtpPacketizer writes the 8-byte form of the abs-capture-time RTP
+	/// header extension on every packet of this frame. Receivers use this
+	/// to recover the source's capture wallclock and compute glass-to-glass
+	/// latency.
+	/// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+	optional<uint64_t> absCaptureTimeNtp;
 };
 
 } // namespace rtc

--- a/include/rtc/rtppacketizationconfig.hpp
+++ b/include/rtc/rtppacketizationconfig.hpp
@@ -95,6 +95,14 @@ public:
 	uint8_t colorTransfer = 1;              // BT.709-6
 	uint8_t colorMatrix = 1;                // BT.709-6
 
+	// abs-capture-time RTP header extension. When absCaptureTimeId > 0 and an
+	// outgoing FrameInfo carries an absCaptureTimeNtp value, the RtpPacketizer
+	// writes the 8-byte (shortened) form of the abs-capture-time extension into
+	// every packet for that frame. The receiver can recover the source's
+	// capture wallclock and compute true glass-to-glass latency.
+	// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+	uint8_t absCaptureTimeId = 0;
+
 	/// Construct RTP configuration used in packetization process
 	/// @param ssrc SSRC of source
 	/// @param cname CNAME of source

--- a/include/rtc/rtppacketizer.hpp
+++ b/include/rtc/rtppacketizer.hpp
@@ -61,6 +61,11 @@ private:
 	uint32_t videoLayersAllocationInitialPacketCount = 0;
 	bool isGeneratingKeyFrame = false;
 
+	// Per-frame transient: NTP-format absolute capture time copied from the
+	// current FrameInfo by outgoing(), then read by packetize() to emit the
+	// abs-capture-time RTP header extension on every fragment of the frame.
+	optional<uint64_t> currentAbsCaptureTimeNtp;
+
 	bool shouldEmitVideoLayersAllocation();
 };
 

--- a/src/rtppacketizer.cpp
+++ b/src/rtppacketizer.cpp
@@ -32,6 +32,9 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 	const bool setVideoRotation =
 	    (rtpConfig->videoOrientationId != 0) && mark && (rtpConfig->videoOrientation != 0);
 
+	const bool setAbsCaptureTime =
+	    rtpConfig->absCaptureTimeId > 0 && currentAbsCaptureTimeNtp.has_value();
+
 	std::optional<DependencyDescriptorWriter> ddWriter;
 	if (rtpConfig->dependencyDescriptorContext.has_value()) {
 		ddWriter.emplace(*rtpConfig->dependencyDescriptorContext);
@@ -60,7 +63,8 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 	    (rtpConfig->mid.has_value() && rtpConfig->midId > 14) ||
 	    (rtpConfig->rid.has_value() && rtpConfig->ridId > 14) ||
 	    (videoLayersAllocationBuf.size() > 14 || rtpConfig->videoLayersAllocationId > 14) ||
-	    rtpConfig->playoutDelayId > 14) {
+	    rtpConfig->playoutDelayId > 14 ||
+	    (setAbsCaptureTime && rtpConfig->absCaptureTimeId > 14)) {
 		twoByteHeader = true;
 	}
 	size_t headerSize = twoByteHeader ? 2 : 1;
@@ -76,7 +80,10 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 
 	if (setColorSpace)
 		rtpExtHeaderSize += headerSize + 4;
-	
+
+	if (setAbsCaptureTime)
+		rtpExtHeaderSize += headerSize + 8;
+
 	if (rtpConfig->mid.has_value())
 		rtpExtHeaderSize += headerSize + rtpConfig->mid->length();
 
@@ -174,6 +181,20 @@ message_ptr RtpPacketizer::packetize(const binary &payload, bool mark) {
 			offset += extHeader->writeHeader(
 			    twoByteHeader, offset, rtpConfig->colorSpaceId, data, 4);
 		}
+
+		if (setAbsCaptureTime) {
+			// 8-byte (shortened) form: 64-bit NTP timestamp, network order.
+			// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+			uint64_t ntp = *currentAbsCaptureTimeNtp;
+			byte data[8] = {
+			    byte((ntp >> 56) & 0xFF), byte((ntp >> 48) & 0xFF),
+			    byte((ntp >> 40) & 0xFF), byte((ntp >> 32) & 0xFF),
+			    byte((ntp >> 24) & 0xFF), byte((ntp >> 16) & 0xFF),
+			    byte((ntp >> 8) & 0xFF),  byte(ntp & 0xFF)};
+
+			offset += extHeader->writeHeader(
+			    twoByteHeader, offset, rtpConfig->absCaptureTimeId, data, 8);
+		}
 	}
 
 	rtp->preparePacket();
@@ -207,6 +228,8 @@ void RtpPacketizer::outgoing(message_vector &messages,
 
 			if (frameInfo->isKeyFrame)
 				isGeneratingKeyFrame = true;
+
+			currentAbsCaptureTimeNtp = frameInfo->absCaptureTimeNtp;
 		}
 
 		auto payloads = fragment(std::move(*message));
@@ -221,6 +244,7 @@ void RtpPacketizer::outgoing(message_vector &messages,
 		}
 
 		isGeneratingKeyFrame = false;
+		currentAbsCaptureTimeNtp.reset();
 	}
 
 	messages.swap(result);


### PR DESCRIPTION
## Summary

Adds support for the `abs-capture-time` RTP header extension on the
sending side. Applications can stamp every outgoing frame with the
source's absolute capture wallclock in NTP format; receivers (Chrome,
Firefox, etc.) recover that timestamp via `RTCRtpReceiver` and
`requestVideoFrameCallback`'s `metadata.captureTime`, enabling true
glass-to-glass latency measurement.

Spec:
https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time

## Changes

* `RtpPacketizationConfig` gains `absCaptureTimeId` (the negotiated
  extension id from SDP `extmap`).
* `FrameInfo` gains `optional<uint64_t> absCaptureTimeNtp` carrying a
  per-frame 64-bit NTP timestamp (high 32 bits seconds since the NTP
  epoch, low 32 bits fractional).
* When both are set, `RtpPacketizer` writes the 8-byte (shortened)
  form of the extension on every packet of the frame, accounting for
  it in extension-block size and one-byte / two-byte header
  selection.

The receive side is intentionally out of scope for this PR.

## Wire format

8-byte (shortened) form: 64-bit NTP timestamp, network order. No
estimated capture clock offset. This matches the form Chrome emits
by default for outgoing media and is what Chrome's receiver expects
to surface `captureTime` to JS.

## Behaviour when not used

When `absCaptureTimeId` is `0` (default) the path is fully bypassed:
no extra bytes, no header changes. Existing applications are
unaffected.

## Diff size

49 insertions, 2 deletions across 4 files.

## Build

Verified locally on macOS (Apple clang, OpenSSL 3) with
`-DWARNINGS_AS_ERRORS=ON`. Clean build.