### PR TITLE
Add TCP connection timeout for WebSocket

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -101,8 +101,9 @@ struct WebSocketConfiguration {
 	bool disableTlsVerification = false; // if true, don't verify the TLS certificate
 	optional<ProxyServer> proxyServer;   // only non-authenticated http supported for now
 	std::vector<string> protocols;
-	optional<std::chrono::milliseconds> connectionTimeout; // zero to disable
-	optional<std::chrono::milliseconds> pingInterval;      // zero to disable
+	optional<std::chrono::milliseconds> tcpConnectionTimeout; // zero to disable
+	optional<std::chrono::milliseconds> connectionTimeout;    // zero to disable
+	optional<std::chrono::milliseconds> pingInterval;         // zero to disable
 	optional<int> maxOutstandingPings;
 	optional<string> caCertificatePemFile;
 	optional<string> certificatePemFile;

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -501,10 +501,11 @@ typedef struct {
 	const char *proxyServer;     // only non-authenticated http supported for now
 	const char **protocols;
 	int protocolsCount;
-	int connectionTimeoutMs; // in milliseconds, 0 means default, < 0 means disabled
-	int pingIntervalMs;      // in milliseconds, 0 means default, < 0 means disabled
-	int maxOutstandingPings; // 0 means default, < 0 means disabled
-	int maxMessageSize;      // <= 0 means default
+	int tcpConnectionTimeoutMs; // in milliseconds, 0 means default, < 0 means disabled
+	int connectionTimeoutMs;    // in milliseconds, 0 means default, < 0 means disabled
+	int pingIntervalMs;         // in milliseconds, 0 means default, < 0 means disabled
+	int maxOutstandingPings;    // 0 means default, < 0 means disabled
+	int maxMessageSize;         // <= 0 means default
 } rtcWsConfiguration;
 
 RTC_C_EXPORT int rtcCreateWebSocket(const char *url); // returns ws id

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1693,6 +1693,11 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 		for (int i = 0; i < config->protocolsCount; ++i)
 			c.protocols.emplace_back(string(config->protocols[i]));
 
+		if (config->tcpConnectionTimeoutMs > 0)
+			c.tcpConnectionTimeout = milliseconds(config->tcpConnectionTimeoutMs);
+		else if (config->tcpConnectionTimeoutMs < 0)
+			c.tcpConnectionTimeout = milliseconds::zero(); // setting to 0 disables,
+			                                            // not setting keeps default
 		if (config->connectionTimeoutMs > 0)
 			c.connectionTimeout = milliseconds(config->connectionTimeoutMs);
 		else if (config->connectionTimeoutMs < 0)

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -90,6 +90,10 @@ void TcpTransport::onBufferedAmount(amount_callback callback) {
 	mBufferedAmountCallback = std::move(callback);
 }
 
+void TcpTransport::setConnectTimeout(std::chrono::milliseconds connectTimeout) {
+	mConnectTimeout = connectTimeout;
+}
+
 void TcpTransport::setReadTimeout(std::chrono::milliseconds readTimeout) {
 	mReadTimeout = readTimeout;
 }
@@ -228,9 +232,8 @@ void TcpTransport::attempt() {
 		return;
 	}
 
-	const auto timeout = 10s;
-	PollService::Instance().add(mSock, {PollService::Direction::Out, timeout, 
-	    weak_bind(&TcpTransport::processConnect, this, _1)});
+	PollService::Instance().add(mSock, {PollService::Direction::Out, mConnectTimeout,
+	                                    weak_bind(&TcpTransport::processConnect, this, _1)});
 }
 
 void TcpTransport::createSocket(const struct sockaddr *addr, socklen_t addrlen) {

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -33,6 +33,7 @@ public:
 	~TcpTransport();
 
 	void onBufferedAmount(amount_callback callback);
+	void setConnectTimeout(std::chrono::milliseconds connectTimeout);
 	void setReadTimeout(std::chrono::milliseconds readTimeout);
 
 	void start() override;
@@ -64,6 +65,7 @@ private:
 	const bool mIsActive;
 	string mHostname, mService;
 	amount_callback mBufferedAmountCallback;
+	optional<std::chrono::milliseconds> mConnectTimeout;
 	optional<std::chrono::milliseconds> mReadTimeout;
 
 	std::list<std::tuple<struct sockaddr_storage, socklen_t>> mResolved;

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -267,6 +267,11 @@ shared_ptr<TcpTransport> WebSocket::setTcpTransport(shared_ptr<TcpTransport> tra
 		if (pingInterval > milliseconds::zero())
 			transport->setReadTimeout(pingInterval);
 
+		// Set TCP connect timeout if specified
+		auto connectTimeout = config.tcpConnectionTimeout.value_or(5000ms);
+		if (connectTimeout > milliseconds::zero())
+			transport->setConnectTimeout(connectTimeout);
+
 		scheduleConnectionTimeout();
 
 		return emplaceTransport(this, &mTcpTransport, std::move(transport));


### PR DESCRIPTION
This PR adds `WebSocketConfiguration::tcpConnectionTimeout` to change the TCP connection timeout, and reduces it to 5s by default.