### PR TITLE
Fix certificate generation with BoringSSL

### DIFF
--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -510,9 +510,6 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 	auto *commonNameBytes =
 	    reinterpret_cast<unsigned char *>(const_cast<char *>(commonName.c_str()));
 
-	if (!X509_set_pubkey(x509.get(), pkey.get()))
-		throw std::runtime_error("Unable to set certificate public key");
-
 	if (!X509_gmtime_adj(X509_getm_notBefore(x509.get()), 3600 * -1) ||
 	    !X509_gmtime_adj(X509_getm_notAfter(x509.get()), 3600 * 24 * 365) ||
 #if OPENSSL_VERSION_NUMBER >= 0x30000000
@@ -527,6 +524,9 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 	    !X509_set_subject_name(x509.get(), name.get()) ||
 	    !X509_set_issuer_name(x509.get(), name.get()))
 		throw std::runtime_error("Unable to set certificate properties");
+
+	if (!X509_set_pubkey(x509.get(), pkey.get()))
+		throw std::runtime_error("Unable to set certificate public key");
 
 	if (!X509_sign(x509.get(), pkey.get(), EVP_sha256()))
 		throw std::runtime_error("Unable to auto-sign certificate");


### PR DESCRIPTION
### Problem
When building `libdatachannel` in an environment that uses **BoringSSL** instead of standard OpenSSL (such as within the Matter/Project CHIP ecosystem), `Certificate::Generate` fails with a `runtime_error: Unable to set certificate public key`.

This seems to happen because `X509_set_pubkey` is called very early in the generation process, before setting the certificate version, serial number, and validity times. BoringSSL seems to be stricter and rejects setting the public key on a certificate that is not sufficiently initialized.

### Solution
Move the call to `X509_set_pubkey` to just before `X509_sign`, after all other properties (validity, version, serial, subject/issuer names) have been set. This makes the sequence compatible with BoringSSL while remaining compatible with standard OpenSSL.

### Testing / Reproduction
1. Build `libdatachannel` linking against BoringSSL.
2. Call `rtc::impl::Certificate::Generate(rtc::CertificateType::Ecdsa, "test")`.
3. Without this fix, it throws an exception. With this fix, it succeeds and returns a valid certificate.
