### PR TITLE
docs: add icey to External resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Features:
 - WebAssembly wrapper compatible with libdatachannel: [datachannel-wasm](https://github.com/paullouisageneau/datachannel-wasm)
 - Lightweight STUN/TURN server: [Violet](https://github.com/paullouisageneau/violet)
 - Native platform (Android/iOS/macOS) wrapper for libdatachannel: [datachannel-native](https://github.com/swarm-cloud/datachannel-native)
+- C++ media runtime built on libdatachannel with FFmpeg integration and signalling: [icey](https://github.com/nilstate/icey)
 
 ## Thanks
 


### PR DESCRIPTION
icey (https://github.com/nilstate/icey) is a C++20 media runtime built on libdatachannel. It adds an FFmpeg-based capture/encode/decode pipeline, Symple signalling, and an RFC 5766 TURN server around the WebRTC transport that libdatachannel provides.

Adding it to External resources alongside Violet and the various language bindings, on the same principle of "projects that extend or build directly on libdatachannel". Happy to relocate to a new "Projects using" section if you'd prefer that.