### PR TITLE
Fix heap-use-after-free in IceTransport::RecvCallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 option(SCTP_DEBUG "Enable SCTP debugging output to verbose log" OFF)
 option(RTC_UPDATE_VERSION_HEADER "Enable updating the version header" OFF)
+option(RTC_TEST_RECV_DELAY "Inject a test-only delay in IceTransport::RecvCallback to reliably expose teardown races under a sanitizer" OFF)
 
 if(NOT NO_MEDIA AND NOT PREFER_SYSTEM_LIB)
 	# libsrtp2 v2.7.0 requires cmake >= v3.21.0
@@ -220,6 +221,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/ice_recv_uaf.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_generation.cpp
@@ -473,6 +475,10 @@ if (USE_NICE)
 	find_package(LibNice REQUIRED)
 	target_compile_definitions(datachannel PRIVATE USE_NICE=1)
 	target_compile_definitions(datachannel-static PRIVATE USE_NICE=1)
+	if(RTC_TEST_RECV_DELAY)
+		target_compile_definitions(datachannel PRIVATE RTC_TEST_RECV_DELAY)
+		target_compile_definitions(datachannel-static PRIVATE RTC_TEST_RECV_DELAY)
+	endif()
 	target_link_libraries(datachannel PRIVATE LibNice::LibNice)
 	target_link_libraries(datachannel-static PRIVATE LibNice::LibNice)
 else()

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -13,6 +13,7 @@
 #include "utils.hpp"
 
 #include <algorithm>
+#include <future>
 #include <iostream>
 #include <random>
 #include <sstream>
@@ -665,6 +666,27 @@ IceTransport::~IceTransport() {
 
 	nice_agent_attach_recv(mNiceAgent.get(), mStreamId, 1, g_main_loop_get_context(MainLoop->get()),
 	                       NULL, NULL);
+
+	// Synchronize with the libnice main loop thread BEFORE freeing the
+	// stream's rx buffer (nice_agent_remove_stream below) or `this`. The
+	// detach above prevents new dispatches, but a callback (e.g.
+	// RecvCallback) may already be running on the main loop thread with
+	// `this` as userData and `buf` pointing into libnice's stream rx buffer.
+	// Post a barrier task to the main context and wait for it to run; GLib
+	// dispatches sources serially on that thread, so once our task runs no
+	// callback can still be using `this` or the rx buffer.
+	{
+		std::promise<void> barrier;
+		auto future = barrier.get_future();
+		g_main_context_invoke_full(
+		    g_main_loop_get_context(MainLoop->get()), G_PRIORITY_HIGH,
+		    [](gpointer data) -> gboolean {
+			    static_cast<std::promise<void> *>(data)->set_value();
+			    return G_SOURCE_REMOVE;
+		    },
+		    &barrier, NULL);
+		future.wait();
+	}
 
 	nice_agent_remove_stream(mNiceAgent.get(), mStreamId);
 	mNiceAgent.reset();

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -18,6 +18,11 @@
 #include <random>
 #include <sstream>
 
+#ifdef RTC_TEST_RECV_DELAY
+#include <chrono>
+#include <thread>
+#endif
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -912,6 +917,12 @@ void IceTransport::StateChangeCallback(NiceAgent * /*agent*/, guint /*streamId*/
 void IceTransport::RecvCallback(NiceAgent * /*agent*/, guint /*streamId*/, guint /*componentId*/,
                                 guint len, gchar *buf, gpointer userData) {
 	auto iceTransport = static_cast<rtc::impl::IceTransport *>(userData);
+#ifdef RTC_TEST_RECV_DELAY
+	// Test-only: widen the window between userData-load and dereference so
+	// teardown races against in-flight RecvCallback dispatches reliably
+	// surface under a sanitizer. Never compiled into production.
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+#endif
 	try {
 		PLOG_VERBOSE << "Incoming size=" << len;
 		auto b = reinterpret_cast<byte *>(buf);

--- a/test/ice_recv_uaf.cpp
+++ b/test/ice_recv_uaf.cpp
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2026 libdatachannel contributors
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+// Regression stress test for the IceTransport teardown race against an
+// in-flight libnice RecvCallback (originally observed as a heap-use-after-free
+// in IceTransport::RecvCallback while ~IceTransport ran on the RTC worker).
+//
+// On a stock build the race window is narrow and this test only catches
+// regressions probabilistically — it should be run under ASan or TSan in CI.
+//
+// Configure with -DRTC_TEST_RECV_DELAY=ON to inject a 50 ms sleep into
+// IceTransport::RecvCallback. With the hook on, this test deterministically
+// triggers the UAF on a broken tree within the first few iterations under a
+// sanitizer. The hook is never compiled into production builds.
+
+#include "rtc/rtc.hpp"
+#include "test.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+
+using namespace rtc;
+using namespace std::chrono_literals;
+
+namespace {
+
+bool run_one_cycle() {
+	Configuration cfg;
+	cfg.iceServers.clear(); // host-only candidates; all-local
+
+	auto pc1 = std::make_shared<PeerConnection>(cfg);
+	auto pc2 = std::make_shared<PeerConnection>(cfg);
+
+	pc1->onLocalDescription([&pc2](Description sdp) {
+		pc2->setRemoteDescription(std::string(sdp));
+	});
+	pc1->onLocalCandidate([&pc2](Candidate c) {
+		pc2->addRemoteCandidate(std::string(c));
+	});
+	pc2->onLocalDescription([&pc1](Description sdp) {
+		pc1->setRemoteDescription(std::string(sdp));
+	});
+	pc2->onLocalCandidate([&pc1](Candidate c) {
+		pc1->addRemoteCandidate(std::string(c));
+	});
+
+	std::shared_ptr<DataChannel> dc2;
+	pc2->onDataChannel([&dc2](std::shared_ptr<DataChannel> dc) {
+		std::atomic_store(&dc2, dc);
+		dc->onMessage([wdc = std::weak_ptr<DataChannel>(dc)](auto) {
+			if (auto d = wdc.lock())
+				d->send("pong");
+		});
+	});
+
+	auto dc1 = pc1->createDataChannel("uafrepro");
+	std::atomic<bool> opened{false};
+	dc1->onOpen([&opened, wdc = std::weak_ptr<DataChannel>(dc1)]() {
+		opened = true;
+		if (auto d = wdc.lock()) {
+			// Burst messages so RecvCallback is actively dispatching
+			// when we tear down below.
+			for (int i = 0; i < 200; ++i)
+				d->send("ping");
+		}
+	});
+	dc1->onMessage([wdc = std::weak_ptr<DataChannel>(dc1)](auto) {
+		if (auto d = wdc.lock())
+			d->send("ping");
+	});
+
+	for (int i = 0; i < 300 && !opened; ++i)
+		std::this_thread::sleep_for(10ms);
+
+	if (!opened)
+		return false;
+
+	// Let data flow briefly so callbacks are pending in the libnice main
+	// loop, then drop both peers — this is the moment the original UAF
+	// fired.
+	std::this_thread::sleep_for(50ms);
+	pc1.reset();
+	pc2.reset();
+	return true;
+}
+
+} // namespace
+
+TestResult test_ice_recv_uaf() {
+	// 50 cycles is enough to occasionally hit the race under ASan/TSan
+	// without blowing up CI wall time. A real regression keeps failing
+	// across runs.
+	constexpr int kIterations = 50;
+	int opened = 0;
+	for (int i = 0; i < kIterations; ++i) {
+		if (run_one_cycle())
+			++opened;
+	}
+	if (opened < kIterations / 2)
+		return TestResult(false, "too few iterations actually connected; check local network");
+	return TestResult(true);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -41,6 +41,7 @@ TestResult test_capi_track();
 TestResult test_websocket();
 TestResult test_websocketserver();
 TestResult test_capi_websocketserver();
+TestResult test_ice_recv_uaf();
 size_t benchmark(chrono::milliseconds duration);
 
 void test_benchmark() {
@@ -83,6 +84,7 @@ static const vector<Test> tests = {
     // Test("WebRTC TURN connectivity", test_turn_connectivity),
     Test("WebRTC negotiated DataChannel", test_negotiated),
     Test("WebRTC reliability mode", test_reliability),
+    Test("ICE transport recv UAF stress", test_ice_recv_uaf),
     Test("WebRTC simulcast SDP generation", test_simulcast_sdp_generation),
     Test("WebRTC simulcast SDP parsing", test_simulcast_sdp_parsing),
 #if RTC_ENABLE_MEDIA


### PR DESCRIPTION
The first commit contains the actual fix.
The second commit contains a test to reproduce the issue.
However the test will only work when built with the address sanitizer (which is currently not the case in the CI).
So I'm not really sure if you'd want to add the test itself.

This test should fail when running without the fix and succeed when running with the fix.
(To make the test fail reliably, a sleep is added in RecvCallback)

```bash
  # Configure: libnice backend + ASan + the test-only delay hook
  cmake -B build-asan-nice \
    -DUSE_NICE=ON \
    -DRTC_TEST_RECV_DELAY=ON \
    -DCMAKE_BUILD_TYPE=Debug \
    -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" \
    -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -g" \
    -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
    -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address"

 cmake --build build-asan-nice --target datachannel-tests -j

 # Run only the new test
 ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1 \
    ./build-asan-nice/tests
```

Explanation by AI:
```
## Summary

  Fixes a heap-use-after-free in `IceTransport::RecvCallback` when a
  `PeerConnection` is destroyed while a libnice `RecvCallback` is mid-dispatch
  on the libnice main-loop thread. `nice_agent_attach_recv(NULL, NULL)` only
  suppresses *future* dispatches and does not join an already-in-flight
  callback, so the destructor can free the `IceTransport` (and, via
  `nice_agent_remove_stream`, the stream's rx buffer) out from under it.

  The branch has two commits:

  1. **`Fix UAF in ~IceTransport against in-flight libnice RecvCallback`** —
     the actual fix. Posts a high-priority barrier task on the libnice main
     context after the detach and waits for it to run; GLib dispatches
     sources serially on that thread, so once the barrier completes neither
     `this` nor the rx buffer can still be in use. The barrier is placed
     *between* the detach and `nice_agent_remove_stream` so it also protects
     the buffer that `RecvCallback`'s `buf` argument points into.

  2. **`Add stress test and opt-in delay hook for ~IceTransport teardown race`** —
     a regression test (`test/ice_recv_uaf.cpp`) plus an opt-in CMake flag
     `RTC_TEST_RECV_DELAY` that injects a 50 ms sleep into `RecvCallback`
     between the `userData` load and the dereference. With the hook on, the
     test deterministically reproduces the UAF on a broken tree within the
     first few iterations under a sanitizer. The hook lives behind `#ifdef`
     and pulls its `<chrono>`/`<thread>` includes only when defined, so
     production builds get nothing.

```