### PR TITLE
Expose ICE restart through the C API

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -213,6 +213,14 @@ RTC_C_EXPORT int rtcSetGatheringStateChangeCallback(int pc, rtcGatheringStateCal
 RTC_C_EXPORT int rtcSetSignalingStateChangeCallback(int pc, rtcSignalingStateCallbackFunc cb);
 
 RTC_C_EXPORT int rtcSetLocalDescription(int pc, const char *type); // type may be NULL
+// Same as rtcSetLocalDescription, but allows supplying fresh ICE
+// credentials. When both iceUfrag and icePwd are non-NULL on a
+// previously-connected PC, the call performs an ICE restart: the new
+// credentials replace the existing ones and a fresh gathering cycle
+// is kicked off. Passing NULL for either of iceUfrag/icePwd is
+// equivalent to rtcSetLocalDescription. type may be NULL.
+RTC_C_EXPORT int rtcSetLocalDescriptionEx(int pc, const char *type, const char *iceUfrag,
+                                          const char *icePwd);
 RTC_C_EXPORT int rtcSetRemoteDescription(int pc, const char *sdp, const char *type);
 RTC_C_EXPORT int rtcAddRemoteCandidate(int pc, const char *cand, const char *mid);
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -570,6 +570,22 @@ int rtcSetLocalDescription(int pc, const char *type) {
 	});
 }
 
+int rtcSetLocalDescriptionEx(int pc, const char *type, const char *iceUfrag,
+                             const char *icePwd) {
+	return wrap([&] {
+		auto peerConnection = getPeerConnection(pc);
+		LocalDescriptionInit init;
+		if (iceUfrag)
+			init.iceUfrag = std::string(iceUfrag);
+		if (icePwd)
+			init.icePwd = std::string(icePwd);
+		peerConnection->setLocalDescription(type ? Description::stringToType(type)
+		                                         : Description::Type::Unspec,
+		                                    std::move(init));
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcSetRemoteDescription(int pc, const char *sdp, const char *type) {
 	return wrap([&] {
 		auto peerConnection = getPeerConnection(pc);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -162,8 +162,20 @@ void PeerConnection::setLocalDescription(Description::Type type, LocalDescriptio
 			setLocalDescription(Description::Type::Offer);
 	}
 
-	if (impl()->gatheringState == GatheringState::New && !impl()->config.disableAutoGathering) {
-		iceTransport->gatherLocalCandidates(impl()->localBundleMid());
+	if (!impl()->config.disableAutoGathering) {
+		const bool iceRestart = init.iceUfrag.has_value() && init.icePwd.has_value();
+		if (impl()->gatheringState == GatheringState::New) {
+			iceTransport->gatherLocalCandidates(impl()->localBundleMid());
+		} else if (iceRestart) {
+			// Caller supplied fresh ICE credentials — perform an ICE
+			// restart: roll the gathering state back to InProgress and
+			// re-gather candidates against the new ufrag/pwd. The
+			// resulting GatheringState::Complete callback fires once
+			// the new cycle finishes, so consumers waiting on a fresh
+			// gather-complete (W3C ICE restart semantics) wake up.
+			impl()->changeGatheringState(GatheringState::InProgress);
+			iceTransport->gatherLocalCandidates(impl()->localBundleMid());
+		}
 	}
 }
 


### PR DESCRIPTION
## Motivation

Long-running PeerConnections (federation transports, P2P signalling channels) need to recover from `ICEState::FAILED` without tearing down the DTLS/SCTP layers above. The W3C-spec way is an ICE restart — re-run ICE on the existing PC while leaving DTLS and SCTP intact — but today neither path through libdatachannel's C API can trigger one.

Two structural gaps in the current code:

1. **No way to pass fresh ICE credentials.** `rtcSetLocalDescription(int pc, const char *type)` (`src/capi.cpp:564`) doesn't plumb `LocalDescriptionInit::iceUfrag` / `icePwd`. The second call regenerates the SDP from the *existing* `iceTransport`, so the new offer carries the **same** ufrag/pwd as the first one — that isn't an ICE restart, just re-signalling.
2. **No re-gather, so `GatheringState::Complete` never re-fires.** `setLocalDescription` only calls `gatherLocalCandidates` when `gatheringState == GatheringState::New` (`src/peerconnection.cpp:165`). After the first connect, that's `Complete`, so no new gather cycle. `changeGatheringState` early-returns when the state is unchanged, so the gathering-state callback never re-fires either. Any caller waiting on a fresh gather-complete hangs forever.

## Changes

* **New C API `rtcSetLocalDescriptionEx(pc, type, iceUfrag, icePwd)`** — same shape as `rtcSetLocalDescription` plus two optional credential parameters. Non-NULL `iceUfrag` + `icePwd` plumb through `LocalDescriptionInit` to the existing C++ `setLocalDescription(type, init)` path. NULL credentials retain the original `rtcSetLocalDescription` semantics.
* **`setLocalDescription` now re-runs ICE gathering when the caller supplies fresh credentials**, even if the previous gathering cycle reached `Complete`. Rolls the gathering state back to `InProgress` (so the `Complete` callback fires again at the end of the new cycle) and calls `gatherLocalCandidates`.

No changes to existing C API signatures. `rtcSetLocalDescription` callers see no behaviour change; ICE-restart support is opt-in via the new `Ex` function.

## Test plan

- [ ] Build with the new function compiled in (`-DUSE_SYSTEM_OPENSSL`, default cmake config).
- [ ] Loopback PC pair: handshake → CONNECTED → call `rtcSetLocalDescriptionEx(pc, "offer", fresh_ufrag, fresh_pwd)` → the new SDP carries `fresh_ufrag` / `fresh_pwd` (different from the original).
- [ ] `GatheringState::InProgress` callback fires on restart; `Complete` callback fires again at the end of the new cycle.
- [ ] DataChannel established before the restart continues to carry traffic afterwards (SCTP layer survives).

## Downstream usage

[social-home-io/aiolibdatachannel](https://github.com/social-home-io/aiolibdatachannel) is the immediate consumer — async Python wrapper that exposes `PeerConnection.restart_ice()` on top of this new C API.