### PR TITLE
fixed sendFrame signature correctly report errors

### DIFF
--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -43,8 +43,8 @@ public:
 	bool isClosed(void) const override;
 	size_t maxMessageSize() const override;
 
-	void sendFrame(binary data, FrameInfo info);
-	void sendFrame(const byte *data, size_t size, FrameInfo info);
+	bool sendFrame(binary data, FrameInfo info);
+	bool sendFrame(const byte *data, size_t size, FrameInfo info);
 	void onFrame(std::function<void(binary data, FrameInfo info)> callback);
 
 	bool requestKeyframe(SSRC ssrc=0, bool retransmit=false);

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -42,12 +42,12 @@ bool Track::isClosed(void) const { return impl()->isClosed(); }
 
 size_t Track::maxMessageSize() const { return impl()->maxMessageSize(); }
 
-void Track::sendFrame(binary data, FrameInfo info) {
-	impl()->outgoing(make_message(std::move(data), std::make_shared<FrameInfo>(std::move(info))));
+bool Track::sendFrame(binary data, FrameInfo info) {
+	return impl()->outgoing(make_message(std::move(data), std::make_shared<FrameInfo>(std::move(info))));
 }
 
-void Track::sendFrame(const byte *data, size_t size, FrameInfo info) {
-	sendFrame(binary(data, data + size), std::move(info));
+bool Track::sendFrame(const byte *data, size_t size, FrameInfo info) {
+	return sendFrame(binary(data, data + size), std::move(info));
 }
 
 void Track::onFrame(std::function<void(binary data, FrameInfo frame)> callback) {


### PR DESCRIPTION
Simply changed the signatures of the Track::sendFrame() overrides to not silently drop errors

See [Issue #1575](https://github.com/paullouisageneau/libdatachannel/issues/1575)