### PR TITLE
Export remaining C-API symbols for the Windows DLL  

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -475,20 +475,20 @@ RTC_C_EXPORT int rtcGetTrackRtcpSyncTimestamps(int tr, uint64_t *rtpTimestamp, u
 
 // Get all available payload types for given codec and stores them in buffer, does nothing if
 // buffer is NULL
-int rtcGetTrackPayloadTypesForCodec(int tr, const char *ccodec, int *buffer, int size);
+RTC_C_EXPORT int rtcGetTrackPayloadTypesForCodec(int tr, const char *ccodec, int *buffer, int size);
 
 // Get all SSRCs for given track
-int rtcGetSsrcsForTrack(int tr, uint32_t *buffer, int count);
+RTC_C_EXPORT int rtcGetSsrcsForTrack(int tr, uint32_t *buffer, int count);
 
 // Get CName for SSRC
-int rtcGetCNameForSsrc(int tr, uint32_t ssrc, char *cname, int cnameSize);
+RTC_C_EXPORT int rtcGetCNameForSsrc(int tr, uint32_t ssrc, char *cname, int cnameSize);
 
 // Get all SSRCs for given media type in given SDP
-int rtcGetSsrcsForType(const char *mediaType, const char *sdp, uint32_t *buffer, int bufferSize);
+RTC_C_EXPORT int rtcGetSsrcsForType(const char *mediaType, const char *sdp, uint32_t *buffer, int bufferSize);
 
 // Set SSRC for given media type in given SDP
-int rtcSetSsrcForType(const char *mediaType, const char *sdp, char *buffer, const int bufferSize,
-                      rtcSsrcForTypeInit *init);
+RTC_C_EXPORT int rtcSetSsrcForType(const char *mediaType, const char *sdp, char *buffer, const int bufferSize,
+                                   rtcSsrcForTypeInit *init);
 
 // For backward compatibility, do not use
 RTC_C_EXPORT RTC_DEPRECATED int rtcSetNeedsToSendRtcpSr(int id);


### PR DESCRIPTION
# Prolog

This PR is part of a series to enable Python bindings for `libdatachannel`.

I am not a C/C++ developer, so this implementation was built with assistance from Claude AI. However, the code is functional and has been thoroughly tested; it is currently running in our [development](https://github.com/facefusion/facefusion/tree/v4) branch, supporting a cross-platform (Linux, Windows, macOS) WHIP/WHEP pipeline with `libaom`, `libvpx`, and `libopus`.

# Description

**Export the remaining public C API symbols so they are usable from the Windows DLL.**

Five functions are declared in `include/rtc/rtc.h` **without** the `RTC_C_EXPORT` macro:

- `rtcGetTrackPayloadTypesForCodec`
- `rtcGetSsrcsForTrack`
- `rtcGetCNameForSsrc`
- `rtcGetSsrcsForType`
- `rtcSetSsrcForType`

They are fully implemented in `src/capi.cpp` and work on Linux/macOS because symbols there default to public visibility. On Windows, however, exports are gated by `__declspec(dllexport)` via `RTC_C_EXPORT`, so these five are **not exported from the DLL** and cannot be linked by consumers (e.g. language bindings loading the shared library).

This PR simply prepends `RTC_C_EXPORT` to the five declarations to match every other public function in the header.

### Notes

- No new code and no behavior change on Linux/macOS — only the export attribute is added.
- These are the only public declarations in `rtc.h` currently missing the macro.

### Files

- `include/rtc/rtc.h`
