### PR TITLE
Add missing C-API depacketizer/packetizer setters

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -1055,6 +1055,7 @@ int rtcSetH264Packetizer(int tr, const rtcPacketizerInit *init)
 int rtcSetH265Packetizer(int tr, const rtcPacketizerInit *init)
 int rtcSetAV1Packetizer(int tr, const rtcPacketizerInit *init)
 int rtcSetVP8Packetizer(int tr, const rtcPacketizerInit *init)
+int rtcSetVP9Packetizer(int tr, const rtcPacketizerInit *init)
 int rtcSetOpusPacketizer(int tr, const rtcPacketizerInit *init)
 int rtcSetAACPacketizer(int tr, const rtcPacketizerInit *init)
 int rtcSetPCMUPacketizer(int tr, const rtcPacketizerInit *init)
@@ -1076,8 +1077,13 @@ Return value: `RTC_ERR_SUCCESS` or a negative error code
 ```
 int rtcSetH264Depacketizer(int tr, rtcNalUnitSeparator nalSeparator)
 int rtcSetH265Depacketizer(int tr, rtcNalUnitSeparator nalSeparator)
+int rtcSetVP8Depacketizer(int tr)
+int rtcSetVP9Depacketizer(int tr)
 int rtcSetOpusDepacketizer(int tr)
 int rtcSetAACDepacketizer(int tr)
+int rtcSetPCMUDepacketizer(int tr)
+int rtcSetPCMADepacketizer(int tr)
+int rtcSetG722Depacketizer(int tr)
 ```
 
 Sets a depacketizer on a Track, which will reassemble incoming RTP packets into media frames. The depacketizer is set as the media handler on the track.

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -403,6 +403,7 @@ RTC_C_EXPORT int rtcSetH264Packetizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetH265Packetizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetAV1Packetizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetVP8Packetizer(int tr, const rtcPacketizerInit *init);
+RTC_C_EXPORT int rtcSetVP9Packetizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetOpusPacketizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetAACPacketizer(int tr, const rtcPacketizerInit *init);
 RTC_C_EXPORT int rtcSetPCMUPacketizer(int tr, const rtcPacketizerInit *init);
@@ -412,8 +413,13 @@ RTC_C_EXPORT int rtcSetG722Packetizer(int tr, const rtcPacketizerInit *init);
 // Set a depacketizer on track
 RTC_C_EXPORT int rtcSetH264Depacketizer(int tr, rtcNalUnitSeparator nalSeparator);
 RTC_C_EXPORT int rtcSetH265Depacketizer(int tr, rtcNalUnitSeparator nalSeparator);
+RTC_C_EXPORT int rtcSetVP8Depacketizer(int tr);
+RTC_C_EXPORT int rtcSetVP9Depacketizer(int tr);
 RTC_C_EXPORT int rtcSetOpusDepacketizer(int tr);
 RTC_C_EXPORT int rtcSetAACDepacketizer(int tr);
+RTC_C_EXPORT int rtcSetPCMUDepacketizer(int tr);
+RTC_C_EXPORT int rtcSetPCMADepacketizer(int tr);
+RTC_C_EXPORT int rtcSetG722Depacketizer(int tr);
 
 // Deprecated, do not use
 RTC_DEPRECATED static inline int

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1363,6 +1363,21 @@ int rtcSetVP8Packetizer(int tr, const rtcPacketizerInit *init) {
 	});
 }
 
+int rtcSetVP9Packetizer(int tr, const rtcPacketizerInit *init) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		// create RTP configuration
+		auto rtpConfig = createRtpPacketizationConfig(init);
+		emplaceRtpConfig(rtpConfig, tr);
+		// create packetizer
+		auto maxFragmentSize =
+		    init && init->maxFragmentSize ? init->maxFragmentSize : RTC_DEFAULT_MAX_FRAGMENT_SIZE;
+		auto packetizer = std::make_shared<VP9RtpPacketizer>(rtpConfig, maxFragmentSize);
+		track->setMediaHandler(packetizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcSetOpusPacketizer(int tr, const rtcPacketizerInit *init) {
 	return wrap([&] {
 		auto track = getTrack(tr);
@@ -1448,6 +1463,24 @@ int rtcSetH265Depacketizer(int tr, rtcNalUnitSeparator nalSeparator) {
 	});
 }
 
+int rtcSetVP8Depacketizer(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto depacketizer = std::make_shared<VP8RtpDepacketizer>();
+		track->setMediaHandler(depacketizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSetVP9Depacketizer(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto depacketizer = std::make_shared<VP9RtpDepacketizer>();
+		track->setMediaHandler(depacketizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcSetOpusDepacketizer(int tr) {
 	return wrap([&] {
 		auto track = getTrack(tr);
@@ -1461,6 +1494,33 @@ int rtcSetAACDepacketizer(int tr) {
 	return wrap([&] {
 		auto track = getTrack(tr);
 		auto depacketizer = std::make_shared<AACRtpDepacketizer>();
+		track->setMediaHandler(depacketizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSetPCMUDepacketizer(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto depacketizer = std::make_shared<PCMURtpDepacketizer>();
+		track->setMediaHandler(depacketizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSetPCMADepacketizer(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto depacketizer = std::make_shared<PCMARtpDepacketizer>();
+		track->setMediaHandler(depacketizer);
+		return RTC_ERR_SUCCESS;
+	});
+}
+
+int rtcSetG722Depacketizer(int tr) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		auto depacketizer = std::make_shared<G722RtpDepacketizer>();
 		track->setMediaHandler(depacketizer);
 		return RTC_ERR_SUCCESS;
 	});


### PR DESCRIPTION
# Prolog

This PR is part of a series to enable Python bindings for `libdatachannel`.

I am not a C/C++ developer, so this implementation was built with assistance from Claude AI. However, the code is functional and has been thoroughly tested; it is currently running in our [development](https://github.com/facefusion/facefusion/tree/v4) branch, supporting a cross-platform (Linux, Windows, macOS) WHIP/WHEP pipeline with `libaom`, `libvpx`, and `libopus`.

# Description

**Expose the remaining packetizer/depacketizer setters to the C API.**

Several media handlers already exist as C++ classes but have no C-API setter, so they are unreachable from the C interface (and therefore from language bindings). This adds the missing wrappers, each following the existing `rtcSet*Depacketizer` / `rtcSet*Packetizer` pattern.

### Added

- `rtcSetVP9Packetizer` and `rtcSetVP9Depacketizer`
- `rtcSetVP8Depacketizer` — VP8 has a packetizer setter (`rtcSetVP8Packetizer`) but no depacketizer setter.
- `rtcSetPCMUDepacketizer`, `rtcSetPCMADepacketizer`, `rtcSetG722Depacketizer` — audio depacketizer setters (the classes are `using` aliases of `AudioRtpDepacketizer` already present).

### Notes

- The new depacketizer setters follow the existing minimal pattern of `rtcSetH264Depacketizer` / `rtcSetOpusDepacketizer` (they set the media handler only), keeping the API consistent. RTCP RR/REMB is wired the same way as for the existing codecs — via `rtcChainRtcpReceivingSession` — so behavior is uniform across all depacketizers.
- All underlying C++ classes already exist; this PR adds only the C wrappers, declarations, and documentation.

### Files

- `src/capi.cpp`
- `include/rtc/rtc.h`
- `DOC.md`
