### PR TITLE
Fix AV1 RTP packetizer handling of OBUs that already carry a size field

### DIFF
--- a/src/av1rtppacketizer.cpp
+++ b/src/av1rtppacketizer.cpp
@@ -63,6 +63,10 @@ std::vector<binary> AV1RtpPacketizer::extractTemporalUnitObus(const binary &data
 			return obus;
 		}
 
+		size_t startIndex = index;
+		bool hasExtension = (data.at(index) & obuHasExtensionMask) != byte(0);
+		size_t headerSize = obuHeaderSize + (hasExtension ? 1 : 0);
+
 		if ((data.at(index) & obuHasExtensionMask) != byte(0)) {
 			index++;
 		}
@@ -86,8 +90,16 @@ std::vector<binary> AV1RtpPacketizer::extractTemporalUnitObus(const binary &data
 			}
 		}
 
-		obus.emplace_back(data.begin() + index,
-		                  data.begin() + index + obuHeaderSize + leb128Size + obuLength);
+		size_t payloadStart = startIndex + headerSize + leb128Size;
+		binary obu;
+		obu.reserve(headerSize + obuLength);
+		obu.push_back(data.at(startIndex) & ~obuHasSizeMask);
+		if (hasExtension)
+			obu.push_back(data.at(startIndex + 1));
+		if (payloadStart + obuLength <= data.size())
+			obu.insert(obu.end(), data.begin() + payloadStart,
+			           data.begin() + payloadStart + obuLength);
+		obus.push_back(std::move(obu));
 
 		index += obuHeaderSize + leb128Size + obuLength;
 	}


### PR DESCRIPTION
# Prolog

This PR is part of a series to enable Python bindings for `libdatachannel`.

I am not a C/C++ developer, so this implementation was built with assistance from Claude AI. However, the code is functional and has been thoroughly tested; it is currently running in our [development](https://github.com/facefusion/facefusion/tree/v4) branch, supporting a cross-platform (Linux, Windows, macOS) WHIP/WHEP pipeline with `libaom`, `libvpx`, and `libopus`.

# Description

**Fix AV1 RTP packetizer handling of OBUs that already carry a size field.**

In `AV1RtpPacketizer::extractTemporalUnitObus`, when an input OBU has `obu_has_size_field` set, the previous code copied the OBU range as-is and computed its offsets incorrectly — the OBU extension byte was not accounted for — producing malformed OBU elements.

The fix rebuilds each element and clears `obu_has_size_field`, as the [AV1 RTP spec §4.5](https://aomediacodec.github.io/av1-rtp-spec/) recommends: *"To minimize overhead, the obu_has_size_field flag SHOULD be set to zero in all OBUs."* The element length is instead conveyed by the aggregation header (§4.4) — a LEB128 length prefix per element, with the last element's size implicit.

This change:

- Detects the extension bit and computes the correct header size.
- Clears `obu_has_size_field` in the emitted OBU header (`& ~obuHasSizeMask`).
- Rebuilds the OBU as header (+ optional extension byte) + payload, **dropping the LEB128 size field** (so the OBU carries no length of its own), with a bounds check against the input buffer.

### Files

- `src/av1rtppacketizer.cpp`

### Note

Best paired with a round-trip test (packetize → depacketize) to lock in the behavior.
