### PR TITLE
Fix single-packet frames being silently dropped in the VP8 depacketizer

### DIFF
--- a/src/vp8rtpdepacketizer.cpp
+++ b/src/vp8rtpdepacketizer.cpp
@@ -154,6 +154,9 @@ message_ptr VP8RtpDepacketizer::reassemble(message_buffer &buffer) {
 					// Add current payload too
 					frame.insert(frame.end(), payloadData, payloadData + payloadSize);
 				}
+			} else if ((firstByte & S) && rtpHeader->marker()) {
+				// Single-packet frame
+				frame.insert(frame.end(), payloadData, payloadData + payloadSize);
 			}
 			payloads.clear();
 			continuousSequence = true;


### PR DESCRIPTION
# Prolog

This PR is part of a series to enable Python bindings for `libdatachannel`.

I am not a C/C++ developer, so this implementation was built with assistance from Claude AI. However, the code is functional and has been thoroughly tested; it is currently running in our [development](https://github.com/facefusion/facefusion/tree/v4) branch, supporting a cross-platform (Linux, Windows, macOS) WHIP/WHEP pipeline with `libaom`, `libvpx`, and `libopus`.

# Description

**Fix single-packet frames being silently dropped in the VP8 depacketizer.**

In `VP8RtpDepacketizer::reassemble`, a frame contained in a single RTP packet (S bit set, [RFC 7741 §4.2](https://www.rfc-editor.org/rfc/rfc7741); marker bit set, §4.1) was only emitted inside the `if (continuousSequence)` path. Since `continuousSequence` starts `false`, such a packet was dropped when it arrived first in the stream or after a gap — so a stream opening with a single-packet key frame (RFC 7741 §4.6.1) loses its first frame.

The fix adds the missing branch: when the current packet has S=1 and M=1, emit it as a complete single-packet frame.

The VP9 depacketizer already handles this exact case (`src/vp9rtpdepacketizer.cpp`: `else if ((firstByte & bitB) && rtpHeader->marker()) { // Single-packet frame at start of buffer }`), so this simply brings the VP8 depacketizer to parity with its VP9 sibling.

### Files

- `src/vp8rtpdepacketizer.cpp`

### Note

A reassembly unit test covering the single-packet (S=1, M=1) case would be a good addition — happy to add one if preferred.
