### PR TITLE
fix: OpenSSL DTLS input BIO synchronization

### DIFF
--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -946,13 +946,14 @@ void DtlsTransport::doRecv() {
 			if (demuxMessage(message))
 				continue;
 
-			BIO_write(mInBio, message->data(), int(message->size()));
-
+			bool incomingWritten = false;
 			if (state() == State::Connecting) {
 				// Continue the handshake
 				int ret, err;
 				{
 					std::lock_guard lock(mSslMutex);
+					BIO_write(mInBio, message->data(), int(message->size()));
+					incomingWritten = true;
 					ret = SSL_do_handshake(mSsl);
 					err = SSL_get_error(mSsl, ret);
 				}
@@ -975,6 +976,8 @@ void DtlsTransport::doRecv() {
 				int ret, err;
 				{
 					std::lock_guard lock(mSslMutex);
+					if (!incomingWritten)
+						BIO_write(mInBio, message->data(), int(message->size()));
 					ret = SSL_read(mSsl, buffer, bufferSize);
 					err = SSL_get_error(mSsl, ret);
 				}


### PR DESCRIPTION
The OpenSSL DTLS implementation was writing incoming packets to `mInBio` without holding `mSslMutex`, while the operations consuming the same BIO were already protected by the mutex:

* `SSL_do_handshake()`
* `SSL_read()`
* `SSL_write()`
* `DTLSv1_handle_timeout()`

This creates a race during DTLS startup.

In `DtlsTransport::start()`, the incoming callback is registered before the first `SSL_do_handshake()` call. If ICE already has a queued DTLS packet at that point, `registerIncoming()` can deliver it immediately and schedule `doRecv()` on the thread pool.

The failing flow is roughly:

1. `start()` enters the initial `SSL_do_handshake()`.
2. A queued DTLS ClientHello is delivered to `doRecv()`.
3. `doRecv()` calls `BIO_write(mInBio, ...)` without taking `mSslMutex`.
4. This write can overlap with an SSL operation which is using the same BIO.
5. The handshake can then fail intermittently with:  `Handshake failed: fatal I/O error`

I was able to reproduce this as an intermittent Chrome-to-libdatachannel WebRTC connection failure on Linux Github Action Runner.

## Fix

Move `BIO_write(mInBio, ...)` under `mSslMutex`.

With this change, while the transport is connecting, incoming packets are written under the same lock as `SSL_do_handshake()`. After the transport is connected, they are written under the same lock as `SSL_read()`.

The `incomingWritten` flag is used to avoid writing the same packet twice to the BIO when that packet completes the handshake and the code later continues to `SSL_read()`.

## Evidence

Verbose PLOG logs from the failing run showed the following sequence:

* ICE reached `connected`.
* DTLS transport startup started.
* `registerIncoming()` immediately delivered a queued 216-byte DTLS packet.
* The initial handshake and queued packet processing ran on different threads.
* DTLS failed immediately with: `Handshake failed: fatal I/O error`
