### PR TITLE
Update libjuice to v1.7.2 and fix build with nettle 4

### DIFF
--- a/src/impl/sha.cpp
+++ b/src/impl/sha.cpp
@@ -13,6 +13,7 @@
 #if USE_GNUTLS
 
 #include <nettle/sha1.h>
+#include <nettle/version.h>
 
 #elif USE_MBEDTLS
 
@@ -39,7 +40,11 @@ binary Sha1(const byte *data, size_t size) {
 	struct sha1_ctx ctx;
 	sha1_init(&ctx);
 	sha1_update(&ctx, size, reinterpret_cast<const uint8_t *>(data));
+#if NETTLE_VERSION_MAJOR >= 4
+	sha1_digest(&ctx, reinterpret_cast<uint8_t *>(output.data()));
+#else
 	sha1_digest(&ctx, SHA1_DIGEST_SIZE, reinterpret_cast<uint8_t *>(output.data()));
+#endif
 	return output;
 
 #elif USE_MBEDTLS


### PR DESCRIPTION
This PR updates libjuice to v1.7.2 and fixes the build with nettle 4.