### PR TITLE
perf: reduce internal message handoff overhead

### DIFF
--- a/src/impl/channel.cpp
+++ b/src/impl/channel.cpp
@@ -71,7 +71,7 @@ void Channel::flushPendingMessages() {
 			break;
 
 		try {
-			messageCallback(*next);
+			messageCallback(std::move(*next));
 		} catch (const std::exception &e) {
 			PLOG_WARNING << "Uncaught exception in callback: " << e.what();
 		}

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -66,7 +66,7 @@ struct AckMessage {
 
 #pragma pack(pop)
 
-bool DataChannel::IsOpenMessage(message_ptr message) {
+bool DataChannel::IsOpenMessage(const message_ptr &message) {
 	if (message->type != Message::Control)
 		return false;
 
@@ -201,7 +201,7 @@ bool DataChannel::outgoing(message_ptr message) {
 		message->stream = mStream.value();
 	}
 
-	return transport->send(message);
+	return transport->send(std::move(message));
 }
 
 void DataChannel::incoming(message_ptr message) {
@@ -233,7 +233,7 @@ void DataChannel::incoming(message_ptr message) {
 		break;
 	case Message::String:
 	case Message::Binary:
-		mRecvQueue.push(message);
+		mRecvQueue.push(std::move(message));
 		triggerAvailable(mRecvQueue.size());
 		break;
 	default:

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -25,7 +25,7 @@ namespace rtc::impl {
 struct PeerConnection;
 
 struct DataChannel : Channel, std::enable_shared_from_this<DataChannel> {
-	static bool IsOpenMessage(message_ptr message);
+	static bool IsOpenMessage(const message_ptr &message);
 
 	DataChannel(weak_ptr<PeerConnection> pc, string label, string protocol,
 	            Reliability reliability);

--- a/src/impl/dtlssrtptransport.cpp
+++ b/src/impl/dtlssrtptransport.cpp
@@ -131,7 +131,7 @@ bool DtlsSrtpTransport::sendMedia(message_ptr message) {
 		message->dscp = 36; // AF42: Assured Forwarding class 4, medium drop probability
 	}
 
-	return Transport::outgoing(message); // bypass DTLS DSCP marking
+	return Transport::outgoing(std::move(message)); // bypass DTLS DSCP marking
 }
 
 void DtlsSrtpTransport::recvMedia(message_ptr message) {

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -162,7 +162,7 @@ void DtlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	mIncomingQueue.push(message);
+	mIncomingQueue.push(std::move(message));
 	enqueueRecv();
 }
 
@@ -501,7 +501,7 @@ void DtlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	mIncomingQueue.push(message);
+	mIncomingQueue.push(std::move(message));
 	enqueueRecv();
 }
 

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -896,7 +896,7 @@ void DtlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	if(mIncomingQueue.tryPush(message)) {
+	if(mIncomingQueue.tryPush(std::move(message))) {
 		enqueueRecv();
 	} else {
 		PLOG_VERBOSE << "DTLS incoming queue is full, dropping";

--- a/src/impl/httpproxytransport.cpp
+++ b/src/impl/httpproxytransport.cpp
@@ -43,7 +43,7 @@ bool HttpProxyTransport::send(message_ptr message) {
 		throw std::runtime_error("HTTP proxy connection is not open");
 
 	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(message);
+	return outgoing(std::move(message));
 }
 
 bool HttpProxyTransport::isActive() const { return true; }

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -290,7 +290,7 @@ bool IceTransport::send(message_ptr message) {
 		return false;
 
 	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(message);
+	return outgoing(std::move(message));
 }
 
 bool IceTransport::outgoing(message_ptr message) {
@@ -804,7 +804,7 @@ bool IceTransport::send(message_ptr message) {
 		return false;
 
 	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(message);
+	return outgoing(std::move(message));
 }
 
 bool IceTransport::outgoing(message_ptr message) {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -521,7 +521,7 @@ void PeerConnection::forwardMessage(message_ptr message) {
 
 	if (channel) {
 		// Forward the message
-		channel->incoming(message);
+		channel->incoming(std::move(message));
 	} else {
 		// DataChannel was destroyed, ignore
 		PLOG_DEBUG << "Ignored message on stream " << stream << ", DataChannel is destroyed";

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -388,8 +388,10 @@ bool SctpTransport::send(message_ptr message) {
 	if (trySendQueue() && trySendMessage(message))
 		return true;
 
-	mSendQueue.push(message);
-	updateBufferedAmount(to_uint16(message->stream), ptrdiff_t(message_size_func(message)));
+	const uint16_t streamId = to_uint16(message->stream);
+	const ptrdiff_t size = ptrdiff_t(message_size_func(message));
+	mSendQueue.push(std::move(message));
+	updateBufferedAmount(streamId, size);
 	return false;
 }
 
@@ -596,7 +598,7 @@ bool SctpTransport::trySendQueue() {
 	return true;
 }
 
-bool SctpTransport::trySendMessage(message_ptr message) {
+bool SctpTransport::trySendMessage(const message_ptr &message) {
 	// Requires mSendMutex to be locked
 	if (state() != State::Connected)
 		return false;

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -85,7 +85,7 @@ private:
 	void enqueueRecv();
 	void enqueueFlush();
 	bool trySendQueue();
-	bool trySendMessage(message_ptr message);
+	bool trySendMessage(const message_ptr &message);
 	void updateBufferedAmount(uint16_t streamId, ptrdiff_t delta);
 	void triggerBufferedAmount(uint16_t streamId, size_t amount);
 	void sendReset(uint16_t streamId);

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -117,7 +117,7 @@ bool TcpTransport::send(message_ptr message) {
 		return trySendQueue();
 
 	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(message);
+	return outgoing(std::move(message));
 }
 
 void TcpTransport::incoming(message_ptr message) {
@@ -125,7 +125,7 @@ void TcpTransport::incoming(message_ptr message) {
 		return;
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	recv(message);
+	recv(std::move(message));
 }
 
 bool TcpTransport::outgoing(message_ptr message) {
@@ -134,8 +134,9 @@ bool TcpTransport::outgoing(message_ptr message) {
 	if (trySendQueue() && trySendMessage(message))
 		return true;
 
-	mSendQueue.push(message);
-	updateBufferedAmount(ptrdiff_t(message->size()));
+	const size_t size = message->size();
+	mSendQueue.push(std::move(message));
+	updateBufferedAmount(ptrdiff_t(size));
 	setPoll(PollService::Direction::Both);
 	return false;
 }

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -125,7 +125,7 @@ bool TlsTransport::send(message_ptr message) {
 		throw std::runtime_error("TLS is not open");
 
 	if (!message || message->size() == 0)
-		return outgoing(message); // pass through
+		return outgoing(std::move(message)); // pass through
 
 	PLOG_VERBOSE << "Send size=" << message->size();
 
@@ -148,7 +148,7 @@ void TlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	mIncomingQueue.push(message);
+	mIncomingQueue.push(std::move(message));
 	enqueueRecv();
 }
 
@@ -259,7 +259,7 @@ ssize_t TlsTransport::ReadCallback(gnutls_transport_ptr_t ptr, void *data, size_
 				if (message->size() > 0)
 					break;
 
-				t->recv(message); // Pass zero-sized messages through
+				t->recv(std::move(message)); // Pass zero-sized messages through
 				message.reset();
 			}
 		}
@@ -393,7 +393,7 @@ bool TlsTransport::send(message_ptr message) {
 		throw std::runtime_error("TLS is not open");
 
 	if (!message || message->size() == 0)
-		return outgoing(message); // pass through
+		return outgoing(std::move(message)); // pass through
 
 	PLOG_VERBOSE << "Send size=" << message->size();
 
@@ -418,7 +418,7 @@ void TlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	mIncomingQueue.push(message);
+	mIncomingQueue.push(std::move(message));
 	enqueueRecv();
 }
 
@@ -531,7 +531,7 @@ int TlsTransport::ReadCallback(void *ctx, unsigned char *buf, size_t len) {
 				if (message->size() > 0)
 					break;
 
-				t->recv(message); // Pass zero-sized messages through
+				t->recv(std::move(message)); // Pass zero-sized messages through
 				message.reset();
 			}
 		}
@@ -691,7 +691,7 @@ bool TlsTransport::send(message_ptr message) {
 		throw std::runtime_error("TLS is not open");
 
 	if (!message || message->size() == 0)
-		return outgoing(message); // pass through
+		return outgoing(std::move(message)); // pass through
 
 	PLOG_VERBOSE << "Send size=" << message->size();
 
@@ -718,7 +718,7 @@ void TlsTransport::incoming(message_ptr message) {
 	}
 
 	PLOG_VERBOSE << "Incoming size=" << message->size();
-	mIncomingQueue.push(message);
+	mIncomingQueue.push(std::move(message));
 	enqueueRecv();
 }
 
@@ -747,7 +747,7 @@ void TlsTransport::doRecv() {
 
 			message_ptr message = std::move(*next);
 			if (message->size() == 0) {
-				recv(message); // Pass zero-sized messages through
+				recv(std::move(message)); // Pass zero-sized messages through
 				continue;
 			}
 

--- a/src/impl/transport.cpp
+++ b/src/impl/transport.cpp
@@ -50,7 +50,7 @@ void Transport::onRecv(message_callback callback) {
 	}
 	for (auto &msg : pending) {
 		try {
-			mRecvCallback(msg);
+			mRecvCallback(std::move(msg));
 		} catch (const std::exception &e) {
 			PLOG_WARNING << e.what();
 		}
@@ -65,7 +65,7 @@ void Transport::start() { registerIncoming(); }
 
 void Transport::stop() { unregisterIncoming(); }
 
-bool Transport::send(message_ptr message) { return outgoing(message); }
+bool Transport::send(message_ptr message) { return outgoing(std::move(message)); }
 
 void Transport::recv(message_ptr message) {
 	try {
@@ -80,7 +80,7 @@ void Transport::recv(message_ptr message) {
 			return;
 		}
 		lock.unlock();
-		mRecvCallback(message);
+		mRecvCallback(std::move(message));
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();
 	}
@@ -95,11 +95,11 @@ void Transport::changeState(State state) {
 	}
 }
 
-void Transport::incoming(message_ptr message) { recv(message); }
+void Transport::incoming(message_ptr message) { recv(std::move(message)); }
 
 bool Transport::outgoing(message_ptr message) {
 	if (mLower)
-		return mLower->send(message);
+		return mLower->send(std::move(message));
 	else
 		return false;
 }

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -186,7 +186,7 @@ bool WebSocket::outgoing(message_ptr message) {
 	if (message->size() > maxMessageSize())
 		throw std::runtime_error("Message size exceeds limit");
 
-	return mWsTransport->send(message);
+	return mWsTransport->send(std::move(message));
 }
 
 void WebSocket::incoming(message_ptr message) {
@@ -196,7 +196,7 @@ void WebSocket::incoming(message_ptr message) {
 	}
 
 	if (message->type == Message::String || message->type == Message::Binary) {
-		mRecvQueue.push(message);
+		mRecvQueue.push(std::move(message));
 		triggerAvailable(mRecvQueue.size());
 	}
 }


### PR DESCRIPTION
## Summary

Reduce avoidable internal message handoff overhead across data-channel and transport paths.

Changes:

- move `message_ptr` values through one-way internal handoff paths instead of forwarding lvalues
- move `message_variant` into the channel message callback instead of copying it
- make read-only helpers take `const message_ptr&`
- extend the same ownership handoff cleanup to WebSocket, TCP, TLS, HTTP proxy, DTLS, and DTLS-SRTP paths where the message is no longer used afterward

## Rationale

Several internal paths accept a `shared_ptr<Message>` by value and then forward it as an lvalue even though the caller does not use it afterward. Moving ownership through those paths avoids unnecessary `shared_ptr` refcount churn while preserving the existing ownership model.

`Channel::flushPendingMessages()` also copied the received `message_variant` into the callback path. Moving the variant avoids an extra binary payload copy before user callback delivery.

The follow-up transport changes intentionally avoid media fan-out paths where the same message can be delivered to multiple receivers.