### PR TITLE
Implement concurrent WebSocket connection attempts

### DIFF
--- a/include/rtc/configuration.hpp
+++ b/include/rtc/configuration.hpp
@@ -101,6 +101,9 @@ struct WebSocketConfiguration {
 	bool disableTlsVerification = false; // if true, don't verify the TLS certificate
 	optional<ProxyServer> proxyServer;   // only non-authenticated http supported for now
 	std::vector<string> protocols;
+	// The delay after which to attempt connecting to the next address in parallel to already
+	// ongoing connection attempts ("Happy Eyeballs"). Zero to disable
+	optional<std::chrono::milliseconds> connectionAttemptDelay;
 	optional<std::chrono::milliseconds> tcpConnectionTimeout; // zero to disable
 	optional<std::chrono::milliseconds> connectionTimeout;    // zero to disable
 	optional<std::chrono::milliseconds> pingInterval;         // zero to disable

--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -513,6 +513,10 @@ typedef struct {
 	const char *proxyServer;     // only non-authenticated http supported for now
 	const char **protocols;
 	int protocolsCount;
+	// The delay after which to attempt connecting to the next address in parallel to already
+	// ongoing connection attempts ("Happy Eyeballs"). Value is in milliseconds, 0 means default,
+	// < 0 means disabled
+	int connectionAttemptDelayMs;
 	int tcpConnectionTimeoutMs; // in milliseconds, 0 means default, < 0 means disabled
 	int connectionTimeoutMs;    // in milliseconds, 0 means default, < 0 means disabled
 	int pingIntervalMs;         // in milliseconds, 0 means default, < 0 means disabled

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1777,11 +1777,16 @@ int rtcCreateWebSocketEx(const char *url, const rtcWsConfiguration *config) {
 		for (int i = 0; i < config->protocolsCount; ++i)
 			c.protocols.emplace_back(string(config->protocols[i]));
 
+		if (config->connectionAttemptDelayMs > 0)
+			c.connectionAttemptDelay = milliseconds(config->connectionAttemptDelayMs);
+		else if (config->connectionAttemptDelayMs < 0)
+			c.connectionAttemptDelay = milliseconds::zero(); // setting to 0 disables,
+			                                                 // not setting keeps default
 		if (config->tcpConnectionTimeoutMs > 0)
 			c.tcpConnectionTimeout = milliseconds(config->tcpConnectionTimeoutMs);
 		else if (config->tcpConnectionTimeoutMs < 0)
 			c.tcpConnectionTimeout = milliseconds::zero(); // setting to 0 disables,
-			                                            // not setting keeps default
+			                                               // not setting keeps default
 		if (config->connectionTimeoutMs > 0)
 			c.connectionTimeout = milliseconds(config->connectionTimeoutMs);
 		else if (config->connectionTimeoutMs < 0)
@@ -1972,4 +1977,3 @@ void rtcCleanup() {
 		PLOG_ERROR << e.what();
 	}
 }
-

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -248,9 +248,21 @@ void TcpTransport::attempt() {
 		if (state() != State::Connecting)
 			return; // Cancelled
 
+		// Handle the rare case where the poll service emits two events in quick succession, while
+		// concurrent connection attempts are enabled: A delayed connection attempt timeout event
+		// that triggers another connection attempt asynchronously on the thread pool, followed by
+		// an out event for a successful connection. The latter acquires the lock and closes all
+		// sockets, then releases the lock before it changes the state to connected (see the
+		// processConnect() method for reasoning). If this happens before the socket for the queued
+		// attempt is created here, which is likely because the thread pool takes some time to
+		// execute the next attempt, we would create a new socket while we have already established
+		// a connection with a socket (race condition). This check prevents the creation of another
+		// connection in this case, since access to mSock is synchronized via mSendMutex.
+		if (mSock != INVALID_SOCKET)
+			return;
+
 		if (mResolved.empty()) {
 			PLOG_WARNING << "Connection to " << mHostname << ":" << mService << " failed";
-			assert(mSock == INVALID_SOCKET);
 			closeUnusedSockets();
 			changeState(State::Failed);
 			return;
@@ -586,6 +598,11 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 				throw std::runtime_error(msg.str());
 			}
 
+			if (mSock != INVALID_SOCKET) {
+				assert(false);
+				throw std::logic_error("Already have a valid socket");
+			}
+
 			// Use this socket and close all other opened sockets
 			mSock = sock;
 			closeUnusedSockets();
@@ -594,6 +611,10 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		// Success
 		PLOG_INFO << "TCP connected";
 		PLOG_VERBOSE << "Using socket with descriptor " << mSock;
+
+		// We must change the connected state after releasing the mSendMutex lock, since the
+		// connected state change handler might e.g. initialize TLS, which would cause a resource
+		// deadlock, if we were still holding the lock to mSendMutex.
 		changeState(State::Connected);
 		setPoll(PollService::Direction::In);
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -225,8 +225,6 @@ void TcpTransport::resolve() {
 
 		freeaddrinfo(result);
 
-		mPendingAddresses = static_cast<int>(mResolved.size());
-
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();
 		changeState(State::Failed);
@@ -269,6 +267,7 @@ void TcpTransport::attempt() {
 		// reuse closed file descriptors
 		assert(mSocks.find(sock) == mSocks.end());
 		mSocks.insert(sock);
+		mPendingSocks += 1;
 
 	} catch (const std::runtime_error &e) {
 		PLOG_DEBUG << e.what();
@@ -521,7 +520,7 @@ void TcpTransport::closeUnusedSockets() {
 	}
 
 	mSocks.clear();
-	mPendingAddresses = 0;
+	mPendingSocks = 0;
 }
 
 void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool isDelayTimeout) {
@@ -550,15 +549,15 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		return;
 	}
 
-	bool isLastSock = false;
+	bool isLastPendingSock = false;
 
 	try {
 		{
 			std::lock_guard lock(mSendMutex);
 
-			mPendingAddresses -= 1;
-			assert(mPendingAddresses >= 0);
-			isLastSock = mPendingAddresses == 0;
+			mPendingSocks -= 1;
+			assert(mPendingSocks >= 0);
+			isLastPendingSock = mPendingSocks == 0;
 
 			if (event == PollService::Event::Error)
 				throw std::runtime_error("TCP connection failed");
@@ -596,12 +595,15 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		PLOG_DEBUG << e.what();
 		PollService::Instance().remove(sock);
 
-		// Queue the next connection attempt in one of two cases:
-		// - We connect synchronously (no connection attempt delay is configured)
-		// - We connect to multiple addresses in parallel and this was the last socket that errored.
-		//   This means that all sockets errored and we must proceed with triggering the connection
-		//   failure handling code in the attempt() method
-		if (!mConnectAttemptDelay.has_value() || isLastSock) {
+		// Queue the next connection attempt in one of these cases:
+		// 1. We connect synchronously (no connection attempt delay is configured)
+		// 2. We connect concurrently and this socket failed before the delay timeout was reached
+		// 3. We connect concurrently and this was the last pending socket that timed out. This
+		//    means that all sockets that were created so far failed and we must proceed either with
+		//    queueing a connection attempt for the next address or with handling connection
+		//    failure, for the case that there are no more addresses left
+		if (!mConnectAttemptDelay.has_value() || event != PollService::Event::Timeout ||
+		    isLastPendingSock) {
 			ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
 		}
 	}

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -557,8 +557,8 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		{
 			std::lock_guard lock(mSendMutex);
 
-			assert(state() == State::Connecting && mPendingSocks > 0 ||
-			       state() != State::Connecting && mPendingSocks == 0);
+			assert((state() == State::Connecting && mPendingSocks > 0) ||
+			       (state() != State::Connecting && mPendingSocks == 0));
 
 			if (state() == State::Connecting) {
 				mPendingSocks -= 1;

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -48,7 +48,7 @@ bool unmap_inet6_v4mapped(struct sockaddr *sa, socklen_t *len) {
 	return true;
 }
 
-}
+} // namespace
 
 TcpTransport::TcpTransport(string hostname, string service, state_callback callback)
     : Transport(nullptr, std::move(callback)), mIsActive(true), mHostname(std::move(hostname)),
@@ -63,7 +63,7 @@ TcpTransport::TcpTransport(socket_t sock, state_callback callback)
 	PLOG_DEBUG << "Initializing TCP transport with socket";
 
 	// Configure socket
-	configureSocket();
+	configureSocket(mSock);
 
 	// Retrieve hostname and service
 	struct sockaddr_storage addr;
@@ -88,6 +88,10 @@ TcpTransport::~TcpTransport() { close(); }
 
 void TcpTransport::onBufferedAmount(amount_callback callback) {
 	mBufferedAmountCallback = std::move(callback);
+}
+
+void TcpTransport::setConnectAttemptDelay(std::chrono::milliseconds connectAttemptDelay) {
+	mConnectAttemptDelay = connectAttemptDelay;
 }
 
 void TcpTransport::setConnectTimeout(std::chrono::milliseconds connectTimeout) {
@@ -157,6 +161,28 @@ void TcpTransport::connect() {
 	ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::resolve, this));
 }
 
+// Reorders the list of addresses to alternate IPv4 and IPv6 addresses towards the beginning of the
+// list whenever possible, while always keeping the first address in its original place.
+static void interleave_address_families(addrinfo *&head) {
+	for (addrinfo *current = head; current;) {
+		int target = current->ai_family == AF_INET ? AF_INET6 : AF_INET;
+
+		addrinfo **candidate_ptr = &current->ai_next;
+		while (*candidate_ptr && (*candidate_ptr)->ai_family != target)
+			candidate_ptr = &(*candidate_ptr)->ai_next;
+		if (!*candidate_ptr)
+			break;
+
+		addrinfo *node = *candidate_ptr;
+		*candidate_ptr = node->ai_next;
+
+		node->ai_next = current->ai_next;
+		current->ai_next = node;
+
+		current = node;
+	}
+}
+
 void TcpTransport::resolve() {
 	std::lock_guard lock(mSendMutex);
 	mResolved.clear();
@@ -178,6 +204,11 @@ void TcpTransport::resolve() {
 			throw std::runtime_error("Resolution failed for \"" + mHostname + ":" + mService +
 			                         "\"");
 
+		// Interleave address families, so that an address of the opposite family of the first
+		// listed address is attempted as early as possible. See section 4. Sorting Addresses of
+		// RFC8305: https://www.rfc-editor.org/info/rfc8305/#section-4
+		interleave_address_families(result);
+
 		try {
 			struct addrinfo *ai = result;
 			while (ai) {
@@ -194,6 +225,8 @@ void TcpTransport::resolve() {
 
 		freeaddrinfo(result);
 
+		mPendingAddresses = static_cast<int>(mResolved.size());
+
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();
 		changeState(State::Failed);
@@ -204,27 +237,38 @@ void TcpTransport::resolve() {
 }
 
 void TcpTransport::attempt() {
+
+	// FIXME Cache and reuse the address that we successfully connected to before
+
+	socket_t sock = INVALID_SOCKET;
+	bool isLastAttempt = false;
+
 	try {
 		std::lock_guard lock(mSendMutex);
 
 		if (state() != State::Connecting)
 			return; // Cancelled
 
-		if (mSock != INVALID_SOCKET) {
-			::closesocket(mSock);
-			mSock = INVALID_SOCKET;
-		}
-
 		if (mResolved.empty()) {
 			PLOG_WARNING << "Connection to " << mHostname << ":" << mService << " failed";
+			assert(mSock == INVALID_SOCKET);
+			closeUnusedSockets();
 			changeState(State::Failed);
 			return;
 		}
 
 		auto [addr, addrlen] = mResolved.front();
 		mResolved.pop_front();
+		isLastAttempt = mResolved.empty();
 
-		createSocket(reinterpret_cast<const struct sockaddr *>(&addr), addrlen);
+		sock = createSocket(reinterpret_cast<const struct sockaddr *>(&addr), addrlen);
+
+		// We need to make sure that we only close the remaining sockets once all addresses have
+		// been attempted or one of the addresses has successfully connected, as createSocket()
+		// might otherwise return a file descriptor that we already encountered before, since it can
+		// reuse closed file descriptors
+		assert(mSocks.find(sock) == mSocks.end());
+		mSocks.insert(sock);
 
 	} catch (const std::runtime_error &e) {
 		PLOG_DEBUG << e.what();
@@ -232,11 +276,31 @@ void TcpTransport::attempt() {
 		return;
 	}
 
-	PollService::Instance().add(mSock, {PollService::Direction::Out, mConnectTimeout,
-	                                    weak_bind(&TcpTransport::processConnect, this, _1)});
+	// Use the connect attempt delay as timeout, if there are more addresses to attempt and a
+	// connect attempt delay is configured, i.e. we are performing "Happy Eyeballs"
+	std::optional<std::chrono::milliseconds> timeout = mConnectTimeout;
+	if (!isLastAttempt && mConnectAttemptDelay.has_value()) {
+		timeout = mConnectAttemptDelay;
+		// Make sure not to exceed the connection timeout.
+		if (mConnectTimeout.has_value())
+			timeout = std::min(*timeout, *mConnectTimeout);
+	}
+
+	bool isDelayTimeout =
+	    timeout.has_value() && (!mConnectTimeout.has_value() || *timeout < *mConnectTimeout);
+
+	PLOG_VERBOSE << "Polling socket with descriptor " << sock;
+	PLOG_VERBOSE_IF(timeout.has_value()) << "Using timeout " << timeout->count() << "ms"
+	                                     << (isDelayTimeout ? " (connection attempt delay)" : "");
+
+	PollService::Instance().add(
+	    sock, {PollService::Direction::Out, timeout,
+	           weak_bind(&TcpTransport::processConnect, this, _1, sock, isDelayTimeout)});
 }
 
-void TcpTransport::createSocket(const struct sockaddr *addr, socklen_t addrlen) {
+socket_t TcpTransport::createSocket(const struct sockaddr *addr, socklen_t addrlen) {
+	socket_t sock = INVALID_SOCKET;
+
 	try {
 		char node[MAX_NUMERICNODE_LEN];
 		char serv[MAX_NUMERICSERV_LEN];
@@ -248,45 +312,50 @@ void TcpTransport::createSocket(const struct sockaddr *addr, socklen_t addrlen) 
 		PLOG_VERBOSE << "Creating TCP socket";
 
 		// Create socket
-		mSock = ::socket(addr->sa_family, SOCK_STREAM, IPPROTO_TCP);
-		if (mSock == INVALID_SOCKET)
+		sock = ::socket(addr->sa_family, SOCK_STREAM, IPPROTO_TCP);
+		if (sock == INVALID_SOCKET)
 			throw std::runtime_error("TCP socket creation failed");
 
 		// Configure socket
-		configureSocket();
+		configureSocket(sock);
 
 		// Initiate connection
-		int ret = ::connect(mSock, addr, addrlen);
+		int ret = ::connect(sock, addr, addrlen);
 		if (ret < 0 && sockerrno != SEINPROGRESS && sockerrno != SEWOULDBLOCK) {
 			std::ostringstream msg;
 			msg << "TCP connection to " << node << ":" << serv << " failed, errno=" << sockerrno;
 			throw std::runtime_error(msg.str());
 		}
 
+		PLOG_VERBOSE << "Successfully created TCP socket with descriptor " << sock;
+
 	} catch (...) {
-		if (mSock != INVALID_SOCKET) {
-			::closesocket(mSock);
-			mSock = INVALID_SOCKET;
+		if (sock != INVALID_SOCKET) {
+			::closesocket(sock);
+			sock = INVALID_SOCKET;
 		}
 		throw;
 	}
+
+	assert(sock != INVALID_SOCKET);
+	return sock;
 }
 
-void TcpTransport::configureSocket() {
+void TcpTransport::configureSocket(socket_t sock) {
 	// Set non-blocking
 	ctl_t nbio = 1;
-	if (::ioctlsocket(mSock, FIONBIO, &nbio) < 0)
+	if (::ioctlsocket(sock, FIONBIO, &nbio) < 0)
 		throw std::runtime_error("Failed to set socket non-blocking mode");
 
 	// Disable the Nagle algorithm
 	int nodelay = 1;
-	::setsockopt(mSock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&nodelay),
+	::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char *>(&nodelay),
 	             sizeof(nodelay));
 
 #ifdef __APPLE__
 	// MacOS lacks MSG_NOSIGNAL and requires SO_NOSIGPIPE instead
 	const sockopt_t enabled = 1;
-	if (::setsockopt(mSock, SOL_SOCKET, SO_NOSIGPIPE, &enabled, sizeof(enabled)) < 0)
+	if (::setsockopt(sock, SOL_SOCKET, SO_NOSIGPIPE, &enabled, sizeof(enabled)) < 0)
 		throw std::runtime_error("Failed to disable SIGPIPE for socket");
 #endif
 }
@@ -310,6 +379,7 @@ void TcpTransport::close() {
 
 bool TcpTransport::trySendQueue() {
 	// mSendMutex must be locked
+
 	while (auto next = mSendQueue.peek()) {
 		message_ptr message = std::move(*next);
 		size_t size = message->size();
@@ -439,38 +509,101 @@ void TcpTransport::process(PollService::Event event) {
 	recv(nullptr);
 }
 
-void TcpTransport::processConnect(PollService::Event event) {
+void TcpTransport::closeUnusedSockets() {
+	// mSendMutex must be locked
+
+	for (socket_t sock : mSocks) {
+		if (mSock == INVALID_SOCKET || sock != mSock) {
+			PLOG_VERBOSE << "Closing unused socket with descriptor " << sock;
+			PollService::Instance().remove(sock);
+			::closesocket(sock);
+		}
+	}
+
+	mSocks.clear();
+	mPendingAddresses = 0;
+}
+
+void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool isDelayTimeout) {
+
+	if (event == PollService::Event::Timeout && isDelayTimeout) {
+
+		// There are more addresses to attempt concurrently. Add this socket back to the poll
+		// service and use the remaining time until the connection timeout as the timeout
+
+		assert(mConnectAttemptDelay.has_value());
+		assert(!mConnectTimeout.has_value() || mConnectAttemptDelay < mConnectTimeout);
+
+		std::optional<std::chrono::milliseconds> timeout;
+		if (mConnectTimeout.has_value() && mConnectAttemptDelay.has_value())
+			timeout = *mConnectTimeout - *mConnectAttemptDelay;
+
+		PLOG_VERBOSE << "Continuing to poll socket with descriptor " << sock;
+		PLOG_VERBOSE_IF(timeout.has_value()) << "Using timeout " << timeout->count() << "ms";
+
+		PollService::Instance().add(
+		    sock, {PollService::Direction::Out, timeout,
+		           weak_bind(&TcpTransport::processConnect, this, _1, sock, false)});
+
+		ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
+
+		return;
+	}
+
+	bool isLastSock = false;
+
 	try {
-		if (event == PollService::Event::Error)
-			throw std::runtime_error("TCP connection failed");
+		{
+			std::lock_guard lock(mSendMutex);
 
-		if (event == PollService::Event::Timeout)
-			throw std::runtime_error("TCP connection timed out");
+			mPendingAddresses -= 1;
+			assert(mPendingAddresses >= 0);
+			isLastSock = mPendingAddresses == 0;
 
-		if (event != PollService::Event::Out)
-			return;
+			if (event == PollService::Event::Error)
+				throw std::runtime_error("TCP connection failed");
 
-		int err = 0;
-		socklen_t errlen = sizeof(err);
-		if (::getsockopt(mSock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&err),
-						 &errlen) != 0)
-			throw std::runtime_error("Failed to get socket error code");
+			if (event == PollService::Event::Timeout)
+				throw std::runtime_error("TCP connection timeout");
 
-		if (err != 0) {
-			std::ostringstream msg;
-			msg << "TCP connection failed, errno=" << err;
-			throw std::runtime_error(msg.str());
+			if (event != PollService::Event::Out)
+				return;
+
+			int err = 0;
+			socklen_t errlen = sizeof(err);
+			if (::getsockopt(sock, SOL_SOCKET, SO_ERROR, reinterpret_cast<char *>(&err), &errlen) !=
+			    0)
+				throw std::runtime_error("Failed to get socket error code");
+
+			if (err != 0) {
+				std::ostringstream msg;
+				msg << "TCP connection failed, errno=" << err;
+				throw std::runtime_error(msg.str());
+			}
+
+			// Use this socket and close all other opened sockets
+			mSock = sock;
+			closeUnusedSockets();
 		}
 
 		// Success
 		PLOG_INFO << "TCP connected";
+		PLOG_VERBOSE << "Using socket with descriptor " << mSock;
 		changeState(State::Connected);
 		setPoll(PollService::Direction::In);
 
 	} catch (const std::exception &e) {
 		PLOG_DEBUG << e.what();
-		PollService::Instance().remove(mSock);
-		ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
+		PollService::Instance().remove(sock);
+
+		// Queue the next connection attempt in one of two cases:
+		// - We connect synchronously (no connection attempt delay is configured)
+		// - We connect to multiple addresses in parallel and this was the last socket that errored.
+		//   This means that all sockets errored and we must proceed with triggering the connection
+		//   failure handling code in the attempt() method
+		if (!mConnectAttemptDelay.has_value() || isLastSock) {
+			ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
+		}
 	}
 }
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -387,6 +387,7 @@ void TcpTransport::close() {
 		::closesocket(mSock);
 		mSock = INVALID_SOCKET;
 	}
+	closeUnusedSockets();
 	changeState(State::Disconnected);
 }
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -186,6 +186,7 @@ static void interleave_address_families(addrinfo *&head) {
 void TcpTransport::resolve() {
 	std::lock_guard lock(mSendMutex);
 	mResolved.clear();
+	mPendingSocks = 0;
 
 	if (state() != State::Connecting)
 		return; // Cancelled
@@ -264,8 +265,9 @@ void TcpTransport::attempt() {
 		// We need to make sure that we only close the remaining sockets once all addresses have
 		// been attempted or one of the addresses has successfully connected, as createSocket()
 		// might otherwise return a file descriptor that we already encountered before, since it can
-		// reuse closed file descriptors
+		// reuse closed file descriptors, and thereby cause issues with our use of a set here
 		assert(mSocks.find(sock) == mSocks.end());
+
 		mSocks.insert(sock);
 		mPendingSocks += 1;
 
@@ -555,9 +557,13 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		{
 			std::lock_guard lock(mSendMutex);
 
-			mPendingSocks -= 1;
-			assert(mPendingSocks >= 0);
-			isLastPendingSock = mPendingSocks == 0;
+			assert(state() == State::Connecting && mPendingSocks > 0 ||
+			       state() != State::Connecting && mPendingSocks == 0);
+
+			if (state() == State::Connecting) {
+				mPendingSocks -= 1;
+				isLastPendingSock = mPendingSocks == 0;
+			}
 
 			if (event == PollService::Event::Error)
 				throw std::runtime_error("TCP connection failed");

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -262,9 +262,11 @@ void TcpTransport::attempt() {
 			return;
 
 		if (mResolved.empty()) {
-			PLOG_WARNING << "Connection to " << mHostname << ":" << mService << " failed";
-			closeUnusedSockets();
-			changeState(State::Failed);
+			if (mPendingSocks == 0) {
+				PLOG_WARNING << "Connection to " << mHostname << ":" << mService << " failed";
+				closeUnusedSockets();
+				changeState(State::Failed);
+			}
 			return;
 		}
 
@@ -564,8 +566,6 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 		return;
 	}
 
-	bool isLastPendingSock = false;
-
 	try {
 		{
 			std::lock_guard lock(mSendMutex);
@@ -575,7 +575,6 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 
 			if (state() == State::Connecting) {
 				mPendingSocks -= 1;
-				isLastPendingSock = mPendingSocks == 0;
 			}
 
 			if (event == PollService::Event::Error)
@@ -622,22 +621,7 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 	} catch (const std::exception &e) {
 		PLOG_DEBUG << e.what();
 		PollService::Instance().remove(sock);
-
-		// Queue the next connection attempt in one of these cases:
-		// 1. We connect synchronously (no connection attempt delay is configured)
-		// 2. A connection attempt delay is configured, but it is identical to the
-
-		// Queue the next connection attempt in one of these cases:
-		// 1. We connect synchronously (no connection attempt delay is configured)
-		// 2. We connect concurrently and this socket failed before the delay timeout was reached
-		// 3. We connect concurrently and this was the last pending socket that timed out. This
-		//    means that all sockets that were created so far failed and we must proceed either with
-		//    queueing a connection attempt for the next address or with handling connection
-		//    failure, for the case that there are no more addresses left
-		if (!mConnectAttemptDelay.has_value() || event != PollService::Event::Timeout ||
-		    isLastPendingSock) {
-			ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
-		}
+		ThreadPool::Instance().enqueue(weak_bind(&TcpTransport::attempt, this));
 	}
 }
 

--- a/src/impl/tcptransport.cpp
+++ b/src/impl/tcptransport.cpp
@@ -289,18 +289,18 @@ void TcpTransport::attempt() {
 		return;
 	}
 
-	// Use the connect attempt delay as timeout, if there are more addresses to attempt and a
-	// connect attempt delay is configured, i.e. we are performing "Happy Eyeballs"
 	std::optional<std::chrono::milliseconds> timeout = mConnectTimeout;
-	if (!isLastAttempt && mConnectAttemptDelay.has_value()) {
-		timeout = mConnectAttemptDelay;
-		// Make sure not to exceed the connection timeout.
-		if (mConnectTimeout.has_value())
-			timeout = std::min(*timeout, *mConnectTimeout);
-	}
+	bool isDelayTimeout = false;
 
-	bool isDelayTimeout =
-	    timeout.has_value() && (!mConnectTimeout.has_value() || *timeout < *mConnectTimeout);
+	// Use the connect attempt delay as timeout, if there are more addresses to attempt and a
+	// connect attempt delay is configured, i.e. we are performing "Happy Eyeballs". This connection
+	// attempt continues after the timeout then. The delay timeout is not required, when the connect
+	// timeout is less than or equal to it, as we just time out normally then
+	if (!isLastAttempt && mConnectAttemptDelay.has_value() &&
+	    (!mConnectTimeout.has_value() || *mConnectAttemptDelay < *mConnectTimeout)) {
+		timeout = *mConnectAttemptDelay;
+		isDelayTimeout = true;
+	}
 
 	PLOG_VERBOSE << "Polling socket with descriptor " << sock;
 	PLOG_VERBOSE_IF(timeout.has_value()) << "Using timeout " << timeout->count() << "ms"
@@ -622,6 +622,10 @@ void TcpTransport::processConnect(PollService::Event event, socket_t sock, bool 
 	} catch (const std::exception &e) {
 		PLOG_DEBUG << e.what();
 		PollService::Instance().remove(sock);
+
+		// Queue the next connection attempt in one of these cases:
+		// 1. We connect synchronously (no connection attempt delay is configured)
+		// 2. A connection attempt delay is configured, but it is identical to the
 
 		// Queue the next connection attempt in one of these cases:
 		// 1. We connect synchronously (no connection attempt delay is configured)

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -75,7 +75,7 @@ private:
 
 	std::list<std::tuple<struct sockaddr_storage, socklen_t>> mResolved;
 	std::unordered_set<socket_t> mSocks;
-	int mPendingAddresses = 0;
+	int mPendingSocks = 0;
 
 	socket_t mSock;
 	Queue<message_ptr> mSendQueue;

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -75,7 +75,7 @@ private:
 
 	std::list<std::tuple<struct sockaddr_storage, socklen_t>> mResolved;
 	std::unordered_set<socket_t> mSocks;
-	int mPendingSocks = 0;
+	size_t mPendingSocks = 0;
 
 	socket_t mSock;
 	Queue<message_ptr> mSendQueue;

--- a/src/impl/tcptransport.hpp
+++ b/src/impl/tcptransport.hpp
@@ -14,6 +14,7 @@
 #include "queue.hpp"
 #include "socket.hpp"
 #include "transport.hpp"
+#include <unordered_set>
 
 #if RTC_ENABLE_WEBSOCKET
 
@@ -33,6 +34,7 @@ public:
 	~TcpTransport();
 
 	void onBufferedAmount(amount_callback callback);
+	void setConnectAttemptDelay(std::chrono::milliseconds connectAttemptDelay);
 	void setConnectTimeout(std::chrono::milliseconds connectTimeout);
 	void setReadTimeout(std::chrono::milliseconds readTimeout);
 
@@ -46,13 +48,15 @@ public:
 	string remoteAddress() const;
 
 private:
+	static socket_t createSocket(const struct sockaddr *addr, socklen_t addrlen);
+	static void configureSocket(socket_t sock);
+
 	void connect();
 	void resolve();
 	void attempt();
-	void createSocket(const struct sockaddr *addr, socklen_t addrlen);
-	void configureSocket();
 	void setPoll(PollService::Direction direction);
 	void close();
+	void closeUnusedSockets();
 
 	bool trySendQueue();
 	bool trySendMessage(message_ptr &message);
@@ -60,15 +64,18 @@ private:
 	void triggerBufferedAmount(size_t amount);
 
 	void process(PollService::Event event);
-	void processConnect(PollService::Event event);
+	void processConnect(PollService::Event event, socket_t sock, bool isDelayTimeout);
 
 	const bool mIsActive;
 	string mHostname, mService;
 	amount_callback mBufferedAmountCallback;
+	optional<std::chrono::milliseconds> mConnectAttemptDelay;
 	optional<std::chrono::milliseconds> mConnectTimeout;
 	optional<std::chrono::milliseconds> mReadTimeout;
 
 	std::list<std::tuple<struct sockaddr_storage, socklen_t>> mResolved;
+	std::unordered_set<socket_t> mSocks;
+	int mPendingAddresses = 0;
 
 	socket_t mSock;
 	Queue<message_ptr> mSendQueue;

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -272,6 +272,11 @@ shared_ptr<TcpTransport> WebSocket::setTcpTransport(shared_ptr<TcpTransport> tra
 		if (connectTimeout > milliseconds::zero())
 			transport->setConnectTimeout(connectTimeout);
 
+		// Set connect attempt delay if specified
+		auto connectAttemptDelay = config.connectionAttemptDelay.value_or(250ms);
+		if (connectAttemptDelay > milliseconds::zero())
+			transport->setConnectAttemptDelay(connectAttemptDelay);
+
 		scheduleConnectionTimeout();
 
 		return emplaceTransport(this, &mTcpTransport, std::move(transport));


### PR DESCRIPTION
This PR implements concurrent connection attempts for WebSockets and is a direct result of #1556. I implemented this mostly to serve my own needs and I didn't read the full Happy Eyeballs RFCs ([RFC 6555](https://www.rfc-editor.org/info/rfc6555/) and [RFC 8305](https://www.rfc-editor.org/info/rfc8305)), but I did my best to address all comments made in #1556, except "For WebSockets the IP address family should also be cached for later connections.", which I left as a TODO.

Summary (commit message): Connects to addresses concurrently, so that IPv4 and IPv6 addresses are attempted concurrently. This reduces connection latency in cases where the first address is not reachable. Reorders addresses in such a way that IPv4 and IPv6 addresses are interleaved and addresses from both families are attempted as early as possible. Closes all created sockets that are unused, once a connection succeeds or all connections fail. Adds an option to configure the connection attempt delay or to disable concurrent connection attempts altogether. Also adds verbose logging to help with debugging.

Fixes #1556.

So far I've only tested this on Linux. I will add this to my app where it will get some battle testing and I will also test this by hand on Windows and Mac. I'll report back once I got the results of that.

I'm certain there are things that need to be adapted or change, I'd appreciate any feedback!