### PR TITLE
Remove unecessary extended grammar for URL-matching regexes

### DIFF
--- a/src/configuration.cpp
+++ b/src/configuration.cpp
@@ -20,7 +20,7 @@ bool parse_url(const std::string &url, std::vector<std::optional<std::string>> &
 	// Modified regex from RFC 3986, see https://www.rfc-editor.org/rfc/rfc3986.html#appendix-B
 	static const char *rs =
 	    R"(^(([^:.@/?#]+):)?(/{0,2}((([^:@]*)(:([^@]*))?)@)?(([^:/?#]*)(:([^/?#]*))?))?([^?#]*)(\?([^#]*))?(#(.*))?)";
-	static const std::regex r(rs, std::regex::extended);
+	static const std::regex r(rs);
 
 	std::smatch m;
 	if (!std::regex_match(url, m, r) || m[10].length() == 0)

--- a/src/impl/websocket.cpp
+++ b/src/impl/websocket.cpp
@@ -78,7 +78,7 @@ void WebSocket::open(const string &url, const rtc::WebSocket::Headers &headers) 
 	static const char *rs =
 	    R"(^(([^:.@/?#]+):)?(/{0,2}((([^:@]*)(:([^@]*))?)@)?(([^:/?#]*)(:([^/?#]*))?))?([^?#]*)(\?([^#]*))?(#(.*))?)";
 
-	static const std::regex r(rs, std::regex::extended);
+	static const std::regex r(rs);
 
 	std::smatch m;
 	if (!std::regex_match(url, m, r) || m[10].length() == 0)


### PR DESCRIPTION
This PR removes the unecessary `std::regex::extended` for URL-matching regexes.

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1591