### PR TITLE
Add support for mbedTLS 4.1, use PSA Crypto API

### DIFF
--- a/.github/workflows/build-mbedtls.yml
+++ b/.github/workflows/build-mbedtls.yml
@@ -30,6 +30,30 @@ jobs:
     - name: test
       run: ./build/tests
 
+  build-linux-v4:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Install Mbed TLS
+      run: brew update && brew install mbedtls@4
+
+    - name: cmake
+      run: cmake -B build -DUSE_MBEDTLS=1 -DNO_MEDIA=1 -DWARNINGS_AS_ERRORS=1  -DCMAKE_PREFIX_PATH=$(brew --prefix mbedtls@4)
+
+    - name: make
+      run: (cd build; make -j2)
+
+    - name: test
+      run: ./build/tests
+
   build-macos:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/build-mbedtls.yml
+++ b/.github/workflows/build-mbedtls.yml
@@ -30,6 +30,30 @@ jobs:
     - name: test
       run: ./build/tests
 
+  build-linux-v4:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 1
+
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Install Mbed TLS
+      run: brew update && brew install mbedtls@4
+
+    - name: cmake
+      run: cmake -B build -DUSE_MBEDTLS=1 -DWARNINGS_AS_ERRORS=1 -DCMAKE_PREFIX_PATH=$(brew --prefix mbedtls@4)
+
+    - name: make
+      run: (cd build; make -j2)
+
+    - name: test
+      run: ./build/tests
+
   build-macos:
     runs-on: macos-latest
     steps:

--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -203,9 +203,11 @@ string make_fingerprint(mbedtls_x509_crt *crt,
 	}
 
 	size_t hash_size = 0;
-	mbedtls::check(psa_hash_compute(alg, crt->raw.p, crt->raw.len,
-	        buffer.data(), buffer.size(), &hash_size),
-	        "Failed to generate certificate fingerprint");
+	int ret = mbedtls::safe_psa([&] {
+		return psa_hash_compute(alg, crt->raw.p, crt->raw.len,
+		        buffer.data(), buffer.size(), &hash_size);
+	});
+	mbedtls::check(ret, "Failed to generate certificate fingerprint");
 	if (hash_size != buffer.size()) {
 		throw std::runtime_error("Unexpected hash size");
 	}
@@ -287,29 +289,42 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		// See https://www.rfc-editor.org/rfc/rfc8827.html#section-6.5
 		case CertificateType::Default:
 		case CertificateType::Ecdsa: {
-			psa_key_id_t slot = PSA_KEY_ID_NULL;
-			psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
-			psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
-			psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
-			psa_set_key_bits(&attr, 256);
-			mbedtls::check(psa_generate_key(&attr, &slot), "Unable to generate ECDSA P-256 key pair");
-			int ret = mbedtls_pk_copy_from_psa(slot, pk.get());
-			psa_destroy_key(slot);
-			mbedtls::check(ret);
+			int ret = mbedtls::safe_psa([&] {
+				psa_key_id_t slot = PSA_KEY_ID_NULL;
+				psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+				psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+				psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+				psa_set_key_bits(&attr, 256);
+				int ret = psa_generate_key(&attr, &slot);
+				if (ret) {
+					psa_destroy_key(slot);
+					return ret;
+				}
+				ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+				psa_destroy_key(slot);
+				return ret;
+			});
+			mbedtls::check(ret, "Unable to generate ECDSA P-256 key pair");
 			break;
 		}
 		case CertificateType::Rsa: {
 			const unsigned int nbits = 2048;
-
-			psa_key_id_t slot = PSA_KEY_ID_NULL;
-			psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
-			psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_KEY_PAIR);
-			psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
-			psa_set_key_bits(&attr, nbits);
-			mbedtls::check(psa_generate_key(&attr, &slot), "Unable to generate RSA key pair");
-			int ret = mbedtls_pk_copy_from_psa(slot, pk.get());
-			psa_destroy_key(slot);
-			mbedtls::check(ret);
+			int ret = mbedtls::safe_psa([&] {
+				psa_key_id_t slot = PSA_KEY_ID_NULL;
+				psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+				psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_KEY_PAIR);
+				psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+				psa_set_key_bits(&attr, nbits);
+				int ret = psa_generate_key(&attr, &slot);
+				if (ret) {
+					psa_destroy_key(slot);
+					return ret;
+				}
+				ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+				psa_destroy_key(slot);
+				return ret;
+			});
+			mbedtls::check(ret, "Unable to generate RSA key pair");
 			break;
 		}
 		default:
@@ -322,8 +337,10 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 
 		const size_t serialBufferSize = 16;
 		unsigned char serialBuffer[serialBufferSize];
-		mbedtls::check(psa_generate_random(serialBuffer, serialBufferSize),
-		               "Failed to generate certificate");
+		int ret = mbedtls::safe_psa([&] {
+			return psa_generate_random(serialBuffer, serialBufferSize);
+		});
+		mbedtls::check(ret, "Failed to generate certificate");
 
 		std::string name = std::string("O=" + commonName + ",CN=" + commonName);
 		mbedtls::check(mbedtls_x509write_crt_set_serial_raw(&wcrt, serialBuffer, serialBufferSize),

--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -180,30 +180,36 @@ string make_fingerprint(mbedtls_x509_crt *crt,
 	std::vector<unsigned char> buffer(size);
 	std::stringstream fingerprint;
 
+	psa_algorithm_t alg = PSA_ALG_NONE;
+
 	switch (fingerprintAlgorithm) {
 	case CertificateFingerprint::Algorithm::Sha1:
-		mbedtls::check(mbedtls_sha1(crt->raw.p, crt->raw.len, buffer.data()),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_1;
 		break;
 	case CertificateFingerprint::Algorithm::Sha224:
-		mbedtls::check(mbedtls_sha256(crt->raw.p, crt->raw.len, buffer.data(), 1),
-		               "Failed to generate certificate fingerprint");
-
+		alg = PSA_ALG_SHA_224;
 		break;
 	case CertificateFingerprint::Algorithm::Sha256:
-		mbedtls::check(mbedtls_sha256(crt->raw.p, crt->raw.len, buffer.data(), 0),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_256;
 		break;
 	case CertificateFingerprint::Algorithm::Sha384:
-		mbedtls::check(mbedtls_sha512(crt->raw.p, crt->raw.len, buffer.data(), 1),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_384;
 		break;
 	case CertificateFingerprint::Algorithm::Sha512:
-		mbedtls::check(mbedtls_sha512(crt->raw.p, crt->raw.len, buffer.data(), 0),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_512;
 		break;
 	default:
 		throw std::invalid_argument("Unknown fingerprint algorithm");
+	}
+
+	size_t hash_size = 0;
+	int ret = mbedtls::safe_psa([&] {
+		return psa_hash_compute(alg, crt->raw.p, crt->raw.len,
+		        buffer.data(), buffer.size(), &hash_size);
+	});
+	mbedtls::check(ret, "Failed to generate certificate fingerprint");
+	if (hash_size != buffer.size()) {
+		throw std::runtime_error("Unexpected hash size");
 	}
 
 	for (auto i = 0; i < size; i++) {
@@ -231,10 +237,17 @@ Certificate Certificate::FromString(string crt_pem, string key_pem) {
 	                                      reinterpret_cast<const unsigned char *>(crt_pem.c_str()),
 	                                      crt_pem.size() + 1),
 	               "Failed to parse certificate");
+#if MBEDTLS_VERSION_MAJOR < 4
 	mbedtls::check(mbedtls_pk_parse_key(pk.get(),
 	                                    reinterpret_cast<const unsigned char *>(key_pem.c_str()),
 	                                    key_pem.size() + 1, NULL, 0, NULL, 0),
 	               "Failed to parse key");
+#else
+	mbedtls::check(mbedtls_pk_parse_key(pk.get(),
+	                                    reinterpret_cast<const unsigned char *>(key_pem.c_str()),
+	                                    key_pem.size() + 1, NULL, 0),
+	               "Failed to parse key");
+#endif
 
 	return Certificate(std::move(crt), std::move(pk));
 }
@@ -248,8 +261,13 @@ Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_
 
 	mbedtls::check(mbedtls_x509_crt_parse_file(crt.get(), crt_pem_file.c_str()),
 	               "Failed to parse certificate");
+#if MBEDTLS_VERSION_MAJOR < 4
 	mbedtls::check(mbedtls_pk_parse_keyfile(pk.get(), key_pem_file.c_str(), pass.c_str(), 0, NULL),
 	               "Failed to parse key");
+#else
+	mbedtls::check(mbedtls_pk_parse_keyfile(pk.get(), key_pem_file.c_str(), pass.c_str()),
+	               "Failed to parse key");
+#endif
 
 	return Certificate(std::move(crt), std::move(pk));
 }
@@ -257,24 +275,13 @@ Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_
 Certificate Certificate::Generate(CertificateType type, const string &commonName) {
 	PLOG_DEBUG << "Generating certificate (MbedTLS)";
 
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
 	mbedtls_x509write_cert wcrt;
-	mbedtls_mpi serial;
 	auto crt = mbedtls::new_x509_crt();
 	auto pk = mbedtls::new_pk_context();
 
-	mbedtls_entropy_init(&entropy);
-	mbedtls_ctr_drbg_init(&drbg);
-	mbedtls_ctr_drbg_set_prediction_resistance(&drbg, MBEDTLS_CTR_DRBG_PR_ON);
 	mbedtls_x509write_crt_init(&wcrt);
-	mbedtls_mpi_init(&serial);
 
 	try {
-		mbedtls::check(mbedtls_ctr_drbg_seed(
-		    &drbg, mbedtls_entropy_func, &entropy,
-		    reinterpret_cast<const unsigned char *>(commonName.data()), commonName.size()));
-
 		switch (type) {
 		// RFC 8827 WebRTC Security Architecture 6.5. Communications Security
 		// All implementations MUST support DTLS 1.2 with the
@@ -282,20 +289,42 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		// See https://www.rfc-editor.org/rfc/rfc8827.html#section-6.5
 		case CertificateType::Default:
 		case CertificateType::Ecdsa: {
-			mbedtls::check(mbedtls_pk_setup(pk.get(), mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)));
-			mbedtls::check(mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pk.get()),
-			                                   mbedtls_ctr_drbg_random, &drbg),
-			               "Unable to generate ECDSA P-256 key pair");
+			int ret = mbedtls::safe_psa([&] {
+				psa_key_id_t slot = PSA_KEY_ID_NULL;
+				psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+				psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+				psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+				psa_set_key_bits(&attr, 256);
+				int ret = psa_generate_key(&attr, &slot);
+				if (ret) {
+					psa_destroy_key(slot);
+					return ret;
+				}
+				ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+				psa_destroy_key(slot);
+				return ret;
+			});
+			mbedtls::check(ret, "Unable to generate ECDSA P-256 key pair");
 			break;
 		}
 		case CertificateType::Rsa: {
 			const unsigned int nbits = 2048;
-			const int exponent = 65537;
-
-			mbedtls::check(mbedtls_pk_setup(pk.get(), mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)));
-			mbedtls::check(mbedtls_rsa_gen_key(mbedtls_pk_rsa(*pk.get()), mbedtls_ctr_drbg_random,
-			                                   &drbg, nbits, exponent),
-			               "Unable to generate RSA key pair");
+			int ret = mbedtls::safe_psa([&] {
+				psa_key_id_t slot = PSA_KEY_ID_NULL;
+				psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+				psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_KEY_PAIR);
+				psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+				psa_set_key_bits(&attr, nbits);
+				int ret = psa_generate_key(&attr, &slot);
+				if (ret) {
+					psa_destroy_key(slot);
+					return ret;
+				}
+				ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+				psa_destroy_key(slot);
+				return ret;
+			});
+			mbedtls::check(ret, "Unable to generate RSA key pair");
 			break;
 		}
 		default:
@@ -308,13 +337,13 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 
 		const size_t serialBufferSize = 16;
 		unsigned char serialBuffer[serialBufferSize];
-		mbedtls::check(mbedtls_ctr_drbg_random(&drbg, serialBuffer, serialBufferSize),
-		               "Failed to generate certificate");
-		mbedtls::check(mbedtls_mpi_read_binary(&serial, serialBuffer, serialBufferSize),
-		               "Failed to generate certificate");
+		int ret = mbedtls::safe_psa([&] {
+			return psa_generate_random(serialBuffer, serialBufferSize);
+		});
+		mbedtls::check(ret, "Failed to generate certificate");
 
 		std::string name = std::string("O=" + commonName + ",CN=" + commonName);
-		mbedtls::check(mbedtls_x509write_crt_set_serial(&wcrt, &serial),
+		mbedtls::check(mbedtls_x509write_crt_set_serial_raw(&wcrt, serialBuffer, serialBufferSize),
 		               "Failed to generate certificate");
 		mbedtls::check(mbedtls_x509write_crt_set_subject_name(&wcrt, name.c_str()),
 		               "Failed to generate certificate");
@@ -333,8 +362,13 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		unsigned char certificateBuffer[certificateBufferSize];
 		std::memset(certificateBuffer, 0, certificateBufferSize);
 
+#if MBEDTLS_VERSION_MAJOR < 4
 		auto certificateLen = mbedtls_x509write_crt_der(
-		    &wcrt, certificateBuffer, certificateBufferSize, mbedtls_ctr_drbg_random, &drbg);
+		    &wcrt, certificateBuffer, certificateBufferSize, &mbedtls::random_func, nullptr);
+#else
+		auto certificateLen = mbedtls_x509write_crt_der(
+		    &wcrt, certificateBuffer, certificateBufferSize);
+#endif
 		if (certificateLen <= 0) {
 			throw std::runtime_error("Certificate generation failed");
 		}
@@ -344,17 +378,11 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		                   certificateLen),
 		               "Failed to generate certificate");
 	} catch (...) {
-		mbedtls_entropy_free(&entropy);
-		mbedtls_ctr_drbg_free(&drbg);
 		mbedtls_x509write_crt_free(&wcrt);
-		mbedtls_mpi_free(&serial);
 		throw;
 	}
 
-	mbedtls_entropy_free(&entropy);
-	mbedtls_ctr_drbg_free(&drbg);
 	mbedtls_x509write_crt_free(&wcrt);
-	mbedtls_mpi_free(&serial);
 	return Certificate(std::move(crt), std::move(pk));
 }
 

--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -180,30 +180,34 @@ string make_fingerprint(mbedtls_x509_crt *crt,
 	std::vector<unsigned char> buffer(size);
 	std::stringstream fingerprint;
 
+	psa_algorithm_t alg = PSA_ALG_NONE;
+
 	switch (fingerprintAlgorithm) {
 	case CertificateFingerprint::Algorithm::Sha1:
-		mbedtls::check(mbedtls_sha1(crt->raw.p, crt->raw.len, buffer.data()),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_1;
 		break;
 	case CertificateFingerprint::Algorithm::Sha224:
-		mbedtls::check(mbedtls_sha256(crt->raw.p, crt->raw.len, buffer.data(), 1),
-		               "Failed to generate certificate fingerprint");
-
+		alg = PSA_ALG_SHA_224;
 		break;
 	case CertificateFingerprint::Algorithm::Sha256:
-		mbedtls::check(mbedtls_sha256(crt->raw.p, crt->raw.len, buffer.data(), 0),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_256;
 		break;
 	case CertificateFingerprint::Algorithm::Sha384:
-		mbedtls::check(mbedtls_sha512(crt->raw.p, crt->raw.len, buffer.data(), 1),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_384;
 		break;
 	case CertificateFingerprint::Algorithm::Sha512:
-		mbedtls::check(mbedtls_sha512(crt->raw.p, crt->raw.len, buffer.data(), 0),
-		               "Failed to generate certificate fingerprint");
+		alg = PSA_ALG_SHA_512;
 		break;
 	default:
 		throw std::invalid_argument("Unknown fingerprint algorithm");
+	}
+
+	size_t hash_size = 0;
+	mbedtls::check(psa_hash_compute(alg, crt->raw.p, crt->raw.len,
+	        buffer.data(), buffer.size(), &hash_size),
+	        "Failed to generate certificate fingerprint");
+	if (hash_size != buffer.size()) {
+		throw std::runtime_error("Unexpected hash size");
 	}
 
 	for (auto i = 0; i < size; i++) {
@@ -231,10 +235,17 @@ Certificate Certificate::FromString(string crt_pem, string key_pem) {
 	                                      reinterpret_cast<const unsigned char *>(crt_pem.c_str()),
 	                                      crt_pem.size() + 1),
 	               "Failed to parse certificate");
+#if MBEDTLS_VERSION_MAJOR < 4
 	mbedtls::check(mbedtls_pk_parse_key(pk.get(),
 	                                    reinterpret_cast<const unsigned char *>(key_pem.c_str()),
 	                                    key_pem.size() + 1, NULL, 0, NULL, 0),
 	               "Failed to parse key");
+#else
+	mbedtls::check(mbedtls_pk_parse_key(pk.get(),
+	                                    reinterpret_cast<const unsigned char *>(key_pem.c_str()),
+	                                    key_pem.size() + 1, NULL, 0),
+	               "Failed to parse key");
+#endif
 
 	return Certificate(std::move(crt), std::move(pk));
 }
@@ -248,8 +259,13 @@ Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_
 
 	mbedtls::check(mbedtls_x509_crt_parse_file(crt.get(), crt_pem_file.c_str()),
 	               "Failed to parse certificate");
+#if MBEDTLS_VERSION_MAJOR < 4
 	mbedtls::check(mbedtls_pk_parse_keyfile(pk.get(), key_pem_file.c_str(), pass.c_str(), 0, NULL),
 	               "Failed to parse key");
+#else
+	mbedtls::check(mbedtls_pk_parse_keyfile(pk.get(), key_pem_file.c_str(), pass.c_str()),
+	               "Failed to parse key");
+#endif
 
 	return Certificate(std::move(crt), std::move(pk));
 }
@@ -257,24 +273,13 @@ Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_
 Certificate Certificate::Generate(CertificateType type, const string &commonName) {
 	PLOG_DEBUG << "Generating certificate (MbedTLS)";
 
-	mbedtls_entropy_context entropy;
-	mbedtls_ctr_drbg_context drbg;
 	mbedtls_x509write_cert wcrt;
-	mbedtls_mpi serial;
 	auto crt = mbedtls::new_x509_crt();
 	auto pk = mbedtls::new_pk_context();
 
-	mbedtls_entropy_init(&entropy);
-	mbedtls_ctr_drbg_init(&drbg);
-	mbedtls_ctr_drbg_set_prediction_resistance(&drbg, MBEDTLS_CTR_DRBG_PR_ON);
 	mbedtls_x509write_crt_init(&wcrt);
-	mbedtls_mpi_init(&serial);
 
 	try {
-		mbedtls::check(mbedtls_ctr_drbg_seed(
-		    &drbg, mbedtls_entropy_func, &entropy,
-		    reinterpret_cast<const unsigned char *>(commonName.data()), commonName.size()));
-
 		switch (type) {
 		// RFC 8827 WebRTC Security Architecture 6.5. Communications Security
 		// All implementations MUST support DTLS 1.2 with the
@@ -282,20 +287,29 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		// See https://www.rfc-editor.org/rfc/rfc8827.html#section-6.5
 		case CertificateType::Default:
 		case CertificateType::Ecdsa: {
-			mbedtls::check(mbedtls_pk_setup(pk.get(), mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY)));
-			mbedtls::check(mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, mbedtls_pk_ec(*pk.get()),
-			                                   mbedtls_ctr_drbg_random, &drbg),
-			               "Unable to generate ECDSA P-256 key pair");
+			psa_key_id_t slot = PSA_KEY_ID_NULL;
+			psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+			psa_set_key_type(&attr, PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1));
+			psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+			psa_set_key_bits(&attr, 256);
+			mbedtls::check(psa_generate_key(&attr, &slot), "Unable to generate ECDSA P-256 key pair");
+			int ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+			psa_destroy_key(slot);
+			mbedtls::check(ret);
 			break;
 		}
 		case CertificateType::Rsa: {
 			const unsigned int nbits = 2048;
-			const int exponent = 65537;
 
-			mbedtls::check(mbedtls_pk_setup(pk.get(), mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)));
-			mbedtls::check(mbedtls_rsa_gen_key(mbedtls_pk_rsa(*pk.get()), mbedtls_ctr_drbg_random,
-			                                   &drbg, nbits, exponent),
-			               "Unable to generate RSA key pair");
+			psa_key_id_t slot = PSA_KEY_ID_NULL;
+			psa_key_attributes_t attr = PSA_KEY_ATTRIBUTES_INIT;
+			psa_set_key_type(&attr, PSA_KEY_TYPE_RSA_KEY_PAIR);
+			psa_set_key_usage_flags(&attr, PSA_KEY_USAGE_EXPORT | PSA_KEY_USAGE_COPY);
+			psa_set_key_bits(&attr, nbits);
+			mbedtls::check(psa_generate_key(&attr, &slot), "Unable to generate RSA key pair");
+			int ret = mbedtls_pk_copy_from_psa(slot, pk.get());
+			psa_destroy_key(slot);
+			mbedtls::check(ret);
 			break;
 		}
 		default:
@@ -308,13 +322,11 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 
 		const size_t serialBufferSize = 16;
 		unsigned char serialBuffer[serialBufferSize];
-		mbedtls::check(mbedtls_ctr_drbg_random(&drbg, serialBuffer, serialBufferSize),
-		               "Failed to generate certificate");
-		mbedtls::check(mbedtls_mpi_read_binary(&serial, serialBuffer, serialBufferSize),
+		mbedtls::check(psa_generate_random(serialBuffer, serialBufferSize),
 		               "Failed to generate certificate");
 
 		std::string name = std::string("O=" + commonName + ",CN=" + commonName);
-		mbedtls::check(mbedtls_x509write_crt_set_serial(&wcrt, &serial),
+		mbedtls::check(mbedtls_x509write_crt_set_serial_raw(&wcrt, serialBuffer, serialBufferSize),
 		               "Failed to generate certificate");
 		mbedtls::check(mbedtls_x509write_crt_set_subject_name(&wcrt, name.c_str()),
 		               "Failed to generate certificate");
@@ -333,8 +345,13 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		unsigned char certificateBuffer[certificateBufferSize];
 		std::memset(certificateBuffer, 0, certificateBufferSize);
 
+#if MBEDTLS_VERSION_MAJOR < 4
 		auto certificateLen = mbedtls_x509write_crt_der(
-		    &wcrt, certificateBuffer, certificateBufferSize, mbedtls_ctr_drbg_random, &drbg);
+		    &wcrt, certificateBuffer, certificateBufferSize, &mbedtls::random_func, nullptr);
+#else
+		auto certificateLen = mbedtls_x509write_crt_der(
+		    &wcrt, certificateBuffer, certificateBufferSize);
+#endif
 		if (certificateLen <= 0) {
 			throw std::runtime_error("Certificate generation failed");
 		}
@@ -344,17 +361,11 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 		                   certificateLen),
 		               "Failed to generate certificate");
 	} catch (...) {
-		mbedtls_entropy_free(&entropy);
-		mbedtls_ctr_drbg_free(&drbg);
 		mbedtls_x509write_crt_free(&wcrt);
-		mbedtls_mpi_free(&serial);
 		throw;
 	}
 
-	mbedtls_entropy_free(&entropy);
-	mbedtls_ctr_drbg_free(&drbg);
 	mbedtls_x509write_crt_free(&wcrt);
-	mbedtls_mpi_free(&serial);
 	return Certificate(std::move(crt), std::move(pk));
 }
 

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -391,23 +391,20 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 	if (!mCertificate)
 		throw std::invalid_argument("DTLS certificate is null");
 
-	mbedtls_entropy_init(&mEntropy);
-	mbedtls_ctr_drbg_init(&mDrbg);
 	mbedtls_ssl_init(&mSsl);
 	mbedtls_ssl_config_init(&mConf);
-	mbedtls_ctr_drbg_set_prediction_resistance(&mDrbg, MBEDTLS_CTR_DRBG_PR_ON);
 
 	try {
-		mbedtls::check(mbedtls_ctr_drbg_seed(&mDrbg, mbedtls_entropy_func, &mEntropy, NULL, 0));
-
 		mbedtls::check(mbedtls_ssl_config_defaults(
 		                   &mConf, mIsClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
 		                   MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT));
 
-		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
+		mbedtls_ssl_conf_max_tls_version(&mConf, MBEDTLS_SSL_VERSION_TLS1_2);
 		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_OPTIONAL);
 		mbedtls_ssl_conf_verify(&mConf, DtlsTransport::CertificateCallback, this);
-		mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, &mDrbg);
+#if MBEDTLS_VERSION_MAJOR < 4
+		mbedtls_ssl_conf_rng(&mConf, mbedtls::random_func, nullptr);
+#endif
 
 		auto [crt, pk] = mCertificate->credentials();
 		mbedtls::check(mbedtls_ssl_conf_own_cert(&mConf, crt.get(), pk.get()));
@@ -422,8 +419,6 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
 		mbedtls_ssl_set_timer_cb(&mSsl, this, SetTimerCallback, GetTimerCallback);
 
 	} catch (...) {
-		mbedtls_entropy_free(&mEntropy);
-		mbedtls_ctr_drbg_free(&mDrbg);
 		mbedtls_ssl_free(&mSsl);
 		mbedtls_ssl_config_free(&mConf);
 		throw;
@@ -438,8 +433,6 @@ DtlsTransport::~DtlsTransport() {
 	stop();
 
 	PLOG_DEBUG << "Destroying DTLS transport";
-	mbedtls_entropy_free(&mEntropy);
-	mbedtls_ctr_drbg_free(&mDrbg);
 	mbedtls_ssl_free(&mSsl);
 	mbedtls_ssl_config_free(&mConf);
 }

--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -73,8 +73,6 @@ protected:
 	static int TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms);
 
 #elif USE_MBEDTLS
-	mbedtls_entropy_context mEntropy;
-	mbedtls_ctr_drbg_context mDrbg;
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
 

--- a/src/impl/init.cpp
+++ b/src/impl/init.cpp
@@ -138,7 +138,7 @@ void Init::doInit() {
 #if USE_GNUTLS
 	// Nothing to do
 #elif USE_MBEDTLS
-	// Nothing to do
+	mbedtls::init();
 #else
 	openssl::init();
 #endif

--- a/src/impl/sha.cpp
+++ b/src/impl/sha.cpp
@@ -17,7 +17,8 @@
 
 #elif USE_MBEDTLS
 
-#include <mbedtls/sha1.h>
+#include "tls.hpp"
+#include <psa/crypto.h>
 
 #else
 
@@ -50,8 +51,12 @@ binary Sha1(const byte *data, size_t size) {
 #elif USE_MBEDTLS
 
 	binary output(20);
-	mbedtls_sha1(reinterpret_cast<const unsigned char *>(data), size,
-	             reinterpret_cast<unsigned char *>(output.data()));
+	size_t hash_size = 0;
+	mbedtls::safe_psa([&] {
+		return psa_hash_compute(PSA_ALG_SHA_1, reinterpret_cast<const unsigned char *>(data),
+		             size, reinterpret_cast<unsigned char *>(output.data()), 20,
+		             &hash_size);
+	});
 	return output;
 
 #else

--- a/src/impl/sha.cpp
+++ b/src/impl/sha.cpp
@@ -17,6 +17,7 @@
 
 #elif USE_MBEDTLS
 
+#include "tls.hpp"
 #include <psa/crypto.h>
 
 #else
@@ -51,9 +52,11 @@ binary Sha1(const byte *data, size_t size) {
 
 	binary output(20);
 	size_t hash_size = 0;
-	psa_hash_compute(PSA_ALG_SHA_1, reinterpret_cast<const unsigned char *>(data),
-	             size, reinterpret_cast<unsigned char *>(output.data()), 20,
-	             &hash_size);
+	mbedtls::safe_psa([&] {
+		return psa_hash_compute(PSA_ALG_SHA_1, reinterpret_cast<const unsigned char *>(data),
+		             size, reinterpret_cast<unsigned char *>(output.data()), 20,
+		             &hash_size);
+	});
 	return output;
 
 #else

--- a/src/impl/sha.cpp
+++ b/src/impl/sha.cpp
@@ -17,7 +17,7 @@
 
 #elif USE_MBEDTLS
 
-#include <mbedtls/sha1.h>
+#include <psa/crypto.h>
 
 #else
 
@@ -50,8 +50,10 @@ binary Sha1(const byte *data, size_t size) {
 #elif USE_MBEDTLS
 
 	binary output(20);
-	mbedtls_sha1(reinterpret_cast<const unsigned char *>(data), size,
-	             reinterpret_cast<unsigned char *>(output.data()));
+	size_t hash_size = 0;
+	psa_hash_compute(PSA_ALG_SHA_1, reinterpret_cast<const unsigned char *>(data),
+	             size, reinterpret_cast<unsigned char *>(output.data()), 20,
+	             &hash_size);
 	return output;
 
 #else

--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -96,6 +96,33 @@ size_t my_strftme(char *buf, size_t size, const char *format, const time_t *t) {
 
 namespace rtc::mbedtls {
 
+void init() {
+	check(psa_crypto_init(), "psa_crypto_init failed.");
+}
+
+#if !defined(MBEDTLS_THREADING_C)
+std::mutex psa_mutex;
+
+int safe_psa(std::function<int()> func) {
+	std::unique_lock<std::mutex> lock(psa_mutex);
+	return func();
+}
+
+int random_func(void *rng, unsigned char *out, size_t len) {
+	std::unique_lock<std::mutex> lock(psa_mutex);
+	(void)rng;
+	return psa_generate_random(out, len);
+}
+#else
+int safe_psa(std::function<int()> func) {
+	return func();
+}
+int random_func(void *rng, unsigned char *out, size_t len) {
+	(void)rng;
+	return psa_generate_random(out, len);
+}
+#endif
+
 // Return false on non-fatal error
 bool check(int ret, const string &message) {
 	if (ret < 0) {

--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -96,6 +96,15 @@ size_t my_strftme(char *buf, size_t size, const char *format, const time_t *t) {
 
 namespace rtc::mbedtls {
 
+void init() {
+	check(psa_crypto_init(), "psa_crypto_init failed.");
+}
+
+int random_func(void *rng, unsigned char *out, size_t len) {
+	(void)rng;
+	return psa_generate_random(out, len);
+}
+
 // Return false on non-fatal error
 bool check(int ret, const string &message) {
 	if (ret < 0) {

--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -100,10 +100,28 @@ void init() {
 	check(psa_crypto_init(), "psa_crypto_init failed.");
 }
 
+#if !defined(MBEDTLS_THREADING_C)
+std::mutex psa_mutex;
+
+int safe_psa(std::function<int()> func) {
+	std::unique_lock<std::mutex> lock(psa_mutex);
+	return func();
+}
+
+int random_func(void *rng, unsigned char *out, size_t len) {
+	std::unique_lock<std::mutex> lock(psa_mutex);
+	(void)rng;
+	return psa_generate_random(out, len);
+}
+#else
+int safe_psa(std::function<int()> func) {
+	return func();
+}
 int random_func(void *rng, unsigned char *out, size_t len) {
 	(void)rng;
 	return psa_generate_random(out, len);
 }
+#endif
 
 // Return false on non-fatal error
 bool check(int ret, const string &message) {

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -40,17 +40,26 @@ gnutls_datum_t make_datum(char *data, size_t size);
 
 #elif USE_MBEDTLS
 
-#include "mbedtls/ctr_drbg.h"
-#include "mbedtls/ecdsa.h"
-#include "mbedtls/entropy.h"
+#include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/pk.h"
-#include "mbedtls/rsa.h"
-#include "mbedtls/sha256.h"
-#include "mbedtls/ssl.h"
 #include "mbedtls/x509_crt.h"
 
+// Mbed TLS version 3, relies on internal states when build with MBEDTLS_USE_PSA_CRYPTO.
+// Mbed TLS version 4 always realies on internal states.
+// In those scenarios, MBEDTLS_THREADING_C is required when using any Mbed TLS function
+// unless all calls comes from the same thread.
+#if !defined(MBEDTLS_THREADING_C) && (MBEDTLS_VERSION_MAJOR >= 4 || defined(MBEDTLS_USE_PSA_CRYPTO))
+#error "Mbed TLS was not build with threading support (MBEDTLS_THREADING_C)."
+#endif
+
 namespace rtc::mbedtls {
+
+void init();
+
+int random_func(void *rng, unsigned char *out, size_t len);
+
+int safe_psa(std::function<int()> func);
 
 bool check(int ret, const string &message = "MbedTLS error");
 

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -45,6 +45,10 @@ gnutls_datum_t make_datum(char *data, size_t size);
 #include "mbedtls/pk.h"
 #include "mbedtls/x509_crt.h"
 
+#if !defined(MBEDTLS_THREADING_C)
+#error "Mbed TLS was not build with threading support (MBEDTLS_THREADING_C)."
+#endif
+
 namespace rtc::mbedtls {
 
 void init();

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -40,17 +40,16 @@ gnutls_datum_t make_datum(char *data, size_t size);
 
 #elif USE_MBEDTLS
 
-#include "mbedtls/ctr_drbg.h"
-#include "mbedtls/ecdsa.h"
-#include "mbedtls/entropy.h"
+#include "mbedtls/ssl.h"
 #include "mbedtls/error.h"
 #include "mbedtls/pk.h"
-#include "mbedtls/rsa.h"
-#include "mbedtls/sha256.h"
-#include "mbedtls/ssl.h"
 #include "mbedtls/x509_crt.h"
 
 namespace rtc::mbedtls {
+
+void init();
+
+int random_func(void *rng, unsigned char *out, size_t len);
 
 bool check(int ret, const string &message = "MbedTLS error");
 

--- a/src/impl/tls.hpp
+++ b/src/impl/tls.hpp
@@ -45,7 +45,11 @@ gnutls_datum_t make_datum(char *data, size_t size);
 #include "mbedtls/pk.h"
 #include "mbedtls/x509_crt.h"
 
-#if !defined(MBEDTLS_THREADING_C)
+// Mbed TLS version 3, relies on internal states when build with MBEDTLS_USE_PSA_CRYPTO.
+// Mbed TLS version 4 always realies on internal states.
+// In those scenarios, MBEDTLS_THREADING_C is required when using any Mbed TLS function
+// unless all calls comes from the same thread.
+#if !defined(MBEDTLS_THREADING_C) && (MBEDTLS_VERSION_MAJOR >= 4 || defined(MBEDTLS_USE_PSA_CRYPTO))
 #error "Mbed TLS was not build with threading support (MBEDTLS_THREADING_C)."
 #endif
 
@@ -54,6 +58,8 @@ namespace rtc::mbedtls {
 void init();
 
 int random_func(void *rng, unsigned char *out, size_t len);
+
+int safe_psa(std::function<int()> func);
 
 bool check(int ret, const string &message = "MbedTLS error");
 

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -324,7 +324,6 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 
 	PLOG_DEBUG << "Initializing TLS transport (MbedTLS)";
 
-	psa_crypto_init();
 	mbedtls_ssl_init(&mSsl);
 	mbedtls_ssl_config_init(&mConf);
 

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -325,22 +325,19 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 	PLOG_DEBUG << "Initializing TLS transport (MbedTLS)";
 
 	psa_crypto_init();
-	mbedtls_entropy_init(&mEntropy);
-	mbedtls_ctr_drbg_init(&mDrbg);
 	mbedtls_ssl_init(&mSsl);
 	mbedtls_ssl_config_init(&mConf);
-	mbedtls_ctr_drbg_set_prediction_resistance(&mDrbg, MBEDTLS_CTR_DRBG_PR_ON);
 
 	try {
-		mbedtls::check(mbedtls_ctr_drbg_seed(&mDrbg, mbedtls_entropy_func, &mEntropy, NULL, 0));
-
 		mbedtls::check(mbedtls_ssl_config_defaults(
 		    &mConf, mIsClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
 		    MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT));
 
-		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
+		mbedtls_ssl_conf_max_tls_version(&mConf, MBEDTLS_SSL_VERSION_TLS1_2);
 		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_OPTIONAL);
-		mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, &mDrbg);
+#if MBEDTLS_VERSION_MAJOR < 4
+		mbedtls_ssl_conf_rng(&mConf, &mbedtls::random_func, nullptr);
+#endif
 
 		if (certificate) {
 			auto [crt, pk] = certificate->credentials();
@@ -356,8 +353,6 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 		mbedtls_ssl_set_bio(&mSsl, static_cast<void *>(this), WriteCallback, ReadCallback, NULL);
 
 	} catch (...) {
-		mbedtls_entropy_free(&mEntropy);
-		mbedtls_ctr_drbg_free(&mDrbg);
 		mbedtls_ssl_free(&mSsl);
 		mbedtls_ssl_config_free(&mConf);
 		throw;
@@ -368,8 +363,6 @@ TlsTransport::~TlsTransport() {
 	stop();
 
 	PLOG_DEBUG << "Destroying TLS transport";
-	mbedtls_entropy_free(&mEntropy);
-	mbedtls_ctr_drbg_free(&mDrbg);
 	mbedtls_ssl_free(&mSsl);
 	mbedtls_ssl_config_free(&mConf);
 }

--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -324,23 +324,19 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 
 	PLOG_DEBUG << "Initializing TLS transport (MbedTLS)";
 
-	psa_crypto_init();
-	mbedtls_entropy_init(&mEntropy);
-	mbedtls_ctr_drbg_init(&mDrbg);
 	mbedtls_ssl_init(&mSsl);
 	mbedtls_ssl_config_init(&mConf);
-	mbedtls_ctr_drbg_set_prediction_resistance(&mDrbg, MBEDTLS_CTR_DRBG_PR_ON);
 
 	try {
-		mbedtls::check(mbedtls_ctr_drbg_seed(&mDrbg, mbedtls_entropy_func, &mEntropy, NULL, 0));
-
 		mbedtls::check(mbedtls_ssl_config_defaults(
 		    &mConf, mIsClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
 		    MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT));
 
-		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
+		mbedtls_ssl_conf_max_tls_version(&mConf, MBEDTLS_SSL_VERSION_TLS1_2);
 		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_NONE);
-		mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, &mDrbg);
+#if MBEDTLS_VERSION_MAJOR < 4
+		mbedtls_ssl_conf_rng(&mConf, &mbedtls::random_func, nullptr);
+#endif
 
 		if (certificate) {
 			auto [crt, pk] = certificate->credentials();
@@ -356,8 +352,6 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 		mbedtls_ssl_set_bio(&mSsl, static_cast<void *>(this), WriteCallback, ReadCallback, NULL);
 
 	} catch (...) {
-		mbedtls_entropy_free(&mEntropy);
-		mbedtls_ctr_drbg_free(&mDrbg);
 		mbedtls_ssl_free(&mSsl);
 		mbedtls_ssl_config_free(&mConf);
 		throw;
@@ -368,8 +362,6 @@ TlsTransport::~TlsTransport() {
 	stop();
 
 	PLOG_DEBUG << "Destroying TLS transport";
-	mbedtls_entropy_free(&mEntropy);
-	mbedtls_ctr_drbg_free(&mDrbg);
 	mbedtls_ssl_free(&mSsl);
 	mbedtls_ssl_config_free(&mConf);
 }

--- a/src/impl/tlstransport.hpp
+++ b/src/impl/tlstransport.hpp
@@ -67,8 +67,6 @@ protected:
 	static int TimeoutCallback(gnutls_transport_ptr_t ptr, unsigned int ms);
 
 #elif USE_MBEDTLS
-	mbedtls_entropy_context mEntropy;
-	mbedtls_ctr_drbg_context mDrbg;
 	mbedtls_ssl_config mConf;
 	mbedtls_ssl_context mSsl;
 


### PR DESCRIPTION
mbedTLS released the new LTS version ([4.1.0](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-4.1.0)) in March, and support for the old LTS branch ([3.6](https://github.com/Mbed-TLS/mbedtls/releases/tag/mbedtls-3.6.6)) is guaranteed only until March 2027.

This PR makes the mbedTLS backend of libdatachannel compatible with mbedTLS 4, while retaining compatibility with mbedTLS 3.6.6 (latest old LTS at the time of writing).

In practice, this moves all the cryptographic functions to the new [PSA Crypto API](https://arm-software.github.io/psa-api/crypto/1.1/) (supported in mbedTLS 3.6, and what mbedTLS 4+ implements).

Plus, it adds a few `ifdef`s for the functions that (annoyingly) changed signature. I can move the clutter inside the `init.hpp`/`init.cpp` as functions in the mbedtls namepsace if you prefer, just let me know (I'm not sure which way is best).

Please note that this only builds with `NO_MEDIA=1`, since libsrtp does not currently support mbedTLS 4 (there is a PR opened for that: https://github.com/cisco/libsrtp/pull/813)

You can test building mbedTLS 4.1.0 + libdatachannel on linux with the following cmake options:
```
# from /path/to/mbedtls
cmake -B build --install-prefix=$(pwd)/build/install -DCMAKE_C_FLAGS='-DMBEDTLS_SSL_DTLS_SRTP' -DCMAKE_POSITION_INDEPENDENT_CODE=1 .
cmake --build build
cmake --install build
```

```
# from /path/to/libdatachannel
PKG_CONFIG_PATH="/path/to/mbedtls/build/install/lib/pkgconfig:$PKG_CONFIG_PATH" \
  cmake -B build -DNO_MEDIA=1 -DUSE_MBEDTLS=1 -DCMAKE_CXX_FLAGS='-DMBEDTLS_SSL_DTLS_SRTP' .
cmake --build build
```