### PR TITLE
address some clang-tidy warnings

### DIFF
--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -256,7 +256,7 @@ public:
 		void setBitrate(int bitrate);
 
 		struct RTC_CPP_EXPORT RtpMap {
-			static int parsePayloadType(string_view description);
+			static int parsePayloadType(string_view mline);
 
 			explicit RtpMap(int payloadType);
 			RtpMap(string_view description);

--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -285,7 +285,7 @@ struct RTC_CPP_EXPORT RtcpRemb {
 	unsigned int getBitrate() const;
 
 	// Deprecated
-	[[deprecated("use setSSRC")]] void setSsrc(int num, SSRC newSssrc);
+	[[deprecated("use setSSRC")]] void setSsrc(int num, SSRC newSsrc);
 	[[deprecated("use getSSRCCount")]] unsigned int getNumSSRC() const;
 	[[deprecated("use getSSRCCount")]] unsigned int getNumSSRC();
 	unsigned int getBitrate();

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -79,24 +79,24 @@ shared_ptr<Track> getTrack(int id) {
 int emplacePeerConnection(shared_ptr<PeerConnection> ptr) {
 	std::lock_guard lock(mutex);
 	int pc = ++lastId;
-	peerConnectionMap.emplace(std::make_pair(pc, ptr));
-	userPointerMap.emplace(std::make_pair(pc, nullptr));
+	peerConnectionMap.emplace(pc, ptr);
+	userPointerMap.emplace(pc, nullptr);
 	return pc;
 }
 
 int emplaceDataChannel(shared_ptr<DataChannel> ptr) {
 	std::lock_guard lock(mutex);
 	int dc = ++lastId;
-	dataChannelMap.emplace(std::make_pair(dc, ptr));
-	userPointerMap.emplace(std::make_pair(dc, nullptr));
+	dataChannelMap.emplace(dc, ptr);
+	userPointerMap.emplace(dc, nullptr);
 	return dc;
 }
 
 int emplaceTrack(shared_ptr<Track> ptr) {
 	std::lock_guard lock(mutex);
 	int tr = ++lastId;
-	trackMap.emplace(std::make_pair(tr, ptr));
-	userPointerMap.emplace(std::make_pair(tr, nullptr));
+	trackMap.emplace(tr, ptr);
+	userPointerMap.emplace(tr, nullptr);
 	return tr;
 }
 
@@ -930,6 +930,7 @@ int rtcReceiveMessage(int id, char *buffer, int *size) {
 		return std::visit( //
 		    overloaded{
 		        [&](binary b) {
+			        auto const originalSize = b.size();
 			        int ret = copyAndReturn(std::move(b), buffer, *size);
 			        if (ret >= 0) {
 				        *size = ret;
@@ -939,11 +940,12 @@ int rtcReceiveMessage(int id, char *buffer, int *size) {
 
 				        return RTC_ERR_SUCCESS;
 			        } else {
-				        *size = int(b.size());
+				        *size = int(originalSize);
 				        return ret;
 			        }
 		        },
 		        [&](string s) {
+			        auto const originalSize = s.size();
 			        int ret = copyAndReturn(std::move(s), buffer, *size);
 			        if (ret >= 0) {
 				        *size = -ret;
@@ -953,7 +955,7 @@ int rtcReceiveMessage(int id, char *buffer, int *size) {
 
 				        return RTC_ERR_SUCCESS;
 			        } else {
-				        *size = -int(s.size() + 1);
+				        *size = -int(originalSize + 1);
 				        return ret;
 			        }
 		        },

--- a/src/datachannel.cpp
+++ b/src/datachannel.cpp
@@ -40,9 +40,9 @@ string DataChannel::protocol() const { return impl()->protocol(); }
 
 Reliability DataChannel::reliability() const { return impl()->reliability(); }
 
-bool DataChannel::isOpen(void) const { return impl()->isOpen(); }
+bool DataChannel::isOpen() const { return impl()->isOpen(); }
 
-bool DataChannel::isClosed(void) const { return impl()->isClosed(); }
+bool DataChannel::isClosed() const { return impl()->isClosed(); }
 
 size_t DataChannel::maxMessageSize() const { return impl()->maxMessageSize(); }
 

--- a/src/dependencydescriptor.cpp
+++ b/src/dependencydescriptor.cpp
@@ -117,7 +117,7 @@ size_t BitWriter::writePartialByte(uint8_t *p, size_t offset, uint64_t v, size_t
 	// ~0b00011110 == 0b11100001
 	uint8_t mask = ~(((1 << need_write_bits) - 1) << shift);
 
-	uint8_t vv = static_cast<uint8_t>(v >> (bits - need_write_bits));
+	auto vv = static_cast<uint8_t>(v >> (bits - need_write_bits));
 
 	if (p != nullptr) {
 		*p = (*p & mask) | (vv << shift);

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -32,7 +32,7 @@ void plogInit(plog::Severity severity, plog::IAppender *appender) {
 			logger->addAppender(appender);
 		} else {
 			using ConsoleAppender = plog::ColorConsoleAppender<plog::TxtFormatter>;
-			static ConsoleAppender *consoleAppender = new ConsoleAppender();
+			static auto *consoleAppender = new ConsoleAppender();
 			logger->addAppender(consoleAppender);
 		}
 	} else {

--- a/src/impl/certificate.cpp
+++ b/src/impl/certificate.cpp
@@ -404,7 +404,7 @@ Certificate Certificate::FromString(string crt_pem, string key_pem) {
 	if (!pkey)
 		throw std::invalid_argument("Unable to import PEM key");
 
-	return Certificate(x509, pkey, std::move(chain));
+	return {x509, pkey, std::move(chain)};
 }
 
 Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_pem_file,
@@ -438,7 +438,7 @@ Certificate Certificate::FromFile(const string &crt_pem_file, const string &key_
 	if (!pkey)
 		throw std::invalid_argument("Unable to import PEM key from file");
 
-	return Certificate(x509, pkey, std::move(chain));
+	return {x509, pkey, std::move(chain)};
 }
 
 Certificate Certificate::Generate(CertificateType type, const string &commonName) {
@@ -531,7 +531,7 @@ Certificate Certificate::Generate(CertificateType type, const string &commonName
 	if (!X509_sign(x509.get(), pkey.get(), EVP_sha256()))
 		throw std::runtime_error("Unable to auto-sign certificate");
 
-	return Certificate(x509, pkey);
+	return {x509, pkey};
 }
 
 Certificate::Certificate(shared_ptr<X509> x509, shared_ptr<EVP_PKEY> pkey,

--- a/src/impl/datachannel.cpp
+++ b/src/impl/datachannel.cpp
@@ -76,7 +76,7 @@ bool DataChannel::IsOpenMessage(message_ptr message) {
 
 DataChannel::DataChannel(weak_ptr<PeerConnection> pc, string label, string protocol,
                          Reliability reliability)
-    : mPeerConnection(pc), mLabel(std::move(label)), mProtocol(std::move(protocol)),
+    : mPeerConnection(std::move(pc)), mLabel(std::move(label)), mProtocol(std::move(protocol)),
       mRecvQueue(RECV_QUEUE_LIMIT, message_size_func) {
 
 	if(reliability.maxPacketLifeTime && reliability.maxRetransmits)
@@ -146,9 +146,9 @@ Reliability DataChannel::reliability() const {
 	return *mReliability;
 }
 
-bool DataChannel::isOpen(void) const { return !mIsClosed && mIsOpen; }
+bool DataChannel::isOpen() const { return !mIsClosed && mIsOpen; }
 
-bool DataChannel::isClosed(void) const { return mIsClosed; }
+bool DataChannel::isClosed() const { return mIsClosed; }
 
 size_t DataChannel::maxMessageSize() const {
 	auto pc = mPeerConnection.lock();

--- a/src/impl/datachannel.hpp
+++ b/src/impl/datachannel.hpp
@@ -12,7 +12,6 @@
 #include "channel.hpp"
 #include "common.hpp"
 #include "message.hpp"
-#include "peerconnection.hpp"
 #include "queue.hpp"
 #include "reliability.hpp"
 #include "sctptransport.hpp"

--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -53,7 +53,7 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
                              optional<size_t> mtu,
                              CertificateFingerprint::Algorithm fingerprintAlgorithm,
                              verifier_callback verifierCallback, state_callback stateChangeCallback)
-    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(certificate),
+    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(std::move(certificate)),
       mFingerprintAlgorithm(fingerprintAlgorithm), mVerifierCallback(std::move(verifierCallback)),
       mIsClient(lower->role() == Description::Role::Active),
       mIncomingQueue(RECV_QUEUE_LIMIT, message_size_func) {
@@ -381,7 +381,7 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
                              optional<size_t> mtu,
                              CertificateFingerprint::Algorithm fingerprintAlgorithm,
                              verifier_callback verifierCallback, state_callback stateChangeCallback)
-    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(certificate),
+    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(std::move(certificate)),
       mFingerprintAlgorithm(fingerprintAlgorithm), mVerifierCallback(std::move(verifierCallback)),
       mIsClient(lower->role() == Description::Role::Active),
       mIncomingQueue(RECV_QUEUE_LIMIT, message_size_func) {
@@ -700,7 +700,7 @@ int DtlsTransport::GetTimerCallback(void *ctx) {
 
 #else // OPENSSL
 
-BIO_METHOD *DtlsTransport::BioMethods = NULL;
+BIO_METHOD *DtlsTransport::BioMethods = nullptr;
 int DtlsTransport::TransportExIndex = -1;
 std::mutex DtlsTransport::GlobalMutex;
 
@@ -719,7 +719,7 @@ void DtlsTransport::Init() {
 		BIO_meth_set_ctrl(BioMethods, BioMethodCtrl);
 	}
 	if (TransportExIndex < 0) {
-		TransportExIndex = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+		TransportExIndex = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
 	}
 }
 
@@ -731,7 +731,7 @@ DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr cer
                              optional<size_t> mtu,
                              CertificateFingerprint::Algorithm fingerprintAlgorithm,
                              verifier_callback verifierCallback, state_callback stateChangeCallback)
-    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(certificate),
+    : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(std::move(certificate)),
       mFingerprintAlgorithm(fingerprintAlgorithm), mVerifierCallback(std::move(verifierCallback)),
       mIsClient(lower->role() == Description::Role::Active),
       mIncomingQueue(RECV_QUEUE_LIMIT, message_size_func) {
@@ -1041,7 +1041,7 @@ void DtlsTransport::handleTimeout() {
 int DtlsTransport::CertificateCallback(int /*preverify_ok*/, X509_STORE_CTX *ctx) {
 	SSL *ssl =
 	    static_cast<SSL *>(X509_STORE_CTX_get_ex_data(ctx, SSL_get_ex_data_X509_STORE_CTX_idx()));
-	DtlsTransport *t =
+	auto *t =
 	    static_cast<DtlsTransport *>(SSL_get_ex_data(ssl, DtlsTransport::TransportExIndex));
 
 	X509 *crt = X509_STORE_CTX_get_current_cert(ctx);
@@ -1051,7 +1051,7 @@ int DtlsTransport::CertificateCallback(int /*preverify_ok*/, X509_STORE_CTX *ctx
 }
 
 void DtlsTransport::InfoCallback(const SSL *ssl, int where, int ret) {
-	DtlsTransport *t =
+	auto *t =
 	    static_cast<DtlsTransport *>(SSL_get_ex_data(ssl, DtlsTransport::TransportExIndex));
 
 	if (where & SSL_CB_ALERT) {
@@ -1064,7 +1064,7 @@ void DtlsTransport::InfoCallback(const SSL *ssl, int where, int ret) {
 
 int DtlsTransport::BioMethodNew(BIO *bio) {
 	BIO_set_init(bio, 1);
-	BIO_set_data(bio, NULL);
+	BIO_set_data(bio, nullptr);
 	BIO_set_shutdown(bio, 0);
 	return 1;
 }
@@ -1072,7 +1072,7 @@ int DtlsTransport::BioMethodNew(BIO *bio) {
 int DtlsTransport::BioMethodFree(BIO *bio) {
 	if (!bio)
 		return 0;
-	BIO_set_data(bio, NULL);
+	BIO_set_data(bio, nullptr);
 	return 1;
 }
 

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -251,7 +251,7 @@ void IceTransport::gatherLocalCandidates(string mid, std::vector<IceServer> addi
 
 optional<string> IceTransport::getLocalAddress() const {
 	char str[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (juice_get_selected_addresses(mAgent.get(), str, JUICE_MAX_ADDRESS_STRING_LEN, NULL, 0) ==
+	if (juice_get_selected_addresses(mAgent.get(), str, JUICE_MAX_ADDRESS_STRING_LEN, nullptr, 0) ==
 	    0) {
 		return std::make_optional(string(str));
 	}
@@ -259,7 +259,7 @@ optional<string> IceTransport::getLocalAddress() const {
 }
 optional<string> IceTransport::getRemoteAddress() const {
 	char str[JUICE_MAX_ADDRESS_STRING_LEN];
-	if (juice_get_selected_addresses(mAgent.get(), NULL, 0, str, JUICE_MAX_ADDRESS_STRING_LEN) ==
+	if (juice_get_selected_addresses(mAgent.get(), nullptr, 0, str, JUICE_MAX_ADDRESS_STRING_LEN) ==
 	    0) {
 		return std::make_optional(string(str));
 	}

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -14,7 +14,6 @@
 #include "configuration.hpp"
 #include "description.hpp"
 #include "global.hpp"
-#include "peerconnection.hpp"
 #include "transport.hpp"
 
 #if !USE_NICE

--- a/src/impl/iceudpmuxlistener.cpp
+++ b/src/impl/iceudpmuxlistener.cpp
@@ -33,7 +33,7 @@ IceUdpMuxListener::IceUdpMuxListener(uint16_t port, [[maybe_unused]] optional<st
 
 #if !USE_NICE
 	PLOG_DEBUG << "Registering ICE UDP mux listener for port " << port;
-	if (juice_mux_listen(bindAddress ? bindAddress->c_str() : NULL, port,
+	if (juice_mux_listen(bindAddress ? bindAddress->c_str() : nullptr, port,
 	                     IceUdpMuxListener::UnhandledStunRequestCallback, this) < 0) {
 		throw std::runtime_error("Failed to register ICE UDP mux listener");
 	}
@@ -53,7 +53,7 @@ void IceUdpMuxListener::stop() {
 
 #if !USE_NICE
 	PLOG_DEBUG << "Unregistering ICE UDP mux listener for port " << port;
-	if (juice_mux_listen(NULL, port, NULL, NULL) < 0) {
+	if (juice_mux_listen(nullptr, port, nullptr, nullptr) < 0) {
 		PLOG_ERROR << "Failed to unregister ICE UDP mux listener";
 	}
 #endif

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -474,7 +474,7 @@ void PeerConnection::forwardMessage(message_ptr message) {
 	if (!iceTransport || !sctpTransport)
 		return;
 
-	const uint16_t stream = uint16_t(message->stream);
+	auto const stream = uint16_t(message->stream);
 	auto [channel, found] = findDataChannel(stream);
 
 	if (DataChannel::IsOpenMessage(message)) {
@@ -711,7 +711,7 @@ shared_ptr<DataChannel> PeerConnection::emplaceDataChannel(string label, DataCha
 			throw std::invalid_argument("DataChannel stream id is too high");
 
 		channel->assignStream(stream);
-		mDataChannels.emplace(std::make_pair(stream, channel));
+		mDataChannels.emplace(stream, channel);
 
 	} else {
 		mUnassignedDataChannels.push_back(channel);
@@ -779,7 +779,7 @@ void PeerConnection::assignDataChannels() {
 		PLOG_DEBUG << "Assigning stream " << stream << " to DataChannel";
 
 		channel->assignStream(stream);
-		mDataChannels.emplace(std::make_pair(stream, channel));
+		mDataChannels.emplace(stream, channel);
 	}
 
 	mUnassignedDataChannels.clear();
@@ -841,7 +841,7 @@ shared_ptr<Track> PeerConnection::emplaceTrack(Description::Media description) {
 		track->setDescription(std::move(description));
 	} else {
 		track = std::make_shared<Track>(weak_from_this(), std::move(description));
-		mTracks.emplace(std::make_pair(track->mid(), track));
+		mTracks.emplace(track->mid(), track);
 		mTrackLines.emplace_back(track);
 	}
 
@@ -1157,7 +1157,7 @@ void PeerConnection::processRemoteDescription(Description description) {
 
 			// Create incoming track
 			auto track = std::make_shared<Track>(weak_from_this(), std::move(reciprocated));
-			mTracks.emplace(std::make_pair(track->mid(), track));
+			mTracks.emplace(track->mid(), track);
 			mTrackLines.emplace_back(track);
 			triggerTrack(track); // The user may modify the track description
 

--- a/src/impl/processor.cpp
+++ b/src/impl/processor.cpp
@@ -31,7 +31,7 @@ void Processor::schedule() {
 }
 
 TearDownProcessor &TearDownProcessor::Instance() {
-	static TearDownProcessor *instance = new TearDownProcessor;
+	static auto *instance = new TearDownProcessor;
 	return *instance;
 }
 

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -93,7 +93,7 @@ private:
 	void handleUpcall() noexcept;
 	int handleWrite(byte *data, size_t len, uint8_t tos, uint8_t set_df) noexcept;
 
-	void processData(binary &&data, uint16_t streamId, PayloadId ppid);
+	void processData(binary &&data, uint16_t sid, PayloadId ppid);
 	void processNotification(const union sctp_notification *notify, size_t len);
 
 	const size_t mMaxMessageSize;

--- a/src/impl/threadpool.cpp
+++ b/src/impl/threadpool.cpp
@@ -12,7 +12,7 @@
 namespace rtc::impl {
 
 ThreadPool &ThreadPool::Instance() {
-	static ThreadPool *instance = new ThreadPool;
+	static auto *instance = new ThreadPool;
 	return *instance;
 }
 

--- a/src/impl/tls.cpp
+++ b/src/impl/tls.cpp
@@ -119,7 +119,7 @@ string format_time(const std::chrono::system_clock::time_point &tp) {
 	if (my_strftme(buffer, bufferSize, "%Y%m%d%H%M%S", &t) == 0)
 		throw std::runtime_error("Time conversion failed");
 
-	return string(buffer);
+	return {buffer};
 };
 
 std::shared_ptr<mbedtls_pk_context> new_pk_context() {
@@ -171,7 +171,7 @@ string error_string(unsigned long error) {
 	const size_t bufferSize = 256;
 	char buffer[bufferSize];
 	ERR_error_string_n(error, buffer, bufferSize);
-	return string(buffer);
+	return {buffer};
 }
 
 bool check(int success, const string &message) {

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -20,7 +20,7 @@ static LogCounter COUNTER_QUEUE_FULL(plog::warning,
                                      "Number of media packets dropped due to a full queue");
 
 Track::Track(weak_ptr<PeerConnection> pc, Description::Media desc)
-    : mPeerConnection(pc), mMediaDescription(std::move(desc)),
+    : mPeerConnection(std::move(pc)), mMediaDescription(std::move(desc)),
       mRecvQueue(RECV_QUEUE_LIMIT, [](const message_ptr &m) { return m->size(); }) {
 
 	// Discard messages by default if track is send only
@@ -99,7 +99,7 @@ optional<message_variant> Track::peek() {
 
 size_t Track::availableAmount() const { return mRecvQueue.amount(); }
 
-bool Track::isOpen(void) const {
+bool Track::isOpen() const {
 #if RTC_ENABLE_MEDIA
 	std::shared_lock lock(mMutex);
 	return !mIsClosed && mDtlsSrtpTransport.lock();
@@ -108,7 +108,7 @@ bool Track::isOpen(void) const {
 #endif
 }
 
-bool Track::isClosed(void) const { return mIsClosed; }
+bool Track::isClosed() const { return mIsClosed; }
 
 size_t Track::maxMessageSize() const {
 	optional<size_t> mtu;

--- a/src/impl/utils.cpp
+++ b/src/impl/utils.cpp
@@ -137,7 +137,7 @@ std::seed_seq random_seed() {
 	seed.push_back(
 	    static_cast<unsigned int>(std::hash<std::thread::id>{}(std::this_thread::get_id())));
 
-	return std::seed_seq(seed.begin(), seed.end());
+	return {seed.begin(), seed.end()};
 }
 
 namespace {

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -214,7 +214,6 @@ void PeerConnection::setRemoteDescription(Description description) {
 			// created an offer receives an offer from the remote peer
 			impl()->rollbackLocalDescription();
 			impl()->changeSignalingState(SignalingState::Stable);
-			signalingState = SignalingState::Stable;
 			newSignalingState = SignalingState::HaveRemoteOffer;
 			break;
 		}

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -350,7 +350,7 @@ void RtcpSr::log() const {
 
 unsigned int RtcpSdesItem::Size(uint8_t textLength) { return textLength + 2; }
 
-std::string RtcpSdesItem::text() const { return std::string(_text, _length); }
+std::string RtcpSdesItem::text() const { return {_text, _length}; }
 
 void RtcpSdesItem::setText(std::string text) {
 	if (text.size() > 0xFF)
@@ -512,7 +512,7 @@ void RtcpSdes::preparePacket(uint8_t chunkCount) {
 		auto chunk = getChunk(i);
 		chunkSize += chunk->getSize();
 	}
-	uint16_t length = uint16_t((sizeof(header) + chunkSize) / 4 - 1);
+	auto length = uint16_t((sizeof(header) + chunkSize) / 4 - 1);
 	header.prepareHeader(202, chunkCount, length);
 }
 
@@ -743,7 +743,7 @@ bool RtcpNack::addMissingPacket(unsigned int *fciCount, uint16_t *fciPID, uint16
 	} else {
 		// TODO SPEED!
 		uint16_t blp = parts[(*fciCount) - 1].blp();
-		uint16_t newBit = uint16_t(1u << (missingPacket - (1 + *fciPID)));
+		auto newBit = uint16_t(1u << (missingPacket - (1 + *fciPID)));
 		parts[(*fciCount) - 1].setBlp(blp | newBit);
 		return false;
 	}
@@ -768,7 +768,7 @@ size_t RtcpApp::dataSize() const {
 }
 
 void RtcpApp::preparePacket(SSRC ssrc, const RtcpAppName &name, uint8_t subtype, size_t dataLength) {
-	uint16_t lengthField =
+	auto lengthField =
 	    uint16_t((sizeof(SSRC) + 4 + dataLength) / 4); // in 32-bit words, minus 1 for header
 	header.prepareHeader(204, subtype, lengthField);
 	setSSRC(ssrc);

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -36,9 +36,9 @@ bool Track::send(message_variant data) { return impl()->outgoing(make_message(st
 
 bool Track::send(const byte *data, size_t size) { return send(binary(data, data + size)); }
 
-bool Track::isOpen(void) const { return impl()->isOpen(); }
+bool Track::isOpen() const { return impl()->isOpen(); }
 
-bool Track::isClosed(void) const { return impl()->isClosed(); }
+bool Track::isClosed() const { return impl()->isClosed(); }
 
 size_t Track::maxMessageSize() const { return impl()->maxMessageSize(); }
 


### PR DESCRIPTION
this is addressing some clang-tidy warnings. mostly style changes. feel free to close the PR if it's not of interest.

This is what clang-tidy output:

```
src/track.cpp:37:20: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
   37 | bool Track::isOpen(void) const { return impl()->isOpen(); }
      |                    ^~~~
src/track.cpp:39:22: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
   39 | bool Track::isClosed(void) const { return impl()->isClosed(); }
      |                      ^~~~
src/rtp.cpp:343:49: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  343 | std::string RtcpSdesItem::text() const { return std::string(_text, _length); }
      |                                                 ^~~~~~~~~~~~              ~
      |                                                 {                         }
src/rtp.cpp:504:2: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
  504 |         uint16_t length = uint16_t((sizeof(header) + chunkSize) / 4 - 1);
      |         ^~~~~~~~
      |         auto
src/rtp.cpp:661:3: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
  661 |                 uint16_t newBit = uint16_t(1u << (missingPacket - (1 + *fciPID)));
      |                 ^~~~~~~~
      |                 auto
src/global.cpp:35:11: error: use auto when initializing with new to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
   35 |                         static ConsoleAppender *consoleAppender = new ConsoleAppender();
      |                                ^~~~~~~~~~~~~~~
      |                                auto
src/datachannel.cpp:43:26: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
   43 | bool DataChannel::isOpen(void) const { return impl()->isOpen(); }
      |                          ^~~~
src/datachannel.cpp:45:28: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
   45 | bool DataChannel::isClosed(void) const { return impl()->isClosed(); }
      |                            ^~~~
src/impl/peerconnection.hpp:13:10: error: circular header file dependency detected while including 'datachannel.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   13 | #include "datachannel.hpp"
      |          ^
src/impl/datachannel.hpp:15:10: note: 'peerconnection.hpp' included from here
   15 | #include "peerconnection.hpp"
      |          ^
src/datachannel.cpp:13:10: note: 'datachannel.hpp' included from here
   13 | #include "impl/datachannel.hpp"
      |          ^
src/dependencydescriptor.cpp:120:2: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
  120 |         uint8_t vv = static_cast<uint8_t>(v >> (bits - need_write_bits));
      |         ^~~~~~~
      |         auto
src/impl/peerconnection.hpp:15:10: error: circular header file dependency detected while including 'icetransport.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "icetransport.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: note: 'peerconnection.hpp' included from here
   17 | #include "peerconnection.hpp"
      |          ^
src/peerconnection.cpp:16:10: note: 'icetransport.hpp' included from here
   16 | #include "impl/icetransport.hpp"
      |          ^
src/peerconnection.cpp:217:4: error: Value stored to 'signalingState' is never read [clang-analyzer-deadcode.DeadStores,-warnings-as-errors]
  217 |                         signalingState = SignalingState::Stable;
      |                         ^                ~~~~~~~~~~~~~~~~~~~~~~
src/peerconnection.cpp:217:4: note: Value stored to 'signalingState' is never read
  217 |                         signalingState = SignalingState::Stable;
      |                         ^                ~~~~~~~~~~~~~~~~~~~~~~
src/impl/utils.cpp:140:9: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  140 |         return std::seed_seq(seed.begin(), seed.end());
      |                ^~~~~~~~~~~~~~                        ~
      |                {                                     }
src/capi.cpp:81:28: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   81 |         peerConnectionMap.emplace(std::make_pair(pc, ptr));
      |                                   ^~~~~~~~~~~~~~~       ~
src/capi.cpp:82:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   82 |         userPointerMap.emplace(std::make_pair(pc, nullptr));
      |                                ^~~~~~~~~~~~~~~           ~
src/capi.cpp:89:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   89 |         dataChannelMap.emplace(std::make_pair(dc, ptr));
      |                                ^~~~~~~~~~~~~~~       ~
src/capi.cpp:90:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   90 |         userPointerMap.emplace(std::make_pair(dc, nullptr));
      |                                ^~~~~~~~~~~~~~~           ~
src/capi.cpp:97:19: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   97 |         trackMap.emplace(std::make_pair(tr, ptr));
      |                          ^~~~~~~~~~~~~~~       ~
src/capi.cpp:98:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
   98 |         userPointerMap.emplace(std::make_pair(tr, nullptr));
      |                                ^~~~~~~~~~~~~~~           ~
src/impl/tls.cpp:174:9: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  174 |         return string(buffer);
      |                ^~~~~~~      ~
      |                {            }
src/impl/datachannel.hpp:15:10: error: circular header file dependency detected while including 'peerconnection.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "peerconnection.hpp"
      |          ^
src/impl/peerconnection.hpp:13:10: note: 'datachannel.hpp' included from here
   13 | #include "datachannel.hpp"
      |          ^
src/impl/track.cpp:12:10: note: 'peerconnection.hpp' included from here
   12 | #include "peerconnection.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: error: circular header file dependency detected while including 'peerconnection.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   17 | #include "peerconnection.hpp"
      |          ^
src/impl/peerconnection.hpp:15:10: note: 'icetransport.hpp' included from here
   15 | #include "icetransport.hpp"
      |          ^
src/impl/track.cpp:12:10: note: 'peerconnection.hpp' included from here
   12 | #include "peerconnection.hpp"
      |          ^
src/impl/track.cpp:22:14: error: pass by value and use std::move [modernize-pass-by-value,-warnings-as-errors]
   10 | #include "internals.hpp"
   11 | #include "logcounter.hpp"
   12 | #include "peerconnection.hpp"
   13 | #include "rtp.hpp"
   14 | 
   15 | namespace rtc::impl {
   16 | 
   17 | static LogCounter COUNTER_MEDIA_BAD_DIRECTION(plog::warning,
   18 |                                               "Number of media packets sent in invalid directions");
   19 | static LogCounter COUNTER_QUEUE_FULL(plog::warning,
   20 |                                      "Number of media packets dropped due to a full queue");
   21 | 
   22 | Track::Track(weak_ptr<PeerConnection> pc, Description::Media desc)
      |              ^
   23 |     : mPeerConnection(pc), mMediaDescription(std::move(desc)),
      |                         
      |                       std::move( )
src/impl/track.cpp:102:20: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
  102 | bool Track::isOpen(void) const {
      |                    ^~~~
src/impl/track.cpp:111:22: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
  111 | bool Track::isClosed(void) const { return mIsClosed; }
      |                      ^~~~
src/impl/threadpool.cpp:15:9: error: use auto when initializing with new to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
   15 |         static ThreadPool *instance = new ThreadPool;
      |                ^~~~~~~~~~
      |                auto
src/impl/processor.cpp:34:9: error: use auto when initializing with new to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
   34 |         static TearDownProcessor *instance = new TearDownProcessor;
      |                ^~~~~~~~~~~~~~~~~
      |                auto
src/impl/peerconnection.hpp:15:10: error: circular header file dependency detected while including 'icetransport.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "icetransport.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: note: 'peerconnection.hpp' included from here
   17 | #include "peerconnection.hpp"
      |          ^
src/impl/init.cpp:12:10: note: 'icetransport.hpp' included from here
   12 | #include "icetransport.hpp"
      |          ^
deps/libdatachannel/include/rtc/description.hpp:201:15: error: function 'rtc::Description::Media::RtpMap::parsePayloadType' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
  201 |                         static int parsePayloadType(string_view description);
      |                                    ^
src/description.cpp:1141:33: note: the definition seen here
 1141 | int Description::Media::RtpMap::parsePayloadType(string_view mline) {
      |                                 ^
deps/libdatachannel/include/rtc/description.hpp:201:15: note: differing parameters are named here: ('description'), in definition: ('mline')
  201 |                         static int parsePayloadType(string_view description);
      |                                    ^                            ~~~~~~~~~~~
      |                                                                 mline
src/impl/iceudpmuxlistener.cpp:36:60: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
   36 |         if (juice_mux_listen(bindAddress ? bindAddress->c_str() : NULL, port,
      |                                                                   ^~~~
      |                                                                   nullptr
src/impl/iceudpmuxlistener.cpp:56:23: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
   56 |         if (juice_mux_listen(NULL, port, NULL, NULL) < 0) {
      |                              ^~~~
      |                              nullptr
src/impl/iceudpmuxlistener.cpp:56:35: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
   56 |         if (juice_mux_listen(NULL, port, NULL, NULL) < 0) {
      |                                          ^~~~
      |                                          nullptr
src/impl/iceudpmuxlistener.cpp:56:41: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
   56 |         if (juice_mux_listen(NULL, port, NULL, NULL) < 0) {
      |                                                ^~~~
      |                                                nullptr
src/impl/sctptransport.hpp:96:7: error: function 'rtc::impl::SctpTransport::processData' has a definition with different parameter names [readability-inconsistent-declaration-parameter-name,-warnings-as-errors]
   96 |         void processData(binary &&data, uint16_t streamId, PayloadId ppid);
      |              ^
src/impl/sctptransport.cpp:783:21: note: the definition seen here
  783 | void SctpTransport::processData(binary &&data, uint16_t sid, PayloadId ppid) {
      |                     ^
src/impl/sctptransport.hpp:96:7: note: differing parameters are named here: ('streamId'), in definition: ('sid')
   96 |         void processData(binary &&data, uint16_t streamId, PayloadId ppid);
      |              ^                                   ~~~~~~~~
      |                                                  sid
src/impl/icetransport.cpp:253:84: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  253 |         if (juice_get_selected_addresses(mAgent.get(), str, JUICE_MAX_ADDRESS_STRING_LEN, NULL, 0) ==
      |                                                                                           ^~~~
      |                                                                                           nullptr
src/impl/icetransport.cpp:261:49: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  261 |         if (juice_get_selected_addresses(mAgent.get(), NULL, 0, str, JUICE_MAX_ADDRESS_STRING_LEN) ==
      |                                                        ^~~~
      |                                                        nullptr
src/impl/peerconnection.hpp:15:10: error: circular header file dependency detected while including 'icetransport.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "icetransport.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: note: 'peerconnection.hpp' included from here
   17 | #include "peerconnection.hpp"
      |          ^
src/impl/icetransport.cpp:9:10: note: 'icetransport.hpp' included from here
    9 | #include "icetransport.hpp"
      |          ^
src/impl/dtlstransport.cpp:703:41: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  703 | BIO_METHOD *DtlsTransport::BioMethods = NULL;
      |                                         ^~~~
      |                                         nullptr
src/impl/dtlstransport.cpp:722:46: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  722 |                 TransportExIndex = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
      |                                                            ^~~~
      |                                                            nullptr
src/impl/dtlstransport.cpp:722:52: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  722 |                 TransportExIndex = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
      |                                                                  ^~~~
      |                                                                  nullptr
src/impl/dtlstransport.cpp:722:58: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  722 |                 TransportExIndex = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
      |                                                                        ^~~~
      |                                                                        nullptr
src/impl/dtlstransport.cpp:722:64: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
  722 |                 TransportExIndex = SSL_get_ex_new_index(0, NULL, NULL, NULL, NULL);
      |                                                                              ^~~~
      |                                                                              nullptr
src/impl/dtlstransport.cpp:730:62: error: pass by value and use std::move [modernize-pass-by-value,-warnings-as-errors]
   19 | DtlsTransport::DtlsTransport(shared_ptr<IceTransport> lower, certificate_ptr certificate,
      |                                                              ^
   20 |                              optional<size_t> mtu,
   21 |                              CertificateFingerprint::Algorithm fingerprintAlgorithm,
   22 |                              verifier_callback verifierCallback, state_callback stateChangeCallback)
   23 |     : Transport(lower, std::move(stateChangeCallback)), mMtu(mtu), mCertificate(certificate),
      |                                                                                            
      |                                                                                 std::move( )
src/impl/dtlstransport.cpp:1038:2: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
 1038 |         DtlsTransport *t =
      |         ^~~~~~~~~~~~~
      |         auto
src/impl/dtlstransport.cpp:1048:2: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
 1048 |         DtlsTransport *t =
      |         ^~~~~~~~~~~~~
      |         auto
src/impl/dtlstransport.cpp:1061:20: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
 1061 |         BIO_set_data(bio, NULL);
      |                           ^~~~
      |                           nullptr
src/impl/dtlstransport.cpp:1069:20: error: use nullptr [modernize-use-nullptr,-warnings-as-errors]
 1069 |         BIO_set_data(bio, NULL);
      |                           ^~~~
      |                           nullptr
src/impl/peerconnection.hpp:15:10: error: circular header file dependency detected while including 'icetransport.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "icetransport.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: note: 'peerconnection.hpp' included from here
   17 | #include "peerconnection.hpp"
      |          ^
src/impl/dtlstransport.cpp:11:10: note: 'icetransport.hpp' included from here
   11 | #include "icetransport.hpp"
      |          ^
src/impl/datachannel.cpp:77:26: error: pass by value and use std::move [modernize-pass-by-value,-warnings-as-errors]
   20 | DataChannel::DataChannel(weak_ptr<PeerConnection> pc, string label, string protocol,
      |                          ^
   21 |                          Reliability reliability)
   22 |     : mPeerConnection(pc), mLabel(std::move(label)), mProtocol(std::move(protocol)),
      |                         
      |                       std::move( )
src/impl/datachannel.cpp:149:26: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
  149 | bool DataChannel::isOpen(void) const { return !mIsClosed && mIsOpen; }
      |                          ^~~~
src/impl/datachannel.cpp:151:28: error: redundant void argument list in function definition [modernize-redundant-void-arg,-warnings-as-errors]
  151 | bool DataChannel::isClosed(void) const { return mIsClosed; }
      |                            ^~~~
src/impl/peerconnection.hpp:13:10: error: circular header file dependency detected while including 'datachannel.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   13 | #include "datachannel.hpp"
      |          ^
src/impl/datachannel.hpp:15:10: note: 'peerconnection.hpp' included from here
   15 | #include "peerconnection.hpp"
      |          ^
src/impl/datachannel.cpp:9:10: note: 'datachannel.hpp' included from here
    9 | #include "datachannel.hpp"
      |          ^
src/impl/certificate.cpp:407:9: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  407 |         return Certificate(x509, pkey, std::move(chain));
      |                ^~~~~~~~~~~~                            ~
      |                {                                       }
src/impl/certificate.cpp:441:9: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  441 |         return Certificate(x509, pkey, std::move(chain));
      |                ^~~~~~~~~~~~                            ~
      |                {                                       }
src/impl/certificate.cpp:534:9: error: avoid repeating the return type from the declaration; use a braced initializer list instead [modernize-return-braced-init-list,-warnings-as-errors]
  534 |         return Certificate(x509, pkey);
      |                ^~~~~~~~~~~~          ~
      |                {                     }
src/impl/datachannel.hpp:15:10: error: circular header file dependency detected while including 'peerconnection.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   15 | #include "peerconnection.hpp"
      |          ^
src/impl/peerconnection.hpp:13:10: note: 'datachannel.hpp' included from here
   13 | #include "datachannel.hpp"
      |          ^
src/impl/peerconnection.cpp:10:10: note: 'peerconnection.hpp' included from here
   10 | #include "peerconnection.hpp"
      |          ^
src/impl/icetransport.hpp:17:10: error: circular header file dependency detected while including 'peerconnection.hpp', please check the include path [misc-header-include-cycle,-warnings-as-errors]
   17 | #include "peerconnection.hpp"
      |          ^
src/impl/peerconnection.hpp:15:10: note: 'icetransport.hpp' included from here
   15 | #include "icetransport.hpp"
      |          ^
src/impl/peerconnection.cpp:10:10: note: 'peerconnection.hpp' included from here
   10 | #include "peerconnection.hpp"
      |          ^
src/impl/peerconnection.cpp:477:8: error: use auto when initializing with a cast to avoid duplicating the type name [modernize-use-auto,-warnings-as-errors]
  477 |         const uint16_t stream = uint16_t(message->stream);
      |               ^~~~~~~~
      |               auto
src/impl/peerconnection.cpp:670:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
  670 |                 mDataChannels.emplace(std::make_pair(stream, channel));
      |                                       ^~~~~~~~~~~~~~~               ~
src/impl/peerconnection.cpp:738:25: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
  738 |                 mDataChannels.emplace(std::make_pair(stream, channel));
      |                                       ^~~~~~~~~~~~~~~               ~
src/impl/peerconnection.cpp:800:19: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
  800 |                 mTracks.emplace(std::make_pair(track->mid(), track));
      |                                 ^~~~~~~~~~~~~~~                   ~
src/impl/peerconnection.cpp:1108:20: error: unnecessary temporary object created while calling emplace [modernize-use-emplace,-warnings-as-errors]
 1108 |                         mTracks.emplace(std::make_pair(track->mid(), track));
      |                                         ^~~~~~~~~~~~~~~                   ~
```