### PR TITLE
pass -A to cmake, based on b2's address-model (64 or 32 bits)

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -110,7 +110,14 @@ rule make_libusrsctp_msvc ( targets * : sources * : properties * )
 {
 	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
 	VARIANT on $(targets) = $(VARIANT) ;
-	BUILD_DIR on $(targets) = "build-$(VARIANT)" ;
+
+	local ADDRESS_MODEL = [ feature.get-values <address-model> : $(properties) ] ;
+	local ARCH = x64 ;
+	if $(ADDRESS_MODEL) = 32
+	{ ARCH = Win32 ; }
+	ARCH on $(targets) = $(ARCH) ;
+
+	BUILD_DIR on $(targets) = "build-$(ARCH)-$(VARIANT)" ;
 }
 actions make_libusrsctp_msvc
 {
@@ -118,7 +125,7 @@ actions make_libusrsctp_msvc
     cd $(CWD)/deps/usrsctp
     mkdir $(BUILD_DIR)
     cd $(BUILD_DIR)
-    cmake -G "Visual Studio 17 2022" -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
+    cmake -G "Visual Studio 17 2022" -A $(ARCH) -Dsctp_werror=0 -Dsctp_build_shared_lib=0 -Dsctp_build_programs=0 -Dsctp_inet=0 -Dsctp_inet6=0 ..
     msbuild usrsctplib.sln /property:Configuration=$(VARIANT)
     cd %OLDD%
     cp $(CWD)/deps/usrsctp/$(BUILD_DIR)/usrsctplib/Release/usrsctp.lib $(<)
@@ -165,14 +172,21 @@ rule make_libjuice_msvc ( targets * : sources * : properties * )
 {
 	local VARIANT = [ feature.get-values <variant> : $(properties) ] ;
 	VARIANT on $(targets) = $(VARIANT) ;
+
+	local ADDRESS_MODEL = [ feature.get-values <address-model> : $(properties) ] ;
+	local ARCH = x64 ;
+	if $(ADDRESS_MODEL) = 32
+	{ ARCH = Win32 ; }
+	ARCH on $(targets) = $(ARCH) ;
+
 	if <gnutls>on in $(properties)
 	{
-		BUILD_DIR on $(targets) += "build-gnutls-$(VARIANT)" ;
+		BUILD_DIR on $(targets) += "build-gnutls-$(ARCH)-$(VARIANT)" ;
 		CMAKEOPTS on $(targets) = "-DUSE_NETTLE=1" ;
 	}
 	else
 	{
-		BUILD_DIR on $(targets) += "build-openssl-$(VARIANT)" ;
+		BUILD_DIR on $(targets) += "build-openssl-$(ARCH)-$(VARIANT)" ;
 		CMAKEOPTS on $(targets) = "-DUSE_NETTLE=0" ;
 	}
 }
@@ -182,7 +196,7 @@ actions make_libjuice_msvc
     cd $(CWD)/deps/libjuice
     mkdir $(BUILD_DIR)
     cd $(BUILD_DIR)
-    cmake -G "Visual Studio 17 2022" $(CMAKEOPTS) ..
+    cmake -G "Visual Studio 17 2022" -A $(ARCH) $(CMAKEOPTS) ..
     msbuild libjuice.sln /property:Configuration=$(VARIANT)
     cd %OLDD%
     cp $(CWD)/deps/libjuice/$(BUILD_DIR)/Release/juice-static.lib $(<)


### PR DESCRIPTION
The `Jamfile` in this project invokes `cmake` directly, but it only forwards the `debug`/`release` build variant, no other build options.

When passing `address-model=32` (for 32 bit builds) to the `Jamfile`, `cmake` is still invoked making a 64 bit build. This patch looks at the `address-model` build feature and passes it along to `cmake` via `-A`, to build a compatible library.

This patch is demonstrated to work in this PR: https://github.com/arvidn/libtorrent/pull/8532 Specifically, this commit: https://github.com/arvidn/libtorrent/pull/8532/changes/82cd97f710a3ff533f81f906fd910789f4f36c8d

Building 32bit python wheels for libtorrent (with cibuildwheel) failed prior to this patch because of a 32/64 bit incompatibility.