### PR TITLE
feat: enable SCTP I-DATA interleaving

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,6 +25,8 @@ The option `PREFER_SYSTEM_LIB` allows to link against the system library rather 
 
 If you only need Data Channels, the option `NO_MEDIA` allows to make the library lighter by removing media support. Similarly, `NO_WEBSOCKET` removes WebSocket support.
 
+The option `DISABLE_SCTP_INTERLEAVING` disables SCTP I-DATA interleaving support if needed for compatibility with a specific SCTP stack.
+
 For the sake of performance, the library should be compiled in `Release` mode if you don't plan to debug it.
 
 The CMake build exports the targets with namespace `LibDataChannel::LibDataChannel` and `LibDataChannel::LibDataChannelStatic` to link the library from another CMake project.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -25,6 +25,8 @@ The option `PREFER_SYSTEM_LIB` allows to link against the system library rather 
 
 If you only need Data Channels, the option `NO_MEDIA` allows to make the library lighter by removing media support. Similarly, `NO_WEBSOCKET` removes WebSocket support.
 
+SCTP I-DATA interleaving is enabled when the linked usrsctp exposes `SCTP_INTERLEAVING_SUPPORTED`. The option `DISABLE_SCTP_INTERLEAVING` forces the legacy non-interleaved behavior if needed for compatibility with a specific SCTP stack.
+
 For the sake of performance, the library should be compiled in `Release` mode if you don't plan to debug it.
 
 The CMake build exports the targets with namespace `LibDataChannel::LibDataChannel` and `LibDataChannel::LibDataChannelStatic` to link the library from another CMake project.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(NO_TESTS "Disable tests build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 option(SCTP_DEBUG "Enable SCTP debugging output to verbose log" OFF)
+option(DISABLE_SCTP_INTERLEAVING "Disable SCTP I-DATA interleaving support" OFF)
 option(RTC_UPDATE_VERSION_HEADER "Enable updating the version header" OFF)
 
 if(NOT NO_MEDIA AND NOT PREFER_SYSTEM_LIB)
@@ -228,6 +229,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/sctp_interleaving.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_generation.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_parsing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
@@ -423,6 +425,11 @@ else()
 		target_link_libraries(datachannel PRIVATE srtp2)
 		target_link_libraries(datachannel-static PRIVATE srtp2)
 	endif()
+endif()
+
+if(DISABLE_SCTP_INTERLEAVING)
+	target_compile_definitions(datachannel PRIVATE DISABLE_SCTP_INTERLEAVING=1)
+	target_compile_definitions(datachannel-static PRIVATE DISABLE_SCTP_INTERLEAVING=1)
 endif()
 
 if (USE_GNUTLS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(NO_TESTS "Disable tests build" OFF)
 option(WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option(CAPI_STDCALL "Set calling convention of C API callbacks stdcall" OFF)
 option(SCTP_DEBUG "Enable SCTP debugging output to verbose log" OFF)
+option(DISABLE_SCTP_INTERLEAVING "Disable SCTP I-DATA interleaving support" OFF)
 option(RTC_UPDATE_VERSION_HEADER "Enable updating the version header" OFF)
 
 if(NOT NO_MEDIA AND NOT PREFER_SYSTEM_LIB)
@@ -230,6 +231,7 @@ set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/sctp_interleaving.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_generation.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/test/simulcast_sdp_parsing.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/turn_connectivity.cpp
@@ -427,6 +429,11 @@ else()
 	endif()
 endif()
 
+if(DISABLE_SCTP_INTERLEAVING)
+	target_compile_definitions(datachannel PRIVATE DISABLE_SCTP_INTERLEAVING=1)
+	target_compile_definitions(datachannel-static PRIVATE DISABLE_SCTP_INTERLEAVING=1)
+endif()
+
 if (USE_GNUTLS)
 	find_package(GnuTLS REQUIRED)
 	if(NOT TARGET GnuTLS::GnuTLS)
@@ -592,7 +599,10 @@ if(NOT NO_TESTS)
 		XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER com.github.paullouisageneau.libdatachannel.tests)
 
 	target_include_directories(datachannel-tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-	target_link_libraries(datachannel-tests datachannel Threads::Threads)
+	target_link_libraries(datachannel-tests datachannel Threads::Threads Usrsctp::Usrsctp)
+	if(DISABLE_SCTP_INTERLEAVING)
+		target_compile_definitions(datachannel-tests PRIVATE DISABLE_SCTP_INTERLEAVING=1)
+	endif()
 
 	# Benchmark
 	if(CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -59,6 +59,18 @@ using utils::to_uint32;
 static LogCounter COUNTER_UNKNOWN_PPID(plog::warning,
                                        "Number of SCTP packets received with an unknown PPID");
 
+#ifdef SCTP_INTERLEAVING_SUPPORTED
+constexpr int SCTP_INTERLEAVING_SUPPORTED_OPTION = SCTP_INTERLEAVING_SUPPORTED;
+#else
+constexpr int SCTP_INTERLEAVING_SUPPORTED_OPTION = 0x00001206;
+#endif
+
+#ifdef SCTP_FRAG_LEVEL_2
+constexpr int SCTP_FRAGMENT_INTERLEAVE_LEVEL_2 = SCTP_FRAG_LEVEL_2;
+#else
+constexpr int SCTP_FRAGMENT_INTERLEAVE_LEVEL_2 = 2;
+#endif
+
 class SctpTransport::InstancesSet {
 public:
 	void insert(SctpTransport *instance) {
@@ -267,13 +279,45 @@ SctpTransport::SctpTransport(shared_ptr<Transport> lower, const Configuration &c
 		throw std::runtime_error("Could not set socket option SCTP_INITMSG, errno=" +
 		                         std::to_string(errno));
 
-	// Prevent fragmented interleave of messages (i.e. level 0), see RFC 6458 section 8.1.20.
-	// Unless the user has set the fragmentation interleave level to 0, notifications
-	// may also be interleaved with partially delivered messages.
-	int level = 0;
-	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level, sizeof(level)))
-		throw std::runtime_error("Could not disable SCTP fragmented interleave, errno=" +
-		                         std::to_string(errno));
+	const auto disableFragmentedInterleave = [&]() {
+		// Prevent fragmented interleave of messages (i.e. level 0), see RFC 6458 section 8.1.20.
+		// Unless the user has set the fragmentation interleave level to 0, notifications
+		// may also be interleaved with partially delivered messages.
+		int level = 0;
+		if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level,
+		                       sizeof(level)))
+			throw std::runtime_error("Could not disable SCTP fragmented interleave, errno=" +
+			                         std::to_string(errno));
+	};
+
+#if !defined(DISABLE_SCTP_INTERLEAVING)
+	// Enable RFC 8260 I-DATA support when usrsctp exposes it. The association negotiates the
+	// extension and falls back to DATA chunks when the remote peer does not support interleaving.
+	int level = SCTP_FRAGMENT_INTERLEAVE_LEVEL_2;
+	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level, sizeof(level))) {
+		const int error = errno;
+		PLOG_WARNING << "Could not enable SCTP fragmented interleave, falling back to level 0, "
+		                "errno="
+		             << error;
+		disableFragmentedInterleave();
+	} else {
+		struct sctp_assoc_value interleaving = {};
+		interleaving.assoc_id = SCTP_FUTURE_ASSOC;
+		interleaving.assoc_value = 1;
+		if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_INTERLEAVING_SUPPORTED_OPTION,
+		                       &interleaving, sizeof(interleaving))) {
+			const int error = errno;
+			PLOG_WARNING << "Could not enable SCTP I-DATA interleaving, falling back to level 0, "
+			                "errno="
+			             << error;
+			disableFragmentedInterleave();
+		} else {
+			PLOG_DEBUG << "SCTP I-DATA interleaving enabled for negotiation";
+		}
+	}
+#else
+	disableFragmentedInterleave();
+#endif
 
 #ifdef SCTP_ACCEPT_ZERO_CHECKSUM // not available in usrsctp v0.9.5.0
 	// When using SCTP over DTLS, the data integrity is ensured by DTLS. Therefore, there's no
@@ -517,19 +561,23 @@ void SctpTransport::doRecv() {
 
 			} else {
 				// SCTP message
-				mPartialMessage.insert(mPartialMessage.end(), buffer, buffer + len);
-				if (mPartialMessage.size() > mMaxMessageSize) {
+				if (infotype != SCTP_RECVV_RCVINFO)
+					throw std::runtime_error("Missing SCTP recv info");
+
+				const PartialMessageKey key(info.rcv_sid, info.rcv_ssn,
+				                            (info.rcv_flags & SCTP_UNORDERED) != 0);
+				auto &partialMessage = mPartialMessages[key];
+				partialMessage.insert(partialMessage.end(), buffer, buffer + len);
+				if (partialMessage.size() > mMaxMessageSize) {
 					PLOG_WARNING << "SCTP message is too large, truncating it";
-					mPartialMessage.resize(mMaxMessageSize);
+					partialMessage.resize(mMaxMessageSize);
 				}
 
 				if (flags & MSG_EOR) {
 					// Message is complete, process it
 					binary message;
-					mPartialMessage.swap(message);
-					if (infotype != SCTP_RECVV_RCVINFO)
-						throw std::runtime_error("Missing SCTP recv info");
-
+					partialMessage.swap(message);
+					mPartialMessages.erase(key);
 					processData(std::move(message), info.rcv_sid, PayloadId(ntohl(info.rcv_ppid)));
 				}
 			}
@@ -624,8 +672,7 @@ bool SctpTransport::trySendMessage(const message_ptr &message) {
 
 	PLOG_VERBOSE << "SCTP try send size=" << message->size();
 
-	// TODO: Implement SCTP ndata specification draft when supported everywhere
-	// See https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-sctp-ndata-08
+	// usrsctp emits DATA or I-DATA chunks according to association negotiation.
 
 	const Reliability reliability = message->reliability ? *message->reliability : Reliability();
 

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -209,6 +209,11 @@ SctpTransport::SctpTransport(shared_ptr<Transport> lower, const Configuration &c
 	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_EVENT, &se, sizeof(se)))
 		throw std::runtime_error("Could not subscribe to event SCTP_STREAM_RESET_EVENT, errno=" +
 		                         std::to_string(errno));
+	se.se_type = SCTP_PARTIAL_DELIVERY_EVENT;
+	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_EVENT, &se, sizeof(se)))
+		throw std::runtime_error(
+		    "Could not subscribe to event SCTP_PARTIAL_DELIVERY_EVENT, errno=" +
+		    std::to_string(errno));
 
 	// RFC 8831 6.6. Transferring User Data on a Data Channel
 	// The sender SHOULD disable the Nagle algorithm (see [RFC1122) to minimize the latency
@@ -267,13 +272,7 @@ SctpTransport::SctpTransport(shared_ptr<Transport> lower, const Configuration &c
 		throw std::runtime_error("Could not set socket option SCTP_INITMSG, errno=" +
 		                         std::to_string(errno));
 
-	// Prevent fragmented interleave of messages (i.e. level 0), see RFC 6458 section 8.1.20.
-	// Unless the user has set the fragmentation interleave level to 0, notifications
-	// may also be interleaved with partially delivered messages.
-	int level = 0;
-	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level, sizeof(level)))
-		throw std::runtime_error("Could not disable SCTP fragmented interleave, errno=" +
-		                         std::to_string(errno));
+	configureInterleaving();
 
 #ifdef SCTP_ACCEPT_ZERO_CHECKSUM // not available in usrsctp v0.9.5.0
 	// When using SCTP over DTLS, the data integrity is ensured by DTLS. Therefore, there's no
@@ -501,8 +500,7 @@ void SctpTransport::doRecv() {
 
 			PLOG_VERBOSE << "SCTP recv, len=" << len;
 
-			// SCTP_FRAGMENT_INTERLEAVE does not seem to work as expected for messages > 64KB,
-			// therefore partial notifications and messages need to be handled separately.
+			// Notifications and messages may be delivered in partial reads and interleaved.
 			if (flags & MSG_NOTIFICATION) {
 				// SCTP event notification
 				mPartialNotification.insert(mPartialNotification.end(), buffer, buffer + len);
@@ -517,19 +515,21 @@ void SctpTransport::doRecv() {
 
 			} else {
 				// SCTP message
-				mPartialMessage.insert(mPartialMessage.end(), buffer, buffer + len);
-				if (mPartialMessage.size() > mMaxMessageSize) {
+				if (infotype != SCTP_RECVV_RCVINFO)
+					throw std::runtime_error("Missing SCTP recv info");
+
+				auto &partialMessage = mPartialMessages[info.rcv_sid];
+				partialMessage.insert(partialMessage.end(), buffer, buffer + len);
+				if (partialMessage.size() > mMaxMessageSize) {
 					PLOG_WARNING << "SCTP message is too large, truncating it";
-					mPartialMessage.resize(mMaxMessageSize);
+					partialMessage.resize(mMaxMessageSize);
 				}
 
 				if (flags & MSG_EOR) {
 					// Message is complete, process it
 					binary message;
-					mPartialMessage.swap(message);
-					if (infotype != SCTP_RECVV_RCVINFO)
-						throw std::runtime_error("Missing SCTP recv info");
-
+					partialMessage.swap(message);
+					mPartialMessages.erase(info.rcv_sid);
 					processData(std::move(message), info.rcv_sid, PayloadId(ntohl(info.rcv_ppid)));
 				}
 			}
@@ -547,6 +547,39 @@ void SctpTransport::doFlush() {
 	} catch (const std::exception &e) {
 		PLOG_WARNING << e.what();
 	}
+}
+
+void SctpTransport::configureInterleaving() {
+	int level = 0;
+
+#if defined(SCTP_INTERLEAVING_SUPPORTED) && !defined(DISABLE_SCTP_INTERLEAVING)
+	// The association negotiates RFC 8260 and falls back to DATA chunks when unsupported by the
+	// remote endpoint.
+	level = 2;
+	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level, sizeof(level))) {
+		PLOG_WARNING << "Could not enable SCTP fragmented interleave, falling back to level 0, "
+		                "errno="
+		             << errno;
+	} else {
+		struct sctp_assoc_value interleaving = {};
+		interleaving.assoc_id = SCTP_FUTURE_ASSOC;
+		interleaving.assoc_value = 1;
+		if (!usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_INTERLEAVING_SUPPORTED,
+		                        &interleaving, sizeof(interleaving))) {
+			PLOG_DEBUG << "SCTP I-DATA interleaving enabled for negotiation";
+			return;
+		}
+
+		PLOG_WARNING << "Could not enable SCTP I-DATA interleaving, falling back to level 0, "
+		                "errno="
+		             << errno;
+	}
+#endif
+
+	level = 0;
+	if (usrsctp_setsockopt(mSock, IPPROTO_SCTP, SCTP_FRAGMENT_INTERLEAVE, &level, sizeof(level)))
+		throw std::runtime_error("Could not disable SCTP fragmented interleave, errno=" +
+		                         std::to_string(errno));
 }
 
 void SctpTransport::enqueueRecv() {
@@ -624,8 +657,7 @@ bool SctpTransport::trySendMessage(const message_ptr &message) {
 
 	PLOG_VERBOSE << "SCTP try send size=" << message->size();
 
-	// TODO: Implement SCTP ndata specification draft when supported everywhere
-	// See https://datatracker.ietf.org/doc/html/draft-ietf-tsvwg-sctp-ndata-08
+	// usrsctp emits DATA or I-DATA chunks according to association negotiation.
 
 	const Reliability reliability = message->reliability ? *message->reliability : Reliability();
 
@@ -932,6 +964,15 @@ void SctpTransport::processNotification(const union sctp_notification *notify, s
 				uint16_t streamId = reset_event.strreset_stream_list[i];
 				recv(make_message(0, Message::Reset, streamId));
 			}
+		}
+		break;
+	}
+
+	case SCTP_PARTIAL_DELIVERY_EVENT: {
+		const struct sctp_pdapi_event &event = notify->sn_pdapi_event;
+		if (event.pdapi_indication == SCTP_PARTIAL_DELIVERY_ABORTED) {
+			PLOG_VERBOSE << "SCTP partial delivery aborted, stream=" << event.pdapi_stream;
+			mPartialMessages.erase(static_cast<uint16_t>(event.pdapi_stream));
 		}
 		break;
 	}

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <map>
 #include <mutex>
+#include <tuple>
 
 #include "usrsctp.h"
 
@@ -116,7 +117,9 @@ private:
 	std::atomic<bool> mWritten = false;     // written outside lock
 	std::atomic<bool> mWrittenOnce = false; // same
 
-	binary mPartialMessage, mPartialNotification;
+	using PartialMessageKey = std::tuple<uint16_t, uint16_t, bool>;
+	std::map<PartialMessageKey, binary> mPartialMessages;
+	binary mPartialNotification;
 	binary mPartialStringData, mPartialBinaryData;
 
 	// Stats

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -82,6 +82,7 @@ private:
 
 	void doRecv();
 	void doFlush();
+	void configureInterleaving();
 	void enqueueRecv();
 	void enqueueFlush();
 	bool trySendQueue();
@@ -116,7 +117,8 @@ private:
 	std::atomic<bool> mWritten = false;     // written outside lock
 	std::atomic<bool> mWrittenOnce = false; // same
 
-	binary mPartialMessage, mPartialNotification;
+	std::map<uint16_t, binary> mPartialMessages;
+	binary mPartialNotification;
 	binary mPartialStringData, mPartialBinaryData;
 
 	// Stats

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -26,6 +26,7 @@ TestResult test_connectivity_fail_on_wrong_fingerprint();
 TestResult test_pem();
 TestResult test_negotiated();
 TestResult test_reliability();
+TestResult test_sctp_interleaving();
 TestResult test_simulcast_sdp_generation();
 TestResult test_simulcast_sdp_parsing();
 TestResult test_turn_connectivity();
@@ -91,6 +92,7 @@ static const vector<Test> tests = {
     // Test("WebRTC TURN connectivity", test_turn_connectivity),
     Test("WebRTC negotiated DataChannel", test_negotiated),
     Test("WebRTC reliability mode", test_reliability),
+    Test("WebRTC SCTP interleaving", test_sctp_interleaving),
     Test("WebRTC simulcast SDP generation", test_simulcast_sdp_generation),
     Test("WebRTC simulcast SDP parsing", test_simulcast_sdp_parsing),
 #if RTC_ENABLE_MEDIA

--- a/test/sctp_interleaving.cpp
+++ b/test/sctp_interleaving.cpp
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2026 Mertushka
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "rtc/rtc.hpp"
+#include "test.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <variant>
+#include <vector>
+
+using namespace rtc;
+using namespace std;
+using namespace std::chrono_literals;
+
+namespace {
+
+template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
+
+bool waitUntil(function<bool()> condition, chrono::seconds timeout) {
+	const auto deadline = chrono::steady_clock::now() + timeout;
+	while (chrono::steady_clock::now() < deadline) {
+		if (condition())
+			return true;
+		this_thread::sleep_for(100ms);
+	}
+	return condition();
+}
+
+binary makePattern(size_t size) {
+	binary data(size);
+	for (size_t i = 0; i < data.size(); ++i)
+		data[i] = rtc::byte((i * 31 + 17) % 251);
+	return data;
+}
+
+} // namespace
+
+TestResult test_sctp_interleaving() {
+	InitLogger(LogLevel::Debug);
+
+	Configuration config1;
+	config1.maxMessageSize = 2 * 1024 * 1024;
+	PeerConnection pc1(config1);
+
+	Configuration config2;
+	config2.maxMessageSize = 2 * 1024 * 1024;
+	PeerConnection pc2(config2);
+
+	pc1.onLocalDescription([&pc2](Description sdp) { pc2.setRemoteDescription(string(sdp)); });
+	pc1.onLocalCandidate([&pc2](Candidate candidate) { pc2.addRemoteCandidate(string(candidate)); });
+	pc2.onLocalDescription([&pc1](Description sdp) { pc1.setRemoteDescription(string(sdp)); });
+	pc2.onLocalCandidate([&pc1](Candidate candidate) { pc1.addRemoteCandidate(string(candidate)); });
+
+	mutex failureMutex;
+	string failure;
+	atomic<bool> failed = false;
+	auto fail = [&](string reason) {
+		lock_guard lock(failureMutex);
+		if (!failed) {
+			failure = std::move(reason);
+			failed = true;
+		}
+	};
+
+	const binary largeMessage = makePattern(384 * 1024);
+	const int expectedLargeMessages = 2;
+	const int expectedReliableMessages = 20;
+	const int expectedUnreliableMessages = 4;
+	atomic<int> largeReceived = 0;
+	atomic<int> reliableReceived = 0;
+	atomic<int> unreliableReceived = 0;
+
+	shared_ptr<DataChannel> bulk2;
+	shared_ptr<DataChannel> reliable2;
+	shared_ptr<DataChannel> unreliable2;
+
+	pc2.onDataChannel([&](shared_ptr<DataChannel> dc) {
+		const auto label = dc->label();
+		if (label == "interleave-bulk") {
+			dc->onMessage([&, wdc = make_weak_ptr(dc)](const variant<binary, string> &message) {
+				if (!wdc.lock())
+					return;
+				if (!holds_alternative<binary>(message)) {
+					fail("Bulk channel received a non-binary message");
+					return;
+				}
+				const auto &data = get<binary>(message);
+				if (data != largeMessage) {
+					fail("Bulk channel received corrupted binary data");
+					return;
+				}
+				++largeReceived;
+			});
+			std::atomic_store(&bulk2, dc);
+		} else if (label == "interleave-reliable") {
+			dc->onMessage([&](const variant<binary, string> &message) {
+				if (!holds_alternative<string>(message)) {
+					fail("Reliable small channel received a non-string message");
+					return;
+				}
+				const auto &text = get<string>(message);
+				if (text.rfind("reliable-", 0) != 0) {
+					fail("Reliable small channel received corrupted string data");
+					return;
+				}
+				++reliableReceived;
+			});
+			std::atomic_store(&reliable2, dc);
+		} else if (label == "interleave-unreliable") {
+			dc->onMessage([&](const variant<binary, string> &message) {
+				if (!holds_alternative<string>(message)) {
+					fail("Unreliable small channel received a non-string message");
+					return;
+				}
+				const auto &text = get<string>(message);
+				if (text.rfind("unreliable-", 0) != 0) {
+					fail("Unreliable small channel received corrupted string data");
+					return;
+				}
+				++unreliableReceived;
+			});
+			std::atomic_store(&unreliable2, dc);
+		} else {
+			fail("Unexpected DataChannel label: " + label);
+		}
+	});
+
+	auto bulk1 = pc1.createDataChannel("interleave-bulk");
+
+	Reliability reliable;
+	reliable.unordered = true;
+	auto reliable1 = pc1.createDataChannel("interleave-reliable", {reliable});
+
+	Reliability unreliable;
+	unreliable.unordered = true;
+	unreliable.maxRetransmits = 0;
+	auto unreliable1 = pc1.createDataChannel("interleave-unreliable", {unreliable});
+
+	if (!waitUntil(
+	        [&] {
+		        auto rb = std::atomic_load(&bulk2);
+		        auto rr = std::atomic_load(&reliable2);
+		        auto ru = std::atomic_load(&unreliable2);
+		        return rb && rr && ru && bulk1->isOpen() && reliable1->isOpen() &&
+		               unreliable1->isOpen() && rb->isOpen() && rr->isOpen() && ru->isOpen();
+	        },
+	        15s)) {
+		pc1.close();
+		pc2.close();
+		return TestResult(false, "DataChannels are not open");
+	}
+
+	for (int round = 0; round < expectedLargeMessages; ++round) {
+		bulk1->send(largeMessage);
+		for (int i = 0; i < expectedReliableMessages / expectedLargeMessages; ++i)
+			reliable1->send("reliable-" + to_string(round) + "-" + to_string(i));
+	}
+	for (int i = 0; i < expectedUnreliableMessages; ++i)
+		unreliable1->send("unreliable-" + to_string(i));
+
+	const bool delivered = waitUntil(
+	    [&] {
+		    return failed || (largeReceived == expectedLargeMessages &&
+		                      reliableReceived == expectedReliableMessages &&
+		                      unreliableReceived > 0);
+	    },
+	    15s);
+
+	pc1.close();
+	pc2.close();
+	this_thread::sleep_for(1s);
+
+	if (failed) {
+		lock_guard lock(failureMutex);
+		return TestResult(false, failure);
+	}
+	if (!delivered)
+		return TestResult(false, "Timed out waiting for interleaved data-channel messages");
+	if (unreliableReceived == 0)
+		return TestResult(false, "Unreliable maxRetransmits=0 channel did not deliver any message");
+
+	return TestResult(true);
+}

--- a/test/sctp_interleaving.cpp
+++ b/test/sctp_interleaving.cpp
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2026 mertushka
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "rtc/rtc.hpp"
+#include "test.hpp"
+#include "usrsctp.h"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <variant>
+#include <vector>
+
+using namespace rtc;
+using namespace std;
+using namespace std::chrono_literals;
+
+namespace {
+
+template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
+
+bool waitUntil(function<bool()> condition, chrono::seconds timeout) {
+	const auto deadline = chrono::steady_clock::now() + timeout;
+	while (chrono::steady_clock::now() < deadline) {
+		if (condition())
+			return true;
+		this_thread::sleep_for(100ms);
+	}
+	return condition();
+}
+
+binary makePattern(size_t size) {
+	binary data(size);
+	for (size_t i = 0; i < data.size(); ++i)
+		data[i] = rtc::byte((i * 31 + 17) % 251);
+	return data;
+}
+
+} // namespace
+
+TestResult test_sctp_interleaving() {
+#if !defined(SCTP_INTERLEAVING_SUPPORTED) || defined(DISABLE_SCTP_INTERLEAVING)
+	return TestResult(true);
+#endif
+
+	InitLogger(LogLevel::Debug);
+
+	Configuration config1;
+	config1.maxMessageSize = 2 * 1024 * 1024;
+	PeerConnection pc1(config1);
+
+	Configuration config2;
+	config2.maxMessageSize = 2 * 1024 * 1024;
+	PeerConnection pc2(config2);
+
+	pc1.onLocalDescription([&pc2](Description sdp) { pc2.setRemoteDescription(string(sdp)); });
+	pc1.onLocalCandidate([&pc2](Candidate candidate) { pc2.addRemoteCandidate(string(candidate)); });
+	pc2.onLocalDescription([&pc1](Description sdp) { pc1.setRemoteDescription(string(sdp)); });
+	pc2.onLocalCandidate([&pc1](Candidate candidate) { pc1.addRemoteCandidate(string(candidate)); });
+
+	mutex failureMutex;
+	string failure;
+	atomic<bool> failed = false;
+	auto fail = [&](string reason) {
+		lock_guard lock(failureMutex);
+		if (!failed) {
+			failure = std::move(reason);
+			failed = true;
+		}
+	};
+
+	const binary largeMessage = makePattern(384 * 1024);
+	const int expectedLargeMessages = 2;
+	const int expectedReliableMessages = 20;
+	const int expectedUnreliableMessages = 4;
+	atomic<int> largeReceived = 0;
+	atomic<int> reliableReceived = 0;
+	atomic<int> unreliableReceived = 0;
+	atomic<int> firstDataMessage = 0;
+
+	shared_ptr<DataChannel> bulk2;
+	shared_ptr<DataChannel> reliable2;
+	shared_ptr<DataChannel> unreliable2;
+
+	pc2.onDataChannel([&](shared_ptr<DataChannel> dc) {
+		const auto label = dc->label();
+		if (label == "interleave-bulk") {
+			dc->onMessage([&, wdc = make_weak_ptr(dc)](const variant<binary, string> &message) {
+				int expected = 0;
+				firstDataMessage.compare_exchange_strong(expected, 1);
+				if (!wdc.lock())
+					return;
+				if (!holds_alternative<binary>(message)) {
+					fail("Bulk channel received a non-binary message");
+					return;
+				}
+				const auto &data = get<binary>(message);
+				if (data != largeMessage) {
+					fail("Bulk channel received corrupted binary data");
+					return;
+				}
+				++largeReceived;
+			});
+			std::atomic_store(&bulk2, dc);
+		} else if (label == "interleave-reliable") {
+			dc->onMessage([&](const variant<binary, string> &message) {
+				int expected = 0;
+				firstDataMessage.compare_exchange_strong(expected, 2);
+				if (!holds_alternative<string>(message)) {
+					fail("Reliable small channel received a non-string message");
+					return;
+				}
+				const auto &text = get<string>(message);
+				if (text.rfind("reliable-", 0) != 0) {
+					fail("Reliable small channel received corrupted string data");
+					return;
+				}
+				++reliableReceived;
+			});
+			std::atomic_store(&reliable2, dc);
+		} else if (label == "interleave-unreliable") {
+			dc->onMessage([&](const variant<binary, string> &message) {
+				if (!holds_alternative<string>(message)) {
+					fail("Unreliable small channel received a non-string message");
+					return;
+				}
+				const auto &text = get<string>(message);
+				if (text.rfind("unreliable-", 0) != 0) {
+					fail("Unreliable small channel received corrupted string data");
+					return;
+				}
+				++unreliableReceived;
+			});
+			std::atomic_store(&unreliable2, dc);
+		} else {
+			fail("Unexpected DataChannel label: " + label);
+		}
+	});
+
+	auto bulk1 = pc1.createDataChannel("interleave-bulk");
+
+	Reliability reliable;
+	reliable.unordered = true;
+	auto reliable1 = pc1.createDataChannel("interleave-reliable", {reliable});
+
+	Reliability unreliable;
+	unreliable.unordered = true;
+	unreliable.maxRetransmits = 0;
+	auto unreliable1 = pc1.createDataChannel("interleave-unreliable", {unreliable});
+
+	if (!waitUntil(
+	        [&] {
+		        auto rb = std::atomic_load(&bulk2);
+		        auto rr = std::atomic_load(&reliable2);
+		        auto ru = std::atomic_load(&unreliable2);
+		        return rb && rr && ru && bulk1->isOpen() && reliable1->isOpen() &&
+		               unreliable1->isOpen() && rb->isOpen() && rr->isOpen() && ru->isOpen();
+	        },
+	        15s)) {
+		pc1.close();
+		pc2.close();
+		return TestResult(false, "DataChannels are not open");
+	}
+
+	for (int round = 0; round < expectedLargeMessages; ++round) {
+		bulk1->send(largeMessage);
+		for (int i = 0; i < expectedReliableMessages / expectedLargeMessages; ++i)
+			reliable1->send("reliable-" + to_string(round) + "-" + to_string(i));
+	}
+	for (int i = 0; i < expectedUnreliableMessages; ++i)
+		unreliable1->send("unreliable-" + to_string(i));
+
+	const bool delivered = waitUntil(
+	    [&] {
+		    return failed || (largeReceived == expectedLargeMessages &&
+		                      reliableReceived == expectedReliableMessages &&
+		                      unreliableReceived > 0);
+	    },
+	    15s);
+
+	pc1.close();
+	pc2.close();
+	this_thread::sleep_for(1s);
+
+	if (failed) {
+		lock_guard lock(failureMutex);
+		return TestResult(false, failure);
+	}
+	if (!delivered)
+		return TestResult(false, "Timed out waiting for interleaved data-channel messages");
+	if (unreliableReceived == 0)
+		return TestResult(false, "Unreliable maxRetransmits=0 channel did not deliver any message");
+	if (firstDataMessage != 2)
+		return TestResult(false, "Small messages did not bypass the fragmented bulk message");
+
+	return TestResult(true);
+}


### PR DESCRIPTION
Enable RFC 8260 I-DATA when the linked public usrsctp header exposes `SCTP_INTERLEAVING_SUPPORTED`.

- request fragmentation interleave level 2 and I-DATA, with the existing DATA path as fallback
- assemble partial delivery per stream and clear aborted partial messages
- add a cross-stream regression and a `DISABLE_SCTP_INTERLEAVING` opt-out

Depends on paullouisageneau/usrsctp#1; the general usrsctp change is sctplab/usrsctp#746. This remains draft until the pinned submodule is updated.

Closes #1595.