### PR TITLE
perf: reduce transport packet handoff copies

### DIFF
--- a/src/impl/dtlstransport.cpp
+++ b/src/impl/dtlstransport.cpp
@@ -134,16 +134,23 @@ void DtlsTransport::stop() {
 }
 
 bool DtlsTransport::send(message_ptr message) {
-	if (!message || state() != State::Connected)
+	if (!message)
 		return false;
 
-	PLOG_VERBOSE << "Send size=" << message->size();
+	return send(message->data(), message->size(), message->dscp);
+}
+
+bool DtlsTransport::send(const byte *data, size_t size, unsigned int dscp) {
+	if ((!data && size > 0) || state() != State::Connected)
+		return false;
+
+	PLOG_VERBOSE << "Send size=" << size;
 
 	ssize_t ret;
 	do {
 		std::lock_guard lock(mSendMutex);
-		mCurrentDscp = message->dscp;
-		ret = gnutls_record_send(mSession, message->data(), message->size());
+		mCurrentDscp = dscp;
+		ret = gnutls_record_send(mSession, data, size);
 	} while (ret == GNUTLS_E_INTERRUPTED || ret == GNUTLS_E_AGAIN);
 
 	if (ret == GNUTLS_E_LARGE_PACKET)
@@ -170,6 +177,12 @@ bool DtlsTransport::outgoing(message_ptr message) {
 	message->dscp = mCurrentDscp;
 
 	bool result = Transport::outgoing(std::move(message));
+	mOutgoingResult = result;
+	return result;
+}
+
+bool DtlsTransport::outgoing(const byte *data, size_t size, unsigned int dscp) {
+	bool result = Transport::outgoing(data, size, dscp);
 	mOutgoingResult = result;
 	return result;
 }
@@ -315,8 +328,7 @@ ssize_t DtlsTransport::WriteCallback(gnutls_transport_ptr_t ptr, const void *dat
 	DtlsTransport *t = static_cast<DtlsTransport *>(ptr);
 	try {
 		if (len > 0) {
-			auto b = reinterpret_cast<const byte *>(data);
-			t->outgoing(make_message(b, b + len));
+			t->outgoing(reinterpret_cast<const byte *>(data), len, t->mCurrentDscp.load());
 		}
 		gnutls_transport_set_errno(t->mSession, 0);
 		return ssize_t(len);
@@ -475,20 +487,26 @@ void DtlsTransport::stop() {
 }
 
 bool DtlsTransport::send(message_ptr message) {
-	if (!message || state() != State::Connected)
+	if (!message)
 		return false;
 
-	PLOG_VERBOSE << "Send size=" << message->size();
+	return send(message->data(), message->size(), message->dscp);
+}
+
+bool DtlsTransport::send(const byte *data, size_t size, unsigned int dscp) {
+	if ((!data && size > 0) || state() != State::Connected)
+		return false;
+
+	PLOG_VERBOSE << "Send size=" << size;
 
 	int ret;
 	do {
 		std::lock_guard lock(mSslMutex);
-		if (message->size() > size_t(mbedtls_ssl_get_max_out_record_payload(&mSsl)))
+		if (size > size_t(mbedtls_ssl_get_max_out_record_payload(&mSsl)))
 			return false;
 
-		mCurrentDscp = message->dscp;
-		ret = mbedtls_ssl_write(&mSsl, reinterpret_cast<const unsigned char *>(message->data()),
-		                        message->size());
+		mCurrentDscp = dscp;
+		ret = mbedtls_ssl_write(&mSsl, reinterpret_cast<const unsigned char *>(data), size);
 	} while (!mbedtls::check(ret));
 
 	return mOutgoingResult;
@@ -509,6 +527,12 @@ bool DtlsTransport::outgoing(message_ptr message) {
 	message->dscp = mCurrentDscp;
 
 	bool result = Transport::outgoing(std::move(message));
+	mOutgoingResult = result;
+	return result;
+}
+
+bool DtlsTransport::outgoing(const byte *data, size_t size, unsigned int dscp) {
+	bool result = Transport::outgoing(data, size, dscp);
 	mOutgoingResult = result;
 	return result;
 }
@@ -634,8 +658,7 @@ int DtlsTransport::WriteCallback(void *ctx, const unsigned char *buf, size_t len
 	auto *t = static_cast<DtlsTransport *>(ctx);
 	try {
 		if (len > 0) {
-			auto b = reinterpret_cast<const byte *>(buf);
-			t->outgoing(make_message(b, b + len));
+			t->outgoing(reinterpret_cast<const byte *>(buf), len, t->mCurrentDscp.load());
 		}
 		return int(len);
 
@@ -869,16 +892,23 @@ void DtlsTransport::stop() {
 }
 
 bool DtlsTransport::send(message_ptr message) {
-	if (!message || state() != State::Connected)
+	if (!message)
 		return false;
 
-	PLOG_VERBOSE << "Send size=" << message->size();
+	return send(message->data(), message->size(), message->dscp);
+}
+
+bool DtlsTransport::send(const byte *data, size_t size, unsigned int dscp) {
+	if ((!data && size > 0) || state() != State::Connected)
+		return false;
+
+	PLOG_VERBOSE << "Send size=" << size;
 
 	int ret, err;
 	{
 		std::lock_guard lock(mSslMutex);
-		mCurrentDscp = message->dscp;
-		ret = SSL_write(mSsl, message->data(), int(message->size()));
+		mCurrentDscp = dscp;
+		ret = SSL_write(mSsl, data, int(size));
 		err = SSL_get_error(mSsl, ret);
 	}
 
@@ -907,6 +937,12 @@ bool DtlsTransport::outgoing(message_ptr message) {
 	message->dscp = mCurrentDscp;
 
 	bool result = Transport::outgoing(std::move(message));
+	mOutgoingResult = result;
+	return result;
+}
+
+bool DtlsTransport::outgoing(const byte *data, size_t size, unsigned int dscp) {
+	bool result = Transport::outgoing(data, size, dscp);
 	mOutgoingResult = result;
 	return result;
 }
@@ -1082,8 +1118,8 @@ int DtlsTransport::BioMethodWrite(BIO *bio, const char *in, int inl) {
 	auto transport = reinterpret_cast<DtlsTransport *>(BIO_get_data(bio));
 	if (!transport)
 		return -1;
-	auto b = reinterpret_cast<const byte *>(in);
-	transport->outgoing(make_message(b, b + inl));
+	transport->outgoing(reinterpret_cast<const byte *>(in), size_t(inl),
+	                    transport->mCurrentDscp.load());
 	return inl; // can't fail
 }
 

--- a/src/impl/dtlstransport.hpp
+++ b/src/impl/dtlstransport.hpp
@@ -39,12 +39,14 @@ public:
 	virtual void start() override;
 	virtual void stop() override;
 	virtual bool send(message_ptr message) override; // false if dropped
+	virtual bool send(const byte *data, size_t size, unsigned int dscp) override; // false if dropped
 
 	bool isClient() const { return mIsClient; }
 
 protected:
 	virtual void incoming(message_ptr message) override;
 	virtual bool outgoing(message_ptr message) override;
+	virtual bool outgoing(const byte *data, size_t size, unsigned int dscp) override;
 	virtual bool demuxMessage(message_ptr message);
 	virtual void postHandshake();
 

--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -285,19 +285,29 @@ bool IceTransport::getSelectedCandidatePair(Candidate *local, Candidate *remote)
 }
 
 bool IceTransport::send(message_ptr message) {
-	auto s = state();
-	if (!message || (s != State::Connected && s != State::Completed))
+	if (!message)
 		return false;
 
-	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(std::move(message));
+	return send(message->data(), message->size(), message->dscp);
+}
+
+bool IceTransport::send(const byte *data, size_t size, unsigned int dscp) {
+	auto s = state();
+	if ((!data && size > 0) || (s != State::Connected && s != State::Completed))
+		return false;
+
+	PLOG_VERBOSE << "Send size=" << size;
+	return outgoing(data, size, dscp);
 }
 
 bool IceTransport::outgoing(message_ptr message) {
+	return outgoing(message->data(), message->size(), message->dscp);
+}
+
+bool IceTransport::outgoing(const byte *data, size_t size, unsigned int dscp) {
 	// Explicit Congestion Notification takes the least-significant 2 bits of the DS field
-	int ds = int(message->dscp << 2);
-	return juice_send_diffserv(mAgent.get(), reinterpret_cast<const char *>(message->data()),
-	                           message->size(), ds) >= 0;
+	int ds = int(dscp << 2);
+	return juice_send_diffserv(mAgent.get(), reinterpret_cast<const char *>(data), size, ds) >= 0;
 }
 
 void IceTransport::changeGatheringState(GatheringState state) {
@@ -799,24 +809,35 @@ optional<string> IceTransport::getRemoteAddress() const {
 }
 
 bool IceTransport::send(message_ptr message) {
-	auto s = state();
-	if (!message || (s != State::Connected && s != State::Completed))
+	if (!message)
 		return false;
 
-	PLOG_VERBOSE << "Send size=" << message->size();
-	return outgoing(std::move(message));
+	return send(message->data(), message->size(), message->dscp);
+}
+
+bool IceTransport::send(const byte *data, size_t size, unsigned int dscp) {
+	auto s = state();
+	if ((!data && size > 0) || (s != State::Connected && s != State::Completed))
+		return false;
+
+	PLOG_VERBOSE << "Send size=" << size;
+	return outgoing(data, size, dscp);
 }
 
 bool IceTransport::outgoing(message_ptr message) {
+	return outgoing(message->data(), message->size(), message->dscp);
+}
+
+bool IceTransport::outgoing(const byte *data, size_t size, unsigned int dscp) {
 	std::lock_guard lock(mOutgoingMutex);
-	if (mOutgoingDscp != message->dscp) {
-		mOutgoingDscp = message->dscp;
+	if (mOutgoingDscp != dscp) {
+		mOutgoingDscp = dscp;
 		// Explicit Congestion Notification takes the least-significant 2 bits of the DS field
-		int ds = int(message->dscp << 2);
+		int ds = int(dscp << 2);
 		nice_agent_set_stream_tos(mNiceAgent.get(), mStreamId, ds); // ToS is the legacy name for DS
 	}
-	return nice_agent_send(mNiceAgent.get(), mStreamId, 1, message->size(),
-	                       reinterpret_cast<const char *>(message->data())) >= 0;
+	return nice_agent_send(mNiceAgent.get(), mStreamId, 1, size,
+	                       reinterpret_cast<const char *>(data)) >= 0;
 }
 
 void IceTransport::changeGatheringState(GatheringState state) {

--- a/src/impl/icetransport.hpp
+++ b/src/impl/icetransport.hpp
@@ -57,11 +57,13 @@ public:
 	optional<string> getRemoteAddress() const;
 
 	bool send(message_ptr message) override; // false if dropped
+	bool send(const byte *data, size_t size, unsigned int dscp) override; // false if dropped
 
 	bool getSelectedCandidatePair(Candidate *local, Candidate *remote);
 
 private:
 	bool outgoing(message_ptr message) override;
+	bool outgoing(const byte *data, size_t size, unsigned int dscp) override;
 
 	void changeGatheringState(GatheringState state);
 

--- a/src/impl/sctptransport.cpp
+++ b/src/impl/sctptransport.cpp
@@ -476,6 +476,12 @@ bool SctpTransport::outgoing(message_ptr message) {
 	return Transport::outgoing(std::move(message));
 }
 
+bool SctpTransport::outgoing(const byte *data, size_t size, unsigned int /*dscp*/) {
+	// Set recommended medium-priority DSCP value
+	// See https://www.rfc-editor.org/rfc/rfc8837.html#section-5
+	return Transport::outgoing(data, size, 10); // AF11: Assured Forwarding class 1, low drop probability
+}
+
 void SctpTransport::doRecv() {
 	std::lock_guard lock(mRecvMutex);
 	--mPendingRecvCount;
@@ -768,7 +774,7 @@ int SctpTransport::handleWrite(byte *data, size_t len, uint8_t /*tos*/,
 		std::unique_lock lock(mWriteMutex);
 		PLOG_VERBOSE << "Handle write, len=" << len;
 
-		if (!outgoing(make_message(data, data + len)))
+		if (!outgoing(data, len, 0))
 			return -1;
 
 		mWritten = true;

--- a/src/impl/sctptransport.hpp
+++ b/src/impl/sctptransport.hpp
@@ -79,6 +79,7 @@ private:
 	void shutdown();
 	void incoming(message_ptr message) override;
 	bool outgoing(message_ptr message) override;
+	bool outgoing(const byte *data, size_t size, unsigned int dscp) override;
 
 	void doRecv();
 	void doFlush();

--- a/src/impl/transport.cpp
+++ b/src/impl/transport.cpp
@@ -67,6 +67,15 @@ void Transport::stop() { unregisterIncoming(); }
 
 bool Transport::send(message_ptr message) { return outgoing(std::move(message)); }
 
+bool Transport::send(const byte *data, size_t size, unsigned int dscp) {
+	if (!data && size > 0)
+		return false;
+
+	auto message = size > 0 ? make_message(data, data + size) : make_message(0);
+	message->dscp = dscp;
+	return send(std::move(message));
+}
+
 void Transport::recv(message_ptr message) {
 	try {
 		std::unique_lock lock(mPendingMutex);
@@ -100,6 +109,13 @@ void Transport::incoming(message_ptr message) { recv(std::move(message)); }
 bool Transport::outgoing(message_ptr message) {
 	if (mLower)
 		return mLower->send(std::move(message));
+	else
+		return false;
+}
+
+bool Transport::outgoing(const byte *data, size_t size, unsigned int dscp) {
+	if (mLower)
+		return mLower->send(data, size, dscp);
 	else
 		return false;
 }

--- a/src/impl/transport.hpp
+++ b/src/impl/transport.hpp
@@ -40,12 +40,14 @@ public:
 	virtual void start();
 	virtual void stop();
 	virtual bool send(message_ptr message);
+	virtual bool send(const byte *data, size_t size, unsigned int dscp);
 
 protected:
 	void recv(message_ptr message);
 	void changeState(State state);
 	virtual void incoming(message_ptr message);
 	virtual bool outgoing(message_ptr message);
+	virtual bool outgoing(const byte *data, size_t size, unsigned int dscp);
 
 private:
 	const init_token mInitToken = Init::Instance().token();


### PR DESCRIPTION
Reduces internal packet handoff overhead on the DataChannel send path by adding a borrowed-buffer transport send path between SCTP, DTLS, and ICE.

It avoids allocating and copying intermediate `Message` objects for synchronous lower-layer sends from usrsctp write callbacks, DTLS write callbacks, and ICE UDP sends, while preserving the existing `message_ptr` fallback for other transports.