### PR TITLE
Fix return type of RtcpReportBlock::getNTPOfSR

### DIFF
--- a/include/rtc/rtp.hpp
+++ b/include/rtc/rtp.hpp
@@ -99,7 +99,7 @@ struct RTC_CPP_EXPORT RtcpReportBlock {
 	[[nodiscard]] uint32_t delaySinceSR() const;
 
 	[[nodiscard]] SSRC getSSRC() const;
-	[[nodiscard]] uint32_t getNTPOfSR() const;
+	[[nodiscard]] uint64_t getNTPOfSR() const;
 	[[nodiscard]] uint8_t getFractionLost() const;
 	[[nodiscard]] unsigned int getPacketsLostCount() const;
 

--- a/src/rtp.cpp
+++ b/src/rtp.cpp
@@ -229,7 +229,7 @@ void RtcpReportBlock::setJitter(uint32_t jitter) { _jitter = htonl(jitter); }
 
 void RtcpReportBlock::setNTPOfSR(uint64_t ntp) { _lastReport = htonl((uint32_t)(ntp >> 16)); }
 
-uint32_t RtcpReportBlock::getNTPOfSR() const { return ntohl(_lastReport) << 16u; }
+uint64_t RtcpReportBlock::getNTPOfSR() const { return (uint64_t)ntohl(_lastReport) << 16u; }
 
 void RtcpReportBlock::setDelaySinceSR(uint32_t sr) {
 	// The delay, expressed in units of 1/65536 seconds


### PR DESCRIPTION
Closes #1607