### PR TITLE
Preserve codec order in SDP attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,6 +225,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 
 set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/description.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -1360,8 +1360,12 @@ string Description::Media::generateSdpLines(string_view eol) const {
 	for (const auto &fb : mRtcpFbs)
 		sdp << "a=rtcp-fb:* " << fb << eol;
 
-	for (auto it = mRtpMaps.begin(); it != mRtpMaps.end(); ++it) {
-		auto &map = it->second;
+	for (const auto payloadType : mOrderedPayloadTypes) {
+		auto it = mRtpMaps.find(payloadType);
+		if (it == mRtpMaps.end())
+			continue;
+
+		const auto &map = it->second;
 
 		// Create the a=rtpmap
 		sdp << "a=rtpmap:" << map.payloadType << ' ' << map.format << '/' << map.clockRate;

--- a/test/description.cpp
+++ b/test/description.cpp
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2026
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "rtc/description.hpp"
+#include "test.hpp"
+
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+using namespace rtc;
+using namespace std;
+
+namespace {
+
+vector<string> codecAttributeLines(const string &sdp) {
+	vector<string> lines;
+	string line;
+	istringstream stream(sdp);
+	while (getline(stream, line)) {
+		if (!line.empty() && line.back() == '\r')
+			line.pop_back();
+
+		if (line.rfind("a=rtpmap:", 0) == 0 || line.rfind("a=fmtp:", 0) == 0 ||
+		    (line.rfind("a=rtcp-fb:", 0) == 0 && line.rfind("a=rtcp-fb:*", 0) != 0))
+			lines.push_back(std::move(line));
+	}
+	return lines;
+}
+
+vector<int> rtpMapPayloadTypes(const string &sdp) {
+	vector<int> payloadTypes;
+	for (const auto &line : codecAttributeLines(sdp)) {
+		constexpr string_view prefix = "a=rtpmap:";
+		if (line.rfind(prefix, 0) != 0)
+			continue;
+
+		const auto end = line.find(' ', prefix.size());
+		payloadTypes.push_back(stoi(line.substr(prefix.size(), end - prefix.size())));
+	}
+	return payloadTypes;
+}
+
+} // namespace
+
+TestResult test_description_codec_order() {
+	const string mediaSdp =
+	    "m=video 9 UDP/TLS/RTP/SAVPF 102 121 96 97\r\n"
+	    "c=IN IP4 0.0.0.0\r\n"
+	    "a=mid:video\r\n"
+	    "a=sendrecv\r\n"
+	    "a=rtcp-mux\r\n"
+	    "a=rtpmap:96 VP8/90000\r\n"
+	    "a=rtcp-fb:96 nack\r\n"
+	    "a=rtpmap:102 H264/90000\r\n"
+	    "a=fmtp:102 profile-level-id=42e01f\r\n"
+	    "a=rtpmap:97 rtx/90000\r\n"
+	    "a=fmtp:97 apt=96\r\n"
+	    "a=rtpmap:121 rtx/90000\r\n"
+	    "a=fmtp:121 apt=102\r\n";
+	const vector<string> expectedLines = {
+	    "a=rtpmap:102 H264/90000",
+	    "a=fmtp:102 profile-level-id=42e01f",
+	    "a=rtpmap:121 rtx/90000",
+	    "a=fmtp:121 apt=102",
+	    "a=rtpmap:96 VP8/90000",
+	    "a=rtcp-fb:96 nack",
+	    "a=rtpmap:97 rtx/90000",
+	    "a=fmtp:97 apt=96",
+	};
+
+	Description::Media parsed(mediaSdp);
+	if (codecAttributeLines(parsed.generateSdp()) != expectedLines)
+		return TestResult(false, "Parsed codec attributes do not follow m-line order");
+
+	Description::Video constructed("video", Description::Direction::SendOnly);
+	constructed.addH264Codec(102);
+	constructed.addVP8Codec(96);
+	if (rtpMapPayloadTypes(constructed.generateSdp()) != vector<int>{102, 96})
+		return TestResult(false, "Added codec attributes do not follow insertion order");
+
+	constructed.removeRtpMap(102);
+	constructed.addH264Codec(102);
+	if (rtpMapPayloadTypes(constructed.generateSdp()) != vector<int>{96, 102})
+		return TestResult(false, "Re-added codec attributes do not move to the end");
+
+	return TestResult(true);
+}

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -23,6 +23,7 @@ using chrono::steady_clock;
 
 TestResult test_connectivity();
 TestResult test_connectivity_fail_on_wrong_fingerprint();
+TestResult test_description_codec_order();
 TestResult test_pem();
 TestResult test_negotiated();
 TestResult test_reliability();
@@ -84,6 +85,7 @@ TestResult test_capi_cleanup() {
 
 static const vector<Test> tests = {
     // C++ API tests
+    Test("Description codec order", test_description_codec_order),
     Test("WebRTC connectivity", test_connectivity),
     Test("WebRTC broken fingerprint", test_connectivity_fail_on_wrong_fingerprint),
     Test("pem", test_pem),


### PR DESCRIPTION
Fixes SDP codec attributes to follow m-line preference order. Adds regression coverage for parsed, constructed, RTX, and remove/re-add cases.