### PR TITLE
Expose remote descriptions on tracks

### DIFF
--- a/include/rtc/rtc.h
+++ b/include/rtc/rtc.h
@@ -162,6 +162,7 @@ typedef void(RTC_API *rtcGatheringStateCallbackFunc)(int pc, rtcGatheringState s
 typedef void(RTC_API *rtcSignalingStateCallbackFunc)(int pc, rtcSignalingState state, void *ptr);
 typedef void(RTC_API *rtcDataChannelCallbackFunc)(int pc, int dc, void *ptr);
 typedef void(RTC_API *rtcTrackCallbackFunc)(int pc, int tr, void *ptr);
+typedef void(RTC_API *rtcTrackDescriptionCallbackFunc)(int tr, const char *sdp, void *ptr);
 typedef void(RTC_API *rtcOpenCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcClosedCallbackFunc)(int id, void *ptr);
 typedef void(RTC_API *rtcErrorCallbackFunc)(int id, const char *error, void *ptr);
@@ -327,7 +328,12 @@ RTC_C_EXPORT int rtcAddTrack(int pc, const char *mediaDescriptionSdp); // return
 RTC_C_EXPORT int rtcAddTrackEx(int pc, const rtcTrackInit *init);      // returns tr id
 RTC_C_EXPORT int rtcDeleteTrack(int tr);
 
+// Local media description used for offer and answer generation
 RTC_C_EXPORT int rtcGetTrackDescription(int tr, char *buffer, int size);
+// Latest media description applied from the remote peer
+RTC_C_EXPORT int rtcGetTrackRemoteDescription(int tr, char *buffer, int size);
+// Called asynchronously when an existing track's remote description changes
+RTC_C_EXPORT int rtcSetTrackRemoteDescriptionCallback(int tr, rtcTrackDescriptionCallbackFunc cb);
 RTC_C_EXPORT int rtcGetTrackMid(int tr, char *buffer, int size);
 RTC_C_EXPORT int rtcGetTrackDirection(int tr, rtcDirection *direction);
 

--- a/include/rtc/track.hpp
+++ b/include/rtc/track.hpp
@@ -31,9 +31,14 @@ public:
 
 	string mid() const;
 	Description::Direction direction() const;
+	// Local media description used for offer and answer generation.
 	Description::Media description() const;
+	// Latest media description applied from the remote peer, if any.
+	optional<Description::Media> remoteDescription() const;
 
 	void setDescription(Description::Media description);
+	// Called asynchronously when an existing track's remote description changes.
+	void onRemoteDescription(std::function<void(Description::Media description)> callback);
 
 	void close(void) override;
 	bool send(message_variant data) override;

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -813,7 +813,7 @@ After this function has been called, `tr` must not be used in a function call an
 int rtcGetTrackDescription(int tr, char *buffer, int size)
 ```
 
-Retrieves the SDP media description of a Track.
+Retrieves the local SDP media description of a Track used for offer and answer generation.
 
 Arguments:
 
@@ -824,6 +824,36 @@ Arguments:
 Return value: the length of the string copied in buffer (including the terminating null character) or a negative error code
 
 If `buffer` is `NULL`, the description is not copied but the size is still returned.
+
+#### rtcGetTrackRemoteDescription
+
+```
+int rtcGetTrackRemoteDescription(int tr, char *buffer, int size)
+```
+
+Retrieves the latest SDP media description applied from the remote peer for a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `buffer`: a user-supplied buffer to store the description
+- `size`: the size of `buffer`
+
+Return value: the length of the string copied in buffer (including the terminating null character), `RTC_ERR_NOT_AVAIL` if no remote description has been applied, or another negative error code
+
+If `buffer` is `NULL`, the description is not copied but the size is still returned.
+
+#### rtcSetTrackRemoteDescriptionCallback
+
+```
+int rtcSetTrackRemoteDescriptionCallback(int tr, rtcTrackDescriptionCallbackFunc cb)
+```
+
+Sets, changes, or unsets (if `cb` is `NULL`) the remote description callback of a Track.
+
+`cb` must have the following signature: `void myTrackDescriptionCallback(int tr, const char *sdp, void *user_ptr)`
+
+The callback is called asynchronously after an existing Track's remote media description changes. The initial remote description of an incoming Track is available through `rtcGetTrackRemoteDescription` when the Track callback runs and does not trigger this callback. The `sdp` string is valid only for the duration of the callback.
 
 #### rtcGetTrackMid
 

--- a/pages/content/pages/reference.md
+++ b/pages/content/pages/reference.md
@@ -813,7 +813,7 @@ After this function has been called, `tr` must not be used in a function call an
 int rtcGetTrackDescription(int tr, char *buffer, int size)
 ```
 
-Retrieves the SDP media description of a Track.
+Retrieves the local SDP media description of a Track used for offer and answer generation.
 
 Arguments:
 
@@ -824,6 +824,36 @@ Arguments:
 Return value: the length of the string copied in buffer (including the terminating null character) or a negative error code
 
 If `buffer` is `NULL`, the description is not copied but the size is still returned.
+
+#### rtcGetTrackRemoteDescription
+
+```
+int rtcGetTrackRemoteDescription(int tr, char *buffer, int size)
+```
+
+Retrieves the latest SDP media description applied from the remote peer for a Track.
+
+Arguments:
+
+- `tr`: the Track identifier
+- `buffer`: a user-supplied buffer to store the description
+- `size`: the size of `buffer`
+
+Return value: the length of the string copied in buffer (including the terminating null character), `RTC_ERR_NOT_AVAIL` if no remote description has been applied, or another negative error code
+
+If `buffer` is `NULL`, the description is not copied but the size is still returned.
+
+#### rtcSetTrackRemoteDescriptionCallback
+
+```
+int rtcSetTrackRemoteDescriptionCallback(int tr, rtcTrackDescriptionCallbackFunc cb)
+```
+
+Sets, changes, or unsets (if `cb` is `NULL`) the remote description callback of a Track.
+
+`cb` must have the following signature: `void myTrackDescriptionCallback(int tr, const char *sdp, void *user_ptr)`
+
+The callback is called asynchronously after an existing Track's remote media description changes. The initial remote description of an incoming Track is available through `rtcGetTrackRemoteDescription` when the Track callback runs and does not trigger this callback. Callback delivery is serialized with Track closure, and queued changes are not delivered after the Track is closed. The `sdp` string is valid only for the duration of the callback.
 
 #### rtcGetTrackMid
 

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1199,6 +1199,33 @@ int rtcGetTrackDescription(int tr, char *buffer, int size) {
 	});
 }
 
+int rtcGetTrackRemoteDescription(int tr, char *buffer, int size) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		if (auto description = track->remoteDescription())
+			return copyAndReturn(std::move(*description), buffer, size);
+
+		return RTC_ERR_NOT_AVAIL;
+	});
+}
+
+int rtcSetTrackRemoteDescriptionCallback(int tr, rtcTrackDescriptionCallbackFunc cb) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		if (cb) {
+			track->onRemoteDescription([tr, cb](Description::Media description) {
+				if (auto ptr = getUserPointer(tr)) {
+					auto sdp = string(description);
+					cb(tr, sdp.c_str(), *ptr);
+				}
+			});
+		} else {
+			track->onRemoteDescription(nullptr);
+		}
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcGetTrackMid(int tr, char *buffer, int size) {
 	return wrap([&] {
 		auto track = getTrack(tr);

--- a/src/capi.cpp
+++ b/src/capi.cpp
@@ -1201,6 +1201,33 @@ int rtcGetTrackDescription(int tr, char *buffer, int size) {
 	});
 }
 
+int rtcGetTrackRemoteDescription(int tr, char *buffer, int size) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		if (auto description = track->remoteDescription())
+			return copyAndReturn(std::move(*description), buffer, size);
+
+		return RTC_ERR_NOT_AVAIL;
+	});
+}
+
+int rtcSetTrackRemoteDescriptionCallback(int tr, rtcTrackDescriptionCallbackFunc cb) {
+	return wrap([&] {
+		auto track = getTrack(tr);
+		if (cb) {
+			track->onRemoteDescription([tr, cb](Description::Media description) {
+				if (auto ptr = getUserPointer(tr)) {
+					auto sdp = string(description);
+					cb(tr, sdp.c_str(), *ptr);
+				}
+			});
+		} else {
+			track->onRemoteDescription(nullptr);
+		}
+		return RTC_ERR_SUCCESS;
+	});
+}
+
 int rtcGetTrackMid(int tr, char *buffer, int size) {
 	return wrap([&] {
 		auto track = getTrack(tr);

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1125,7 +1125,10 @@ void PeerConnection::processLocalCandidate(Candidate candidate) {
 	                   &localCandidateCallback, std::move(candidate));
 }
 
-void PeerConnection::processRemoteDescription(Description description) {
+std::vector<PeerConnection::TrackRemoteDescriptionUpdate>
+PeerConnection::processRemoteDescription(Description description) {
+	std::vector<TrackRemoteDescriptionUpdate> trackUpdates;
+
 	// Create tracks from remote description
 	for (int i = 0; i < description.mediaCount(); ++i) {
 		auto media = description.media(i);
@@ -1140,6 +1143,10 @@ void PeerConnection::processRemoteDescription(Description description) {
 						desc.disableRtx();
 						track->setDescription(std::move(desc));
 					}
+
+					auto remoteDescription = *remoteMedia;
+					if (track->setRemoteDescription(remoteDescription))
+						trackUpdates.emplace_back(track, std::move(remoteDescription));
 				}
 				continue;
 			}
@@ -1157,6 +1164,7 @@ void PeerConnection::processRemoteDescription(Description description) {
 
 			// Create incoming track
 			auto track = std::make_shared<Track>(weak_from_this(), std::move(reciprocated));
+			track->setRemoteDescription(*remoteMedia);
 			mTracks.emplace(std::make_pair(track->mid(), track));
 			mTrackLines.emplace_back(track);
 			triggerTrack(track); // The user may modify the track description
@@ -1198,6 +1206,8 @@ void PeerConnection::processRemoteDescription(Description description) {
 	// Reciprocated tracks might need to be open
 	if (dtlsTransport && dtlsTransport->state() == Transport::State::Connected)
 		mProcessor.enqueue(&PeerConnection::openTracks, shared_from_this());
+
+	return trackUpdates;
 }
 
 void PeerConnection::processRemoteCandidate(Candidate candidate) {
@@ -1308,6 +1318,19 @@ void PeerConnection::triggerTrack(weak_ptr<Track> weakTrack) {
 		mPendingTracks.push(std::move(track));
 	}
 	triggerPendingTracks();
+}
+
+void PeerConnection::dispatchTrackRemoteDescriptions(
+    std::vector<TrackRemoteDescriptionUpdate> updates) {
+	for (auto &[track, description] : updates)
+		mProcessor.enqueue(&PeerConnection::triggerTrackRemoteDescription, shared_from_this(),
+		                   std::move(track), std::move(description));
+}
+
+void PeerConnection::triggerTrackRemoteDescription(weak_ptr<Track> weakTrack,
+                                                   Description::Media description) {
+	if (auto track = weakTrack.lock())
+		track->triggerRemoteDescription(std::move(description));
 }
 
 void PeerConnection::triggerPendingDataChannels() {

--- a/src/impl/peerconnection.cpp
+++ b/src/impl/peerconnection.cpp
@@ -1125,7 +1125,10 @@ void PeerConnection::processLocalCandidate(Candidate candidate) {
 	                   &localCandidateCallback, std::move(candidate));
 }
 
-void PeerConnection::processRemoteDescription(Description description) {
+std::vector<PeerConnection::TrackRemoteDescriptionUpdate>
+PeerConnection::processRemoteDescription(Description description) {
+	std::vector<TrackRemoteDescriptionUpdate> trackUpdates;
+
 	// Create tracks from remote description
 	for (int i = 0; i < description.mediaCount(); ++i) {
 		auto media = description.media(i);
@@ -1140,6 +1143,10 @@ void PeerConnection::processRemoteDescription(Description description) {
 						desc.disableRtx();
 						track->setDescription(std::move(desc));
 					}
+
+					auto remoteDescription = *remoteMedia;
+					if (track->setRemoteDescription(remoteDescription))
+						trackUpdates.emplace_back(track, std::move(remoteDescription));
 				}
 				continue;
 			}
@@ -1157,6 +1164,7 @@ void PeerConnection::processRemoteDescription(Description description) {
 
 			// Create incoming track
 			auto track = std::make_shared<Track>(weak_from_this(), std::move(reciprocated));
+			track->setRemoteDescription(*remoteMedia);
 			mTracks.emplace(track->mid(), track);
 			mTrackLines.emplace_back(track);
 			triggerTrack(track); // The user may modify the track description
@@ -1198,6 +1206,8 @@ void PeerConnection::processRemoteDescription(Description description) {
 	// Reciprocated tracks might need to be open
 	if (dtlsTransport && dtlsTransport->state() == Transport::State::Connected)
 		mProcessor.enqueue(&PeerConnection::openTracks, shared_from_this());
+
+	return trackUpdates;
 }
 
 void PeerConnection::processRemoteCandidate(Candidate candidate) {
@@ -1308,6 +1318,19 @@ void PeerConnection::triggerTrack(weak_ptr<Track> weakTrack) {
 		mPendingTracks.push(std::move(track));
 	}
 	triggerPendingTracks();
+}
+
+void PeerConnection::dispatchTrackRemoteDescriptions(
+    std::vector<TrackRemoteDescriptionUpdate> updates) {
+	for (auto &[track, description] : updates)
+		mProcessor.enqueue(&PeerConnection::triggerTrackRemoteDescription, shared_from_this(),
+		                   std::move(track), std::move(description));
+}
+
+void PeerConnection::triggerTrackRemoteDescription(weak_ptr<Track> weakTrack,
+                                                   Description::Media description) {
+	if (auto track = weakTrack.lock())
+		track->triggerRemoteDescription(std::move(description));
 }
 
 void PeerConnection::triggerPendingDataChannels() {

--- a/src/impl/peerconnection.hpp
+++ b/src/impl/peerconnection.hpp
@@ -78,8 +78,11 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 	void populateLocalDescription(Description &description) const;
 	void processLocalDescription(Description description);
 	void processLocalCandidate(Candidate candidate);
-	void processRemoteDescription(Description description);
+	using TrackRemoteDescriptionUpdate =
+	    std::pair<weak_ptr<Track>, Description::Media>;
+	std::vector<TrackRemoteDescriptionUpdate> processRemoteDescription(Description description);
 	void processRemoteCandidate(Candidate candidate);
+	void dispatchTrackRemoteDescriptions(std::vector<TrackRemoteDescriptionUpdate> updates);
 	string localBundleMid() const;
 
 	bool negotiationNeeded() const;
@@ -89,6 +92,8 @@ struct PeerConnection : std::enable_shared_from_this<PeerConnection> {
 
 	void triggerDataChannel(weak_ptr<DataChannel> weakDataChannel);
 	void triggerTrack(weak_ptr<Track> weakTrack);
+	void triggerTrackRemoteDescription(weak_ptr<Track> weakTrack,
+	                                   Description::Media description);
 
 	void triggerPendingDataChannels();
 	void triggerPendingTracks();

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -52,6 +52,11 @@ Description::Media Track::description() const {
 	return mMediaDescription;
 }
 
+optional<Description::Media> Track::remoteDescription() const {
+	std::shared_lock lock(mMutex);
+	return mRemoteDescription;
+}
+
 void Track::setDescription(Description::Media desc) {
 	{
 		std::unique_lock lock(mMutex);
@@ -65,6 +70,33 @@ void Track::setDescription(Description::Media desc) {
 		handler->mediaChain(description());
 }
 
+bool Track::setRemoteDescription(Description::Media desc) {
+	std::unique_lock lock(mMutex);
+	if (desc.mid() != mMediaDescription.mid())
+		throw std::logic_error("Remote media description mid does not match track mid");
+
+	if (mRemoteDescription && string(*mRemoteDescription) == string(desc))
+		return false;
+
+	mRemoteDescription = std::move(desc);
+	return true;
+}
+
+void Track::triggerRemoteDescription(Description::Media desc) {
+	if (mIsClosed)
+		return;
+
+	auto callback = remoteDescriptionCallback;
+	if (mIsClosed)
+		return;
+
+	try {
+		callback(std::move(desc));
+	} catch (const std::exception &e) {
+		PLOG_WARNING << "Uncaught exception in callback: " << e.what();
+	}
+}
+
 void Track::close() {
 	PLOG_VERBOSE << "Closing Track";
 
@@ -72,6 +104,7 @@ void Track::close() {
 	{
 		triggerClosed();
 		setMediaHandler(nullptr);
+		remoteDescriptionCallback = nullptr;
 		resetCallbacks();
 	}
 }

--- a/src/impl/track.cpp
+++ b/src/impl/track.cpp
@@ -52,6 +52,11 @@ Description::Media Track::description() const {
 	return mMediaDescription;
 }
 
+optional<Description::Media> Track::remoteDescription() const {
+	std::shared_lock lock(mMutex);
+	return mRemoteDescription;
+}
+
 void Track::setDescription(Description::Media desc) {
 	{
 		std::unique_lock lock(mMutex);
@@ -65,6 +70,37 @@ void Track::setDescription(Description::Media desc) {
 		handler->mediaChain(description());
 }
 
+bool Track::setRemoteDescription(Description::Media desc) {
+	std::unique_lock lock(mMutex);
+	if (desc.mid() != mMediaDescription.mid())
+		throw std::logic_error("Remote media description mid does not match track mid");
+
+	if (mRemoteDescription && string(*mRemoteDescription) == string(desc))
+		return false;
+
+	mRemoteDescription = std::move(desc);
+	return true;
+}
+
+void Track::setRemoteDescriptionCallback(std::function<void(Description::Media)> callback) {
+	std::lock_guard lock(mRemoteDescriptionCallbackMutex);
+	if (!mIsClosed)
+		remoteDescriptionCallback = std::move(callback);
+}
+
+void Track::triggerRemoteDescription(Description::Media desc) {
+	std::lock_guard lock(mRemoteDescriptionCallbackMutex);
+	if (mIsClosed)
+		return;
+
+	auto callback = remoteDescriptionCallback;
+	try {
+		callback(std::move(desc));
+	} catch (const std::exception &e) {
+		PLOG_WARNING << "Uncaught exception in callback: " << e.what();
+	}
+}
+
 void Track::close() {
 	PLOG_VERBOSE << "Closing Track";
 
@@ -72,6 +108,10 @@ void Track::close() {
 	{
 		triggerClosed();
 		setMediaHandler(nullptr);
+		{
+			std::lock_guard lock(mRemoteDescriptionCallbackMutex);
+			remoteDescriptionCallback = nullptr;
+		}
 		resetCallbacks();
 	}
 }

--- a/src/impl/track.hpp
+++ b/src/impl/track.hpp
@@ -50,7 +50,10 @@ public:
 	string mid() const;
 	Description::Direction direction() const;
 	Description::Media description() const;
+	optional<Description::Media> remoteDescription() const;
 	void setDescription(Description::Media desc);
+	bool setRemoteDescription(Description::Media desc);
+	void triggerRemoteDescription(Description::Media desc);
 
 	shared_ptr<MediaHandler> getMediaHandler();
 	void setMediaHandler(shared_ptr<MediaHandler> handler);
@@ -62,6 +65,7 @@ public:
 	bool transportSend(message_ptr message);
 
 	synchronized_callback<binary, FrameInfo> frameCallback;
+	synchronized_callback<Description::Media> remoteDescriptionCallback;
 
 private:
 	const weak_ptr<PeerConnection> mPeerConnection;
@@ -70,6 +74,7 @@ private:
 #endif
 
 	Description::Media mMediaDescription;
+	optional<Description::Media> mRemoteDescription;
 	shared_ptr<MediaHandler> mMediaHandler;
 
 	mutable std::shared_mutex mMutex;

--- a/src/impl/track.hpp
+++ b/src/impl/track.hpp
@@ -20,6 +20,7 @@
 #endif
 
 #include <atomic>
+#include <mutex>
 #include <shared_mutex>
 
 namespace rtc::impl {
@@ -50,7 +51,11 @@ public:
 	string mid() const;
 	Description::Direction direction() const;
 	Description::Media description() const;
+	optional<Description::Media> remoteDescription() const;
 	void setDescription(Description::Media desc);
+	bool setRemoteDescription(Description::Media desc);
+	void setRemoteDescriptionCallback(std::function<void(Description::Media)> callback);
+	void triggerRemoteDescription(Description::Media desc);
 
 	shared_ptr<MediaHandler> getMediaHandler();
 	void setMediaHandler(shared_ptr<MediaHandler> handler);
@@ -70,9 +75,12 @@ private:
 #endif
 
 	Description::Media mMediaDescription;
+	optional<Description::Media> mRemoteDescription;
 	shared_ptr<MediaHandler> mMediaHandler;
 
 	mutable std::shared_mutex mMutex;
+	std::recursive_mutex mRemoteDescriptionCallbackMutex;
+	synchronized_callback<Description::Media> remoteDescriptionCallback;
 
 	std::atomic<bool> mIsClosed = false;
 

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -256,9 +256,10 @@ void PeerConnection::setRemoteDescription(Description description) {
 
 	iceTransport->setRemoteDescription(description); // ICE transport might reject the description
 
-	impl()->processRemoteDescription(std::move(description));
+	auto trackUpdates = impl()->processRemoteDescription(std::move(description));
 	impl()->changeSignalingState(newSignalingState);
 	signalingLock.unlock();
+	impl()->dispatchTrackRemoteDescriptions(std::move(trackUpdates));
 
 	for (const auto &candidate : remoteCandidates)
 		addRemoteCandidate(candidate);

--- a/src/peerconnection.cpp
+++ b/src/peerconnection.cpp
@@ -255,9 +255,10 @@ void PeerConnection::setRemoteDescription(Description description) {
 
 	iceTransport->setRemoteDescription(description); // ICE transport might reject the description
 
-	impl()->processRemoteDescription(std::move(description));
+	auto trackUpdates = impl()->processRemoteDescription(std::move(description));
 	impl()->changeSignalingState(newSignalingState);
 	signalingLock.unlock();
+	impl()->dispatchTrackRemoteDescriptions(std::move(trackUpdates));
 
 	for (const auto &candidate : remoteCandidates)
 		addRemoteCandidate(candidate);

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -26,8 +26,16 @@ Description::Direction Track::direction() const { return impl()->direction(); }
 
 Description::Media Track::description() const { return impl()->description(); }
 
+optional<Description::Media> Track::remoteDescription() const {
+	return impl()->remoteDescription();
+}
+
 void Track::setDescription(Description::Media description) {
 	impl()->setDescription(std::move(description));
+}
+
+void Track::onRemoteDescription(std::function<void(Description::Media)> callback) {
+	impl()->remoteDescriptionCallback = std::move(callback);
 }
 
 void Track::close() { impl()->close(); }

--- a/src/track.cpp
+++ b/src/track.cpp
@@ -26,8 +26,16 @@ Description::Direction Track::direction() const { return impl()->direction(); }
 
 Description::Media Track::description() const { return impl()->description(); }
 
+optional<Description::Media> Track::remoteDescription() const {
+	return impl()->remoteDescription();
+}
+
 void Track::setDescription(Description::Media description) {
 	impl()->setDescription(std::move(description));
+}
+
+void Track::onRemoteDescription(std::function<void(Description::Media)> callback) {
+	impl()->setRemoteDescriptionCallback(std::move(callback));
 }
 
 void Track::close() { impl()->close(); }

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -28,6 +28,8 @@ typedef struct {
 	int pc;
 	int tr;
 	bool connected;
+	int remoteDescriptionChanges;
+	bool remoteDescriptionValid;
 } Peer;
 
 static Peer *peer1 = NULL;
@@ -75,6 +77,12 @@ static void RTC_API closedCallback(int id, void *ptr) {
 	printf("Track %d: Closed\n", peer == peer1 ? 1 : 2);
 }
 
+static void RTC_API trackDescriptionCallback(int tr, const char *sdp, void *ptr) {
+	Peer *peer = (Peer *)ptr;
+	++peer->remoteDescriptionChanges;
+	peer->remoteDescriptionValid = strstr(sdp, "a=mid:video") && strstr(sdp, "a=recvonly");
+}
+
 static void RTC_API trackCallback(int pc, int tr, void *ptr) {
 	Peer *peer = (Peer *)ptr;
 
@@ -85,6 +93,11 @@ static void RTC_API trackCallback(int pc, int tr, void *ptr) {
 	}
 
 	printf("Track %d: Received with media description: \n%s\n", peer == peer1 ? 1 : 2, buffer);
+	if (rtcGetTrackRemoteDescription(tr, buffer, 1024) < 0 ||
+	    !strstr(buffer, "a=sendonly")) {
+		fprintf(stderr, "rtcGetTrackRemoteDescription failed\n");
+		return;
+	}
 
 	char mid[256];
 	if (rtcGetTrackMid(tr, mid, 256) < 0 || strcmp(mid, "video") != 0) {
@@ -177,6 +190,7 @@ int test_capi_track_main() {
 	peer1->tr = rtcAddTrack(peer1->pc, mediaDescription);
 	rtcSetOpenCallback(peer1->tr, openCallback);
 	rtcSetClosedCallback(peer1->tr, closedCallback);
+	rtcSetTrackRemoteDescriptionCallback(peer1->tr, trackDescriptionCallback);
 
 	char mid[256];
 	if (rtcGetTrackMid(peer1->tr, mid, 256) < 0 || strcmp(mid, "video") != 0) {
@@ -220,6 +234,11 @@ int test_capi_track_main() {
 
 	if (!peer1->connected || !peer2->connected) {
 		fprintf(stderr, "Track is not connected\n");
+		goto error;
+	}
+
+	if (peer1->remoteDescriptionChanges != 1 || !peer1->remoteDescriptionValid) {
+		fprintf(stderr, "Track remote description callback failed\n");
 		goto error;
 	}
 

--- a/test/capi_track.cpp
+++ b/test/capi_track.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020 Paul-Louis Ageneau
+ * Copyright (c) 2026 mertushka
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -28,6 +29,8 @@ typedef struct {
 	int pc;
 	int tr;
 	bool connected;
+	int remoteDescriptionChanges;
+	bool remoteDescriptionValid;
 } Peer;
 
 static Peer *peer1 = NULL;
@@ -75,6 +78,12 @@ static void RTC_API closedCallback(int id, void *ptr) {
 	printf("Track %d: Closed\n", peer == peer1 ? 1 : 2);
 }
 
+static void RTC_API trackDescriptionCallback(int tr, const char *sdp, void *ptr) {
+	Peer *peer = (Peer *)ptr;
+	++peer->remoteDescriptionChanges;
+	peer->remoteDescriptionValid = strstr(sdp, "a=mid:video") && strstr(sdp, "a=recvonly");
+}
+
 static void RTC_API trackCallback(int pc, int tr, void *ptr) {
 	Peer *peer = (Peer *)ptr;
 
@@ -85,6 +94,11 @@ static void RTC_API trackCallback(int pc, int tr, void *ptr) {
 	}
 
 	printf("Track %d: Received with media description: \n%s\n", peer == peer1 ? 1 : 2, buffer);
+	if (rtcGetTrackRemoteDescription(tr, buffer, 1024) < 0 ||
+	    !strstr(buffer, "a=sendonly")) {
+		fprintf(stderr, "rtcGetTrackRemoteDescription failed\n");
+		return;
+	}
 
 	char mid[256];
 	if (rtcGetTrackMid(tr, mid, 256) < 0 || strcmp(mid, "video") != 0) {
@@ -177,6 +191,11 @@ int test_capi_track_main() {
 	peer1->tr = rtcAddTrack(peer1->pc, mediaDescription);
 	rtcSetOpenCallback(peer1->tr, openCallback);
 	rtcSetClosedCallback(peer1->tr, closedCallback);
+	rtcSetTrackRemoteDescriptionCallback(peer1->tr, trackDescriptionCallback);
+	if (rtcGetTrackRemoteDescription(peer1->tr, NULL, 0) != RTC_ERR_NOT_AVAIL) {
+		fprintf(stderr, "rtcGetTrackRemoteDescription is available before remote negotiation\n");
+		goto error;
+	}
 
 	char mid[256];
 	if (rtcGetTrackMid(peer1->tr, mid, 256) < 0 || strcmp(mid, "video") != 0) {
@@ -220,6 +239,11 @@ int test_capi_track_main() {
 
 	if (!peer1->connected || !peer2->connected) {
 		fprintf(stderr, "Track is not connected\n");
+		goto error;
+	}
+
+	if (peer1->remoteDescriptionChanges != 1 || !peer1->remoteDescriptionValid) {
+		fprintf(stderr, "Track remote description callback failed\n");
 		goto error;
 	}
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -30,6 +30,7 @@ TestResult test_simulcast_sdp_generation();
 TestResult test_simulcast_sdp_parsing();
 TestResult test_turn_connectivity();
 TestResult test_track();
+TestResult test_track_remote_description();
 TestResult test_video_layers_allocation();
 TestResult test_fir_sdp();
 TestResult test_fir_offer_yes_answer_yes();
@@ -95,6 +96,7 @@ static const vector<Test> tests = {
     Test("WebRTC simulcast SDP parsing", test_simulcast_sdp_parsing),
 #if RTC_ENABLE_MEDIA
     Test("WebRTC track", test_track),
+	Test("WebRTC track remote description", test_track_remote_description),
 	Test("WebRTC video layers allocation", test_video_layers_allocation),
     Test("RTX Description::addRtx", test_rtx_description_addrtx),
     Test("RTX Description::addRtx audio=false", test_rtx_description_addrtx_no_audio),

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -30,6 +30,7 @@ TestResult test_simulcast_sdp_generation();
 TestResult test_simulcast_sdp_parsing();
 TestResult test_turn_connectivity();
 TestResult test_track();
+TestResult test_track_remote_description();
 TestResult test_video_layers_allocation();
 TestResult test_fir_sdp();
 TestResult test_fir_offer_yes_answer_yes();
@@ -95,7 +96,8 @@ static const vector<Test> tests = {
     Test("WebRTC simulcast SDP parsing", test_simulcast_sdp_parsing),
 #if RTC_ENABLE_MEDIA
     Test("WebRTC track", test_track),
-	Test("WebRTC video layers allocation", test_video_layers_allocation),
+    Test("WebRTC track remote description", test_track_remote_description),
+    Test("WebRTC video layers allocation", test_video_layers_allocation),
     Test("RTX Description::addRtx", test_rtx_description_addrtx),
     Test("RTX Description::addRtx audio=false", test_rtx_description_addrtx_no_audio),
     Test("RTX negotiation fallback", test_rtx_attribute),

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -22,6 +22,122 @@ using namespace std;
 
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
 
+namespace {
+
+bool hasAttribute(const Description::Media &media, const string &attribute) {
+	for (const auto &candidate : media.attributes())
+		if (candidate == attribute)
+			return true;
+
+	return false;
+}
+
+} // namespace
+
+TestResult test_track_remote_description() {
+	Configuration config;
+	config.disableAutoNegotiation = true;
+	config.disableAutoGathering = true;
+
+	PeerConnection caller(config);
+	PeerConnection callee(config);
+
+	Description::Audio media("audio", Description::Direction::SendOnly);
+	media.addOpusCodec(111);
+	media.addSSRC(1001, "audio", "stream1", "track1");
+	auto callerTrack = caller.addTrack(media);
+
+	shared_ptr<Track> calleeTrack;
+	callee.onTrack([&](shared_ptr<Track> track) { calleeTrack = std::move(track); });
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+
+	if (!calleeTrack)
+		return TestResult(false, "Initial remote track was not created");
+
+	auto initialRemote = calleeTrack->remoteDescription();
+	if (!initialRemote)
+		return TestResult(false, "Initial remote media description is unavailable");
+
+	if (initialRemote->direction() != Description::Direction::SendOnly ||
+	    initialRemote->getSSRCs() != vector<uint32_t>{1001} ||
+	    !hasAttribute(*initialRemote, "msid:stream1 track1"))
+		return TestResult(false, "Initial remote media description is not authoritative");
+
+	if (calleeTrack->description().direction() != Description::Direction::RecvOnly ||
+	    !calleeTrack->description().getSSRCs().empty())
+		return TestResult(false, "Local and remote media descriptions are not distinct");
+
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	atomic<int> callbackCount = 0;
+	atomic<bool> callbackAfterCommit = false;
+	promise<Description::Media> updatePromise;
+	auto updateFuture = updatePromise.get_future();
+	promise<void> finalUpdatePromise;
+	auto finalUpdateFuture = finalUpdatePromise.get_future();
+	calleeTrack->onRemoteDescription([&](Description::Media description) {
+		callbackAfterCommit =
+		    callee.signalingState() == PeerConnection::SignalingState::HaveRemoteOffer &&
+		    callee.remoteDescription().has_value();
+		if (callbackCount.fetch_add(1) == 0)
+			updatePromise.set_value(description);
+		if (hasAttribute(description, "msid:stream4 track1")) {
+			calleeTrack->close();
+			finalUpdatePromise.set_value();
+		}
+	});
+
+	auto updated = callerTrack->description();
+	updated.setDirection(Description::Direction::SendRecv);
+	updated.removeAttribute("msid");
+	updated.removeSSRC(1001);
+	updated.addSSRC(1001, "audio", "stream2", "track1");
+	updated.addAttribute("msid:stream3 track1");
+	callerTrack->setDescription(std::move(updated));
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+
+	if (updateFuture.wait_for(2s) == future_status::timeout)
+		return TestResult(false, "Remote media description change was not reported");
+
+	auto remoteUpdate = updateFuture.get();
+	if (remoteUpdate.direction() != Description::Direction::SendRecv ||
+	    !hasAttribute(remoteUpdate, "msid:stream2 track1") ||
+	    !hasAttribute(remoteUpdate, "msid:stream3 track1"))
+		return TestResult(false, "Remote media description callback has stale state");
+
+	if (!callbackAfterCommit)
+		return TestResult(false, "Remote media description callback ran before peer commit");
+
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	auto finalUpdate = callerTrack->description();
+	finalUpdate.addAttribute("msid:stream4 track1");
+	callerTrack->setDescription(std::move(finalUpdate));
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+	if (finalUpdateFuture.wait_for(2s) == future_status::timeout)
+		return TestResult(false, "Final remote media description change was not reported");
+	if (callbackCount != 2)
+		return TestResult(false, "Identical remote media description triggered a duplicate callback");
+	if (!calleeTrack->isClosed())
+		return TestResult(false, "Track did not close from its remote description callback");
+
+	callee.close();
+	caller.close();
+	return TestResult(true);
+}
+
 TestResult test_track() {
 	InitLogger(LogLevel::Debug);
 

--- a/test/track.cpp
+++ b/test/track.cpp
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2019 Paul-Louis Ageneau
+ * Copyright (c) 2026 mertushka
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,6 +22,148 @@ using namespace rtc;
 using namespace std;
 
 template <class T> weak_ptr<T> make_weak_ptr(shared_ptr<T> ptr) { return ptr; }
+
+namespace {
+
+bool hasAttribute(const Description::Media &media, const string &attribute) {
+	for (const auto &candidate : media.attributes())
+		if (candidate == attribute)
+			return true;
+
+	return false;
+}
+
+} // namespace
+
+TestResult test_track_remote_description() {
+	Configuration config;
+	config.disableAutoNegotiation = true;
+	config.disableAutoGathering = true;
+
+	PeerConnection caller(config);
+	PeerConnection callee(config);
+	atomic<int> calleeLocalDescriptionCount = 0;
+	promise<void> processorBarrierPromise;
+	auto processorBarrierFuture = processorBarrierPromise.get_future();
+	callee.onLocalDescription([&](Description) {
+		if (calleeLocalDescriptionCount.fetch_add(1) + 1 == 5)
+			processorBarrierPromise.set_value();
+	});
+
+	Description::Audio media("audio", Description::Direction::SendOnly);
+	media.addOpusCodec(111);
+	media.addSSRC(1001, "audio", "stream1", "track1");
+	auto callerTrack = caller.addTrack(media);
+
+	shared_ptr<Track> calleeTrack;
+	callee.onTrack([&](shared_ptr<Track> track) { calleeTrack = std::move(track); });
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+
+	if (!calleeTrack)
+		return TestResult(false, "Initial remote track was not created");
+
+	auto initialRemote = calleeTrack->remoteDescription();
+	if (!initialRemote)
+		return TestResult(false, "Initial remote media description is unavailable");
+
+	if (initialRemote->direction() != Description::Direction::SendOnly ||
+	    initialRemote->getSSRCs() != vector<uint32_t>{1001} ||
+	    !hasAttribute(*initialRemote, "msid:stream1 track1"))
+		return TestResult(false, "Initial remote media description is not authoritative");
+
+	if (calleeTrack->description().direction() != Description::Direction::RecvOnly ||
+	    !calleeTrack->description().getSSRCs().empty())
+		return TestResult(false, "Local and remote media descriptions are not distinct");
+
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	atomic<int> callbackCount = 0;
+	atomic<bool> callbackAfterCommit = false;
+	promise<Description::Media> updatePromise;
+	auto updateFuture = updatePromise.get_future();
+	promise<void> finalUpdatePromise;
+	auto finalUpdateFuture = finalUpdatePromise.get_future();
+	calleeTrack->onRemoteDescription([&](Description::Media description) {
+		callbackAfterCommit =
+		    callee.signalingState() == PeerConnection::SignalingState::HaveRemoteOffer &&
+		    callee.remoteDescription().has_value();
+		if (callbackCount.fetch_add(1) == 0)
+			updatePromise.set_value(description);
+		if (hasAttribute(description, "msid:stream4 track1")) {
+			calleeTrack->close();
+			finalUpdatePromise.set_value();
+		}
+	});
+
+	auto updated = callerTrack->description();
+	updated.setDirection(Description::Direction::SendRecv);
+	updated.removeAttribute("msid");
+	updated.removeSSRC(1001);
+	updated.addSSRC(1001, "audio", "stream2", "track1");
+	updated.addAttribute("msid:stream3 track1");
+	callerTrack->setDescription(std::move(updated));
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+
+	if (updateFuture.wait_for(2s) == future_status::timeout)
+		return TestResult(false, "Remote media description change was not reported");
+
+	auto remoteUpdate = updateFuture.get();
+	if (remoteUpdate.direction() != Description::Direction::SendRecv ||
+	    !hasAttribute(remoteUpdate, "msid:stream2 track1") ||
+	    !hasAttribute(remoteUpdate, "msid:stream3 track1"))
+		return TestResult(false, "Remote media description callback has stale state");
+
+	if (!callbackAfterCommit)
+		return TestResult(false, "Remote media description callback ran before peer commit");
+
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	auto finalUpdate = callerTrack->description();
+	finalUpdate.addAttribute("msid:stream4 track1");
+	callerTrack->setDescription(std::move(finalUpdate));
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+	if (finalUpdateFuture.wait_for(2s) == future_status::timeout)
+		return TestResult(false, "Final remote media description change was not reported");
+	if (callbackCount != 2)
+		return TestResult(false, "Identical remote media description triggered a duplicate callback");
+	if (!calleeTrack->isClosed())
+		return TestResult(false, "Track did not close from its remote description callback");
+
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	auto postCloseUpdate = callerTrack->description();
+	postCloseUpdate.addAttribute("msid:stream5 track1");
+	callerTrack->setDescription(std::move(postCloseUpdate));
+	caller.setLocalDescription(Description::Type::Offer);
+	callee.setRemoteDescription(*caller.localDescription());
+	callee.setLocalDescription(Description::Type::Answer);
+	caller.setRemoteDescription(*callee.localDescription());
+
+	if (processorBarrierFuture.wait_for(2s) == future_status::timeout)
+		return TestResult(false, "Timed out draining remote description callbacks");
+	if (callbackCount != 2)
+		return TestResult(false, "Closed track received a late remote description callback");
+	auto remoteAfterClose = calleeTrack->remoteDescription();
+	if (!remoteAfterClose || !hasAttribute(*remoteAfterClose, "msid:stream5 track1"))
+		return TestResult(false, "Closed track remote description state is stale");
+
+	callee.close();
+	caller.close();
+	return TestResult(true);
+}
 
 TestResult test_track() {
 	InitLogger(LogLevel::Debug);


### PR DESCRIPTION
Add C++ and C APIs for reading a Track's applied remote media description and observing later changes on the same m-line.

Notifications run after remote description and signaling state commit, are serialized with `Track::close()`, and are suppressed if the Track closes before queued delivery. Existing `Track::description()` behavior remains unchanged.

Refs #1253.