### PR TITLE
Add typed media stream associations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(LIBDATACHANNEL_IMPL_HEADERS
 
 set(TESTS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/test/main.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/msid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/connectivity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/negotiated.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/test/reliability.cpp

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -237,6 +237,19 @@ public:
 		string description() const override;
 		Media reciprocate() const;
 
+		struct RTC_CPP_EXPORT MediaStreamAssociation {
+			string streamId;
+			optional<string> trackId;
+
+			bool operator==(const MediaStreamAssociation &other) const;
+			bool operator!=(const MediaStreamAssociation &other) const;
+		};
+
+		// Returns valid media-level RFC 8830 associations in SDP order.
+		std::vector<MediaStreamAssociation> mediaStreamAssociations() const;
+		// Replaces media-level RFC 8830 associations, preserving all other attributes.
+		void setMediaStreamAssociations(std::vector<MediaStreamAssociation> associations);
+
 		void addSSRC(uint32_t ssrc, optional<string> name, optional<string> msid = nullopt,
 		             optional<string> trackId = nullopt);
 		void removeSSRC(uint32_t ssrc);

--- a/include/rtc/description.hpp
+++ b/include/rtc/description.hpp
@@ -237,6 +237,19 @@ public:
 		string description() const override;
 		Media reciprocate() const;
 
+		struct RTC_CPP_EXPORT MediaStreamAssociation {
+			string streamId;
+			optional<string> trackId;
+
+			bool operator==(const MediaStreamAssociation &other) const;
+			bool operator!=(const MediaStreamAssociation &other) const;
+		};
+
+		// Returns syntactically valid media-level RFC 8830 associations in SDP order.
+		std::vector<MediaStreamAssociation> mediaStreamAssociations() const;
+		// Replaces associations, enforcing RFC 8830 token and same-track requirements.
+		void setMediaStreamAssociations(std::vector<MediaStreamAssociation> associations);
+
 		void addSSRC(uint32_t ssrc, optional<string> name, optional<string> msid = nullopt,
 		             optional<string> trackId = nullopt);
 		void removeSSRC(uint32_t ssrc);

--- a/src/description.cpp
+++ b/src/description.cpp
@@ -984,6 +984,98 @@ void Description::Entry::ExtMap::setDescription(string_view description) {
 	}
 }
 
+namespace {
+
+bool isValidMsidToken(string_view value) {
+	if (value.empty() || value.size() > 64)
+		return false;
+
+	return std::all_of(value.begin(), value.end(), [](char value) {
+		const auto c = static_cast<unsigned char>(value);
+		return c == 0x21 || (c >= 0x23 && c <= 0x27) || (c >= 0x2A && c <= 0x2B) ||
+		       (c >= 0x2D && c <= 0x2E) || (c >= 0x30 && c <= 0x39) ||
+		       (c >= 0x41 && c <= 0x5A) || (c >= 0x5E && c <= 0x7E);
+	});
+}
+
+optional<Description::Media::MediaStreamAssociation>
+parseMediaStreamAssociation(string_view value) {
+	const size_t separator = value.find(' ');
+	const string_view streamId = value.substr(0, separator);
+	if (!isValidMsidToken(streamId))
+		return nullopt;
+
+	optional<string> trackId;
+	if (separator != string_view::npos) {
+		const string_view appData = value.substr(separator + 1);
+		if (!isValidMsidToken(appData))
+			return nullopt;
+
+		trackId = string(appData);
+	}
+
+	return Description::Media::MediaStreamAssociation{string(streamId), std::move(trackId)};
+}
+
+} // namespace
+
+bool Description::Media::MediaStreamAssociation::operator==(
+    const MediaStreamAssociation &other) const {
+	return streamId == other.streamId && trackId == other.trackId;
+}
+
+bool Description::Media::MediaStreamAssociation::operator!=(
+    const MediaStreamAssociation &other) const {
+	return !(*this == other);
+}
+
+std::vector<Description::Media::MediaStreamAssociation>
+Description::Media::mediaStreamAssociations() const {
+	std::vector<MediaStreamAssociation> result;
+	for (const auto &attribute : mAttributes) {
+		const auto [key, value] = parse_pair(attribute);
+		if (key != "msid")
+			continue;
+
+		auto association = parseMediaStreamAssociation(value);
+		if (association && std::find(result.begin(), result.end(), *association) == result.end())
+			result.emplace_back(std::move(*association));
+	}
+
+	return result;
+}
+
+void Description::Media::setMediaStreamAssociations(
+    std::vector<MediaStreamAssociation> associations) {
+	std::vector<MediaStreamAssociation> normalized;
+	for (auto &association : associations) {
+		if (!isValidMsidToken(association.streamId) ||
+		    (association.trackId && !isValidMsidToken(*association.trackId)))
+			throw std::invalid_argument("Invalid media stream association");
+
+		if (!normalized.empty() && association.trackId != normalized.front().trackId)
+			throw std::invalid_argument("Media stream associations have different track IDs");
+
+		if (std::find(normalized.begin(), normalized.end(), association) == normalized.end())
+			normalized.emplace_back(std::move(association));
+	}
+
+	auto attributes = mAttributes;
+	attributes.erase(std::remove_if(attributes.begin(), attributes.end(), [](const auto &attribute) {
+		                 return parse_pair(attribute).first == "msid";
+	                 }),
+	                 attributes.end());
+
+	for (const auto &association : normalized) {
+		string attribute = "msid:" + association.streamId;
+		if (association.trackId)
+			attribute += " " + *association.trackId;
+		attributes.emplace_back(std::move(attribute));
+	}
+
+	mAttributes = std::move(attributes);
+}
+
 void Description::Media::addSSRC(uint32_t ssrc, optional<string> name, optional<string> msid,
                                  optional<string> trackId) {
 	if (name) {
@@ -996,7 +1088,7 @@ void Description::Media::addSSRC(uint32_t ssrc, optional<string> name, optional<
 	if (msid) {
 		mAttributes.emplace_back("ssrc:" + std::to_string(ssrc) + " msid:" + *msid + " " +
 		                         trackId.value_or(*msid));
-		mAttributes.emplace_back("msid:" + *msid + " " + trackId.value_or(*msid));
+		addAttribute("msid:" + *msid + " " + trackId.value_or(*msid));
 	}
 
 	mSsrcs.emplace_back(ssrc);
@@ -1217,6 +1309,7 @@ Description::Media Description::Media::reciprocate() const {
 
 	// Clear sent SSRCs
 	reciprocated.clearSSRCs();
+	reciprocated.setMediaStreamAssociations({});
 
 	// Remove rtcp-rsize attribute as Reduced-Size RTCP is not supported (see RFC 5506)
 	reciprocated.removeAttribute("rtcp-rsize");

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -23,6 +23,7 @@ using chrono::steady_clock;
 
 TestResult test_connectivity();
 TestResult test_connectivity_fail_on_wrong_fingerprint();
+TestResult test_media_stream_associations();
 TestResult test_pem();
 TestResult test_negotiated();
 TestResult test_reliability();
@@ -84,6 +85,7 @@ TestResult test_capi_cleanup() {
 
 static const vector<Test> tests = {
     // C++ API tests
+    Test("MSID media stream associations", test_media_stream_associations),
     Test("WebRTC connectivity", test_connectivity),
     Test("WebRTC broken fingerprint", test_connectivity_fail_on_wrong_fingerprint),
     Test("pem", test_pem),

--- a/test/msid.cpp
+++ b/test/msid.cpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2026
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "test.hpp"
+
+#include <rtc/description.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace rtc;
+using namespace std;
+
+namespace {
+
+using Association = Description::Media::MediaStreamAssociation;
+
+size_t countSubstring(const string &value, const string &needle) {
+	size_t count = 0;
+	size_t offset = 0;
+	while ((offset = value.find(needle, offset)) != string::npos) {
+		++count;
+		offset += needle.size();
+	}
+	return count;
+}
+
+bool hasSubstring(const string &value, const string &needle) {
+	return value.find(needle) != string::npos;
+}
+
+} // namespace
+
+TestResult test_media_stream_associations() {
+	try {
+		const string parsedSdp =
+		    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+		    "a=mid:audio\r\n"
+		    "a=sendrecv\r\n"
+		    "a=msid:stream1 track1\r\n"
+		    "a=msid:stream2 track1\r\n"
+		    "a=msid:- track1\r\n"
+		    "a=msid:stream2 track1\r\n"
+		    "a=msid:bad/id track1\r\n"
+		    "a=msid:stream3 track1 extra\r\n"
+		    "a=msid:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab track1\r\n"
+		    "a=msid:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abc track1\r\n"
+		    "a=x-preserved:value\r\n"
+		    "a=rtpmap:111 opus/48000/2\r\n";
+		Description::Media parsed(parsedSdp);
+		const vector<Association> expected = {
+		    {"stream1", "track1"},
+		    {"stream2", "track1"},
+		    {"-", "track1"},
+		    {"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab", "track1"},
+		};
+		if (parsed.mediaStreamAssociations() != expected)
+			return TestResult(false, "Valid parsed associations were not returned in SDP order");
+
+		Description::Media withoutAppData(
+		    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+		    "a=mid:audio\r\n"
+		    "a=msid:stream-only\r\n"
+		    "a=rtpmap:111 opus/48000/2\r\n");
+		const vector<Association> expectedWithoutAppData = {{"stream-only", nullopt}};
+		if (withoutAppData.mediaStreamAssociations() != expectedWithoutAppData)
+			return TestResult(false, "An MSID without appdata was not parsed");
+
+		Description::Audio generated("audio", Description::Direction::SendOnly);
+		generated.addOpusCodec(111);
+		generated.addAttribute("x-preserved:value");
+		generated.addAttribute("ssrc:1234 msid:legacy legacy-track");
+		generated.addAttribute("msid:old old-track");
+		generated.setMediaStreamAssociations({
+		    {"stream2", "track1"},
+		    {"stream1", "track1"},
+		    {"stream2", "track1"},
+		});
+
+		const vector<Association> replaced = {
+		    {"stream2", "track1"},
+		    {"stream1", "track1"},
+		};
+		if (generated.mediaStreamAssociations() != replaced)
+			return TestResult(false, "Association replacement did not preserve order and deduplicate");
+
+		const string generatedSdp = string(generated);
+		if (countSubstring(generatedSdp, "a=msid:") != 2 ||
+		    !hasSubstring(generatedSdp, "a=x-preserved:value") ||
+		    !hasSubstring(generatedSdp, "a=ssrc:1234 msid:legacy legacy-track"))
+			return TestResult(false, "Association replacement changed unrelated attributes");
+
+		Description::Media roundTrip(generatedSdp);
+		if (roundTrip.mediaStreamAssociations() != replaced)
+			return TestResult(false, "Associations did not survive SDP round trip");
+
+		const string beforeInvalidReplacement = string(generated);
+		auto rejectsWithoutMutation = [&](vector<Association> associations) {
+			try {
+				generated.setMediaStreamAssociations(std::move(associations));
+				return false;
+			} catch (const invalid_argument &) {
+				return string(generated) == beforeInvalidReplacement;
+			}
+		};
+
+		if (!rejectsWithoutMutation({{"bad/id", "track1"}}) ||
+		    !rejectsWithoutMutation({{"stream1", "bad track"}}) ||
+		    !rejectsWithoutMutation({{"stream1", "track1"}, {"stream2", nullopt}}) ||
+		    !rejectsWithoutMutation({{"stream1", "track1"}, {"stream2", "track2"}}))
+			return TestResult(false, "Invalid association replacement was accepted or mutated state");
+
+		generated.setMediaStreamAssociations({});
+		const string clearedSdp = string(generated);
+		if (!generated.mediaStreamAssociations().empty() ||
+		    hasSubstring(clearedSdp, "a=msid:") ||
+		    !hasSubstring(clearedSdp, "a=ssrc:1234 msid:legacy legacy-track"))
+			return TestResult(false, "Clearing associations removed unrelated SSRC attributes");
+
+		Description::Audio offer("audio", Description::Direction::SendOnly);
+		offer.addOpusCodec(111);
+		offer.addSSRC(1234, "audio", "remote-stream", "remote-track");
+		offer.addSSRC(5678, "audio", "remote-stream", "remote-track");
+		const vector<Association> offered = {{"remote-stream", "remote-track"}};
+		if (offer.mediaStreamAssociations() != offered ||
+		    countSubstring(string(offer), "a=msid:") != 1)
+			return TestResult(false, "SSRCs for one track generated duplicate associations");
+
+		auto answer = offer.reciprocate();
+		if (!answer.mediaStreamAssociations().empty() ||
+		    hasSubstring(string(answer), "a=msid:"))
+			return TestResult(false, "Reciprocation copied the offerer's stream associations");
+
+		return TestResult(true);
+	} catch (const exception &e) {
+		return TestResult(false, e.what());
+	}
+}

--- a/test/msid.cpp
+++ b/test/msid.cpp
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2026 mertushka
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "test.hpp"
+
+#include <rtc/description.hpp>
+#include <rtc/rtc.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace rtc;
+using namespace std;
+
+namespace {
+
+using Association = Description::Media::MediaStreamAssociation;
+
+size_t countSubstring(const string &value, const string &needle) {
+	size_t count = 0;
+	size_t offset = 0;
+	while ((offset = value.find(needle, offset)) != string::npos) {
+		++count;
+		offset += needle.size();
+	}
+	return count;
+}
+
+bool hasSubstring(const string &value, const string &needle) {
+	return value.find(needle) != string::npos;
+}
+
+bool testCapiRoundTrip() {
+	const char *sdp = "audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+	                  "a=mid:audio\r\n"
+	                  "a=sendonly\r\n"
+	                  "a=msid:stream1 track1\r\n"
+	                  "a=msid:stream2 track1\r\n"
+	                  "a=rtpmap:111 opus/48000/2\r\n";
+
+	rtcConfiguration config = {};
+	config.disableAutoNegotiation = true;
+	const int pc = rtcCreatePeerConnection(&config);
+	if (pc < 0)
+		return false;
+
+	const int track = rtcAddTrack(pc, sdp);
+	if (track < 0) {
+		rtcDeletePeerConnection(pc);
+		return false;
+	}
+
+	const int size = rtcGetTrackDescription(track, nullptr, 0);
+	vector<char> buffer(size > 0 ? size : 1);
+	const bool success = size > 0 && rtcGetTrackDescription(track, buffer.data(), size) == size &&
+	                     countSubstring(buffer.data(), "a=msid:") == 2 &&
+	                     hasSubstring(buffer.data(), "a=msid:stream1 track1") &&
+	                     hasSubstring(buffer.data(), "a=msid:stream2 track1");
+
+	rtcDeleteTrack(track);
+	rtcDeletePeerConnection(pc);
+	return success;
+}
+
+} // namespace
+
+TestResult test_media_stream_associations() {
+	try {
+		const string parsedSdp =
+		    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+		    "a=mid:audio\r\n"
+		    "a=sendrecv\r\n"
+		    "a=msid:stream1 track1\r\n"
+		    "a=msid:stream2 track1\r\n"
+		    "a=msid:- track1\r\n"
+		    "a=msid:stream2 track1\r\n"
+		    "a=msid:bad/id track1\r\n"
+		    "a=msid:stream3 track1 extra\r\n"
+		    "a=msid:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab track1\r\n"
+		    "a=msid:abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abc track1\r\n"
+		    "a=x-preserved:value\r\n"
+		    "a=rtpmap:111 opus/48000/2\r\n";
+		Description::Media parsed(parsedSdp);
+		const vector<Association> expected = {
+		    {"stream1", "track1"},
+		    {"stream2", "track1"},
+		    {"-", "track1"},
+		    {"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab", "track1"},
+		};
+		if (parsed.mediaStreamAssociations() != expected)
+			return TestResult(false, "Valid parsed associations were not returned in SDP order");
+
+		Description::Media withoutAppData(
+		    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+		    "a=mid:audio\r\n"
+		    "a=msid:stream-only\r\n"
+		    "a=rtpmap:111 opus/48000/2\r\n");
+		const vector<Association> expectedWithoutAppData = {{"stream-only", nullopt}};
+		if (withoutAppData.mediaStreamAssociations() != expectedWithoutAppData)
+			return TestResult(false, "An MSID without appdata was not parsed");
+
+		Description::Media inconsistentAppData(
+		    "m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n"
+		    "a=mid:audio\r\n"
+		    "a=msid:stream1 track1\r\n"
+		    "a=msid:stream2 track2\r\n"
+		    "a=rtpmap:111 opus/48000/2\r\n");
+		const vector<Association> parsedInconsistent = {
+		    {"stream1", "track1"},
+		    {"stream2", "track2"},
+		};
+		if (inconsistentAppData.mediaStreamAssociations() != parsedInconsistent)
+			return TestResult(false, "Syntactically valid remote associations were hidden");
+
+		Description::Audio generated("audio", Description::Direction::SendOnly);
+		generated.addOpusCodec(111);
+		generated.addAttribute("x-preserved:value");
+		generated.addAttribute("ssrc:1234 msid:legacy legacy-track");
+		generated.addAttribute("msid:old old-track");
+		generated.setMediaStreamAssociations({
+		    {"stream2", "track1"},
+		    {"stream1", "track1"},
+		    {"stream2", "track1"},
+		});
+
+		const vector<Association> replaced = {
+		    {"stream2", "track1"},
+		    {"stream1", "track1"},
+		};
+		if (generated.mediaStreamAssociations() != replaced)
+			return TestResult(false, "Association replacement did not preserve order and deduplicate");
+
+		const string generatedSdp = string(generated);
+		if (countSubstring(generatedSdp, "a=msid:") != 2 ||
+		    !hasSubstring(generatedSdp, "a=x-preserved:value") ||
+		    !hasSubstring(generatedSdp, "a=ssrc:1234 msid:legacy legacy-track"))
+			return TestResult(false, "Association replacement changed unrelated attributes");
+
+		Description::Media roundTrip(generatedSdp);
+		if (roundTrip.mediaStreamAssociations() != replaced)
+			return TestResult(false, "Associations did not survive SDP round trip");
+
+		const string beforeInvalidReplacement = string(generated);
+		auto rejectsWithoutMutation = [&](vector<Association> associations) {
+			try {
+				generated.setMediaStreamAssociations(std::move(associations));
+				return false;
+			} catch (const invalid_argument &) {
+				return string(generated) == beforeInvalidReplacement;
+			}
+		};
+
+		if (!rejectsWithoutMutation({{"bad/id", "track1"}}) ||
+		    !rejectsWithoutMutation({{"stream1", "bad track"}}) ||
+		    !rejectsWithoutMutation({{"stream1", "track1"}, {"stream2", nullopt}}) ||
+		    !rejectsWithoutMutation({{"stream1", "track1"}, {"stream2", "track2"}}))
+			return TestResult(false, "Invalid association replacement was accepted or mutated state");
+
+		generated.setMediaStreamAssociations({});
+		const string clearedSdp = string(generated);
+		if (!generated.mediaStreamAssociations().empty() ||
+		    hasSubstring(clearedSdp, "a=msid:") ||
+		    !hasSubstring(clearedSdp, "a=ssrc:1234 msid:legacy legacy-track"))
+			return TestResult(false, "Clearing associations removed unrelated SSRC attributes");
+
+		Description::Audio offer("audio", Description::Direction::SendOnly);
+		offer.addOpusCodec(111);
+		offer.addSSRC(1234, "audio", "remote-stream", "remote-track");
+		offer.addSSRC(5678, "audio", "remote-stream", "remote-track");
+		const vector<Association> offered = {{"remote-stream", "remote-track"}};
+		if (offer.mediaStreamAssociations() != offered ||
+		    countSubstring(string(offer), "a=msid:") != 1)
+			return TestResult(false, "SSRCs for one track generated duplicate associations");
+
+		auto answer = offer.reciprocate();
+		if (!answer.mediaStreamAssociations().empty() ||
+		    hasSubstring(string(answer), "a=msid:"))
+			return TestResult(false, "Reciprocation copied the offerer's stream associations");
+
+		if (!testCapiRoundTrip())
+			return TestResult(false, "C API did not preserve multiple media stream associations");
+
+		return TestResult(true);
+	} catch (const exception &e) {
+		return TestResult(false, e.what());
+	}
+}


### PR DESCRIPTION
Add a typed C++ API for RFC 8830 media-level `a=msid` associations.

The getter returns valid remote associations in SDP order. The setter validates and atomically replaces a same-track association set. The change also avoids duplicate associations from repeated SSRCs and prevents an answer from copying the offerer's `msid` values.

No C ABI is added; the existing raw-SDP C path remains available.

Specification: https://www.rfc-editor.org/rfc/rfc8830.html