### PR TITLE
Fix TLS server requesting client certificate with MbedTLS

### DIFF
--- a/src/impl/tlstransport.cpp
+++ b/src/impl/tlstransport.cpp
@@ -339,7 +339,7 @@ TlsTransport::TlsTransport(variant<shared_ptr<TcpTransport>, shared_ptr<HttpProx
 		    MBEDTLS_SSL_TRANSPORT_STREAM, MBEDTLS_SSL_PRESET_DEFAULT));
 
 		mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3); // TLS 1.2
-		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_OPTIONAL);
+		mbedtls_ssl_conf_authmode(&mConf, MBEDTLS_SSL_VERIFY_NONE);
 		mbedtls_ssl_conf_rng(&mConf, mbedtls_ctr_drbg_random, &mDrbg);
 
 		if (certificate) {


### PR DESCRIPTION
This PR changes authentication mode to `NONE` instead of `OPTIONAL` by default for MbedTLS to prevent the TLS server from requesting a client certificate. The mode is still set to `REQUIRED` in `VerifiedTlsTransport`. This change aligns the behavior on OpenSSL and GnuTLS.

Fixes connection issues with browsers: https://github.com/paullouisageneau/libdatachannel/issues/1606