### PR TITLE
Fix use-after-free in libnice component_io_cb on ICE stream removal

### DIFF
--- a/src/impl/icetransport.cpp
+++ b/src/impl/icetransport.cpp
@@ -667,28 +667,32 @@ IceTransport::~IceTransport() {
 	nice_agent_attach_recv(mNiceAgent.get(), mStreamId, 1, g_main_loop_get_context(MainLoop->get()),
 	                       NULL, NULL);
 
-	// Synchronize with the libnice main loop thread BEFORE freeing the
-	// stream's rx buffer (nice_agent_remove_stream below) or `this`. The
-	// detach above prevents new dispatches, but a callback (e.g.
-	// RecvCallback) may already be running on the main loop thread with
-	// `this` as userData and `buf` pointing into libnice's stream rx buffer.
-	// Post a barrier task to the main context and wait for it to run; GLib
-	// dispatches sources serially on that thread, so once our task runs no
-	// callback can still be using `this` or the rx buffer.
+	// Remove the stream on the main loop thread. The attach_recv above only
+	// clears the io callback: the socket sources stay attached, and libnice's
+	// component_io_cb dereferences its component before taking the agent lock,
+	// so removing the stream from here would free it under a live dispatch.
+	// GLib dispatches serially on that thread, so the removal cannot overlap
+	// one; waiting for it also ensures no callback still uses `this` or the
+	// stream's rx buffer.
 	{
-		std::promise<void> barrier;
-		auto future = barrier.get_future();
+		struct RemoveStreamData {
+			NiceAgent *agent;
+			guint streamId;
+			std::promise<void> done;
+		} data{mNiceAgent.get(), mStreamId, {}};
+		auto future = data.done.get_future();
 		g_main_context_invoke_full(
 		    g_main_loop_get_context(MainLoop->get()), G_PRIORITY_HIGH,
-		    [](gpointer data) -> gboolean {
-			    static_cast<std::promise<void> *>(data)->set_value();
+		    [](gpointer ptr) -> gboolean {
+			    auto *data = static_cast<RemoveStreamData *>(ptr);
+			    nice_agent_remove_stream(data->agent, data->streamId);
+			    data->done.set_value();
 			    return G_SOURCE_REMOVE;
 		    },
-		    &barrier, NULL);
+		    &data, NULL);
 		future.wait();
 	}
 
-	nice_agent_remove_stream(mNiceAgent.get(), mStreamId);
 	mNiceAgent.reset();
 
 	if (mTimeoutId)


### PR DESCRIPTION
_Code written by AI_

Moves `nice_agent_remove_stream` to the main loop thread. We had ASan issues on closure of ICE streams. 

AI describes the issue as follows: 

> ~IceTransport clears the io callback with nice_agent_attach_recv(..., NULL, NULL),  but that does not detach the component's socket sources, so libnice keeps  dispatching component_io_cb until the stream is actually removed. That callback dereferences its socket source's component before taking the agent lock, so removing the stream from the destroying thread can free the component under a live dispatch — the existing barrier only guarantees nothing is dispatching at that instant,  not that nothing starts right after.

To reproduce, build libnice and libdata with ASan and compile the following file against them:
[ice-teardown-uaf.cpp](https://github.com/user-attachments/files/30707021/ice-teardown-uaf.cpp).

To make this easier I made a script that does this in a docker container (ubuntu:25.10):
[run-ice-teardown-uaf.sh](https://github.com/user-attachments/files/30707280/run-ice-teardown-uaf.sh).
Run this in the root directory of the project:
```
bash ./run-ice-teardown-uaf.sh --iterations 5 ice-teardown-uaf.cpp
```

When run on the main branch this will result in a SEGV:
```
$ ./run-ice-teardown-uaf.sh --iterations 5 ./ice-teardown-uaf.cpp 
libdatachannel: /repos/libdatachannel
reproducer:     /repos/k2/worktrees/COR-912/clogics/contrib/repro/libnice-ice-teardown-uaf/ice-teardown-uaf.cpp
image:          ubuntu:25.10
libnice:        auto (whatever the image packages), built with ASan

=== Installing packages ===
Get:1 http://mirror.unix-solutions.be/ubuntu questing InRelease [275 kB]
Get:2 http://mirror.unix-solutions.be/ubuntu questing-updates InRelease [138 kB]
Get:3 http://mirror.unix-solutions.be/ubuntu questing-backports InRelease [134 kB]
Get:4 http://mirror.unix-solutions.be/ubuntu questing-security InRelease [137 kB]
Get:5 http://mirror.unix-solutions.be/ubuntu questing/restricted amd64 Packages [95.0 kB]
Get:6 http://mirror.unix-solutions.be/ubuntu questing/universe amd64 Packages [19.9 MB]
Get:7 http://mirror.unix-solutions.be/ubuntu questing/multiverse amd64 Packages [337 kB]
Get:8 http://mirror.unix-solutions.be/ubuntu questing/main amd64 Packages [1860 kB]
Get:9 http://mirror.unix-solutions.be/ubuntu questing-updates/restricted amd64 Packages [318 kB]
Get:10 http://mirror.unix-solutions.be/ubuntu questing-updates/multiverse amd64 Packages [22.9 kB]
Get:11 http://mirror.unix-solutions.be/ubuntu questing-updates/main amd64 Packages [491 kB]
Get:12 http://mirror.unix-solutions.be/ubuntu questing-updates/universe amd64 Packages [425 kB]
Get:13 http://mirror.unix-solutions.be/ubuntu questing-backports/universe amd64 Packages [3995 B]
Get:14 http://mirror.unix-solutions.be/ubuntu questing-security/main amd64 Packages [410 kB]
Get:15 http://mirror.unix-solutions.be/ubuntu questing-security/universe amd64 Packages [355 kB]
Get:16 http://mirror.unix-solutions.be/ubuntu questing-security/multiverse amd64 Packages [19.3 kB]
Get:17 http://mirror.unix-solutions.be/ubuntu questing-security/restricted amd64 Packages [293 kB]
Fetched 25.2 MB in 2s (13.6 MB/s)
Reading package lists...
libnice packaged here: 0.1.22-1 -> building 0.1.22 from source

=== Building libnice 0.1.22 with AddressSanitizer ===
installed: /opt/libnice-asan/lib/x86_64-linux-gnu/libnice.so

=== Building libdatachannel and the reproducer with AddressSanitizer ===
linked libnice: /opt/libnice-asan/lib/x86_64-linux-gnu/libnice.so

=== Running the reproducer (5 iteration(s)) ===
iteration 1/5
  [park] in libnice component_io_cb -- teardown will free under us
AddressSanitizer:DEADLYSIGNAL
=================================================================
==5080==ERROR: AddressSanitizer: SEGV on unknown address 0x0000ccccccdc (pc 0x7cbbbd00fabd bp 0x78bb9fb21240 sp 0x78bb9fb21200 T23)
==5080==The signal is caused by a READ memory access.
    #0 0x7cbbbd00fabd in g_pointer_bit_lock_and_get (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x23abd) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9)
    #1 0x7cbbbd02a258 in g_datalist_id_dup_data (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x3e258) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9)
    #2 0x7cbbbd168364 in g_weak_ref_get (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x22364) (BuildId: ebf1a8fa707f55348e9e3e665f8e6087788a387d)
    #3 0x7cbbbd809d9f in component_io_cb ../agent/agent.c:6179
    #4 0x7cbbbceb41fc  (/lib/x86_64-linux-gnu/libgio-2.0.so.0+0xa41fc) (BuildId: d7d7d731ea73ed6be0e2ad85cbd28f16669d3c26)
    #5 0x7cbbbd04cc7a  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x60c7a) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9)
    #6 0x7cbbbd04e2b6  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x622b6) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9)
    #7 0x7cbbbd04e656 in g_main_loop_run (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62656) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9)
    #8 0x7cbbbe584655 in void std::__invoke_impl<void, void (*)(_GMainLoop*), _GMainLoop*>(std::__invoke_other, void (*&&)(_GMainLoop*), _GMainLoop*&&) /usr/include/c++/15/bits/invoke.h:63
    #9 0x7cbbbe58459e in std::__invoke_result<void (*)(_GMainLoop*), _GMainLoop*>::type std::__invoke<void (*)(_GMainLoop*), _GMainLoop*>(void (*&&)(_GMainLoop*), _GMainLoop*&&) /usr/include/c++/15/bits/invoke.h:98
    #10 0x7cbbbe584514 in void std::thread::_Invoker<std::tuple<void (*)(_GMainLoop*), _GMainLoop*> >::_M_invoke<0ul, 1ul>(std::_Index_tuple<0ul, 1ul>) /usr/include/c++/15/bits/std_thread.h:303
    #11 0x7cbbbe584463 in std::thread::_Invoker<std::tuple<void (*)(_GMainLoop*), _GMainLoop*> >::operator()() /usr/include/c++/15/bits/std_thread.h:310
    #12 0x7cbbbe584425 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(_GMainLoop*), _GMainLoop*> > >::_M_run() /usr/include/c++/15/bits/std_thread.h:255
    #13 0x7cbbbde5c583  (/lib/x86_64-linux-gnu/libstdc++.so.6+0xf2583) (BuildId: 280f658f43aae7a7f92bba6ec4c5d96bc2b53a7a)
    #14 0x7cbbbea37802 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:239
    #15 0x7cbbbda8ed63  (/lib/x86_64-linux-gnu/libc.so.6+0xa3d63) (BuildId: a5b27db7ef3036c1dacf2e4ddc2e052767129439)
    #16 0x7cbbbdb22203 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x137203) (BuildId: a5b27db7ef3036c1dacf2e4ddc2e052767129439)

==5080==Register values:
rax = 0x00007cbbbd1425e0  rbx = 0x00000000ccccccdc  rcx = 0x0000000000000002  rdx = 0x0000000000000003  
rdi = 0x00000000ccccccdc  rsi = 0x0000000000000002  rbp = 0x000078bb9fb21240  rsp = 0x000078bb9fb21200  
 r8 = 0x00000000cccccccd   r9 = 0x0000000000000000  r10 = 0x000078bb9ea59ba0  r11 = 0x000078bb9fb236c0  
r12 = 0x000078bb9fb21250  r13 = 0x0000000000000000  r14 = 0x0000000000000004  r15 = 0x00007cbbbd1425ec  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x23abd) (BuildId: b66c779dcf0d629b28c9047d94e0f26f597f88c9) in g_pointer_bit_lock_and_get
Thread T23 created by T0 here:
    #0 0x7cbbbeaf16aa in pthread_create ../../../../src/libsanitizer/asan/asan_interceptors.cpp:250
    #1 0x7cbbbde5c670 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/lib/x86_64-linux-gnu/libstdc++.so.6+0xf2670) (BuildId: 280f658f43aae7a7f92bba6ec4c5d96bc2b53a7a)
    #2 0x7cbbbe57dba6 in std::thread::thread<void (&)(_GMainLoop*), _GMainLoop*, void>(void (&)(_GMainLoop*), _GMainLoop*&&) /usr/include/c++/15/bits/std_thread.h:175
    #3 0x7cbbbe572bdf in rtc::impl::IceTransport::MainLoopWrapper::MainLoopWrapper() /ldc/src/impl/icetransport.cpp:403
    #4 0x7cbbbe572df9 in rtc::impl::IceTransport::Init() /ldc/src/impl/icetransport.cpp:420
    #5 0x7cbbbe586f3a in rtc::impl::Init::doInit() /ldc/src/impl/init.cpp:155
    #6 0x7cbbbe587f3c in rtc::impl::Init::TokenPayload::TokenPayload(std::shared_future<void>*) /ldc/src/impl/init.cpp:38
    #7 0x7cbbbe58b2b4 in void std::_Construct<rtc::impl::Init::TokenPayload, std::shared_future<void>*>(rtc::impl::Init::TokenPayload*, std::shared_future<void>*&&) /usr/include/c++/15/bits/stl_construct.h:133
    #8 0x7cbbbe58ac39 in void std::allocator_traits<std::allocator<void> >::construct<rtc::impl::Init::TokenPayload, std::shared_future<void>*>(std::allocator<void>&, rtc::impl::Init::TokenPayload*, std::shared_future<void>*&&) /usr/include/c++/15/bits/alloc_traits.h:805
    #9 0x7cbbbe58ac39 in std::_Sp_counted_ptr_inplace<rtc::impl::Init::TokenPayload, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<std::shared_future<void>*>(std::allocator<void>, std::shared_future<void>*&&) /usr/include/c++/15/bits/shared_ptr_base.h:606
    #10 0x7cbbbe58a4b6 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<rtc::impl::Init::TokenPayload, std::allocator<void>, std::shared_future<void>*>(rtc::impl::Init::TokenPayload*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, std::shared_future<void>*&&) /usr/include/c++/15/bits/shared_ptr_base.h:969
    #11 0x7cbbbe589ffd in std::__shared_ptr<rtc::impl::Init::TokenPayload, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, std::shared_future<void>*>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::shared_future<void>*&&) /usr/include/c++/15/bits/shared_ptr_base.h:1719
    #12 0x7cbbbe589863 in std::shared_ptr<rtc::impl::Init::TokenPayload>::shared_ptr<std::allocator<void>, std::shared_future<void>*>(std::_Sp_alloc_shared_tag<std::allocator<void> >, std::shared_future<void>*&&) /usr/include/c++/15/bits/shared_ptr.h:463
    #13 0x7cbbbe58913c in std::shared_ptr<std::enable_if<!std::is_array<rtc::impl::Init::TokenPayload>::value, rtc::impl::Init::TokenPayload>::type> std::make_shared<rtc::impl::Init::TokenPayload, std::shared_future<void>*>(std::shared_future<void>*&&) /usr/include/c++/15/bits/shared_ptr.h:1008
    #14 0x7cbbbe585f27 in rtc::impl::Init::token() /ldc/src/impl/init.cpp:80
    #15 0x7cbbbe58bd50 in rtc::impl::PeerConnection::PeerConnection(rtc::Configuration) /ldc/src/impl/peerconnection.cpp:49
    #16 0x7cbbbe4bc169 in void std::_Construct<rtc::impl::PeerConnection, rtc::Configuration>(rtc::impl::PeerConnection*, rtc::Configuration&&) /usr/include/c++/15/bits/stl_construct.h:133
    #17 0x7cbbbe4bb26b in void std::allocator_traits<std::allocator<void> >::construct<rtc::impl::PeerConnection, rtc::Configuration>(std::allocator<void>&, rtc::impl::PeerConnection*, rtc::Configuration&&) /usr/include/c++/15/bits/alloc_traits.h:805
    #18 0x7cbbbe4bb26b in std::_Sp_counted_ptr_inplace<rtc::impl::PeerConnection, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<rtc::Configuration>(std::allocator<void>, rtc::Configuration&&) /usr/include/c++/15/bits/shared_ptr_base.h:606
    #19 0x7cbbbe4ba2a0 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<rtc::impl::PeerConnection, std::allocator<void>, rtc::Configuration>(rtc::impl::PeerConnection*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&&) /usr/include/c++/15/bits/shared_ptr_base.h:969
    #20 0x7cbbbe4b976d in std::__shared_ptr<rtc::impl::PeerConnection, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, rtc::Configuration>(std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&&) (/work/build/libdatachannel-build/libdatachannel.so.0.24+0x4c276d) (BuildId: 6f23ec411fbf99c454943ff41151d2e725b7fca1)
    #21 0x7cbbbe4b8b75 in std::shared_ptr<rtc::impl::PeerConnection>::shared_ptr<std::allocator<void>, rtc::Configuration>(std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&&) (/work/build/libdatachannel-build/libdatachannel.so.0.24+0x4c1b75) (BuildId: 6f23ec411fbf99c454943ff41151d2e725b7fca1)
    #22 0x7cbbbe4b666f in std::shared_ptr<std::enable_if<!std::is_array<rtc::impl::PeerConnection>::value, rtc::impl::PeerConnection>::type> std::make_shared<rtc::impl::PeerConnection, rtc::Configuration>(rtc::Configuration&&) (/work/build/libdatachannel-build/libdatachannel.so.0.24+0x4bf66f) (BuildId: 6f23ec411fbf99c454943ff41151d2e725b7fca1)
    #23 0x7cbbbe4b2e12 in rtc::CheshireCat<rtc::impl::PeerConnection>::CheshireCat<rtc::Configuration>(rtc::Configuration) (/work/build/libdatachannel-build/libdatachannel.so.0.24+0x4bbe12) (BuildId: 6f23ec411fbf99c454943ff41151d2e725b7fca1)
    #24 0x7cbbbe4a75f6 in rtc::PeerConnection::PeerConnection(rtc::Configuration) /ldc/src/peerconnection.cpp:38
    #25 0x646f6fca41de in void std::_Construct<rtc::PeerConnection, rtc::Configuration&>(rtc::PeerConnection*, rtc::Configuration&) /usr/include/c++/15/bits/stl_construct.h:133
    #26 0x646f6fca15e2 in void std::allocator_traits<std::allocator<void> >::construct<rtc::PeerConnection, rtc::Configuration&>(std::allocator<void>&, rtc::PeerConnection*, rtc::Configuration&) /usr/include/c++/15/bits/alloc_traits.h:805
    #27 0x646f6fca15e2 in std::_Sp_counted_ptr_inplace<rtc::PeerConnection, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<rtc::Configuration&>(std::allocator<void>, rtc::Configuration&) /usr/include/c++/15/bits/shared_ptr_base.h:606
    #28 0x646f6fc9fc5d in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<rtc::PeerConnection, std::allocator<void>, rtc::Configuration&>(rtc::PeerConnection*&, std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&) /usr/include/c++/15/bits/shared_ptr_base.h:969
    #29 0x646f6fc9eb9a in std::__shared_ptr<rtc::PeerConnection, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<void>, rtc::Configuration&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&) /usr/include/c++/15/bits/shared_ptr_base.h:1719
    #30 0x646f6fc9b2f6 in std::shared_ptr<rtc::PeerConnection>::shared_ptr<std::allocator<void>, rtc::Configuration&>(std::_Sp_alloc_shared_tag<std::allocator<void> >, rtc::Configuration&) /usr/include/c++/15/bits/shared_ptr.h:463
    #31 0x646f6fc971c8 in std::shared_ptr<std::enable_if<!std::is_array<rtc::PeerConnection>::value, rtc::PeerConnection>::type> std::make_shared<rtc::PeerConnection, rtc::Configuration&>(rtc::Configuration&) /usr/include/c++/15/bits/shared_ptr.h:1008
    #32 0x646f6fc889bc in run_one_cycle /work/build//repro.cpp:233
    #33 0x646f6fc89dc3 in main /work/build//repro.cpp:314
    #34 0x7cbbbda15574  (/lib/x86_64-linux-gnu/libc.so.6+0x2a574) (BuildId: a5b27db7ef3036c1dacf2e4ddc2e052767129439)
    #35 0x7cbbbda15627 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a627) (BuildId: a5b27db7ef3036c1dacf2e4ddc2e052767129439)
    #36 0x646f6fc85b64 in _start (/work/build/ice-teardown-uaf+0x1cb64) (BuildId: 52a2ebff8648bb2837daa9b1169514b1f7f9d884)

==5080==ABORTING

RESULT: AddressSanitizer reported a problem -- issue REPRODUCED
```

On the branch with the fix this does not happen.

