### PR TITLE
Fix ICE options separator in SDP description

### DIFF
--- a/src/description.cpp
+++ b/src/description.cpp
@@ -157,7 +157,7 @@ Description::Description(const string &sdp, Type type, Role role)
 				// RFC 8839: The "ice-options" attribute is a session-level and media-level
 				// attribute.
 				if (mIceOptions.empty())
-					mIceOptions = utils::explode(string(value), ',');
+					mIceOptions = utils::explode(string(value), ' ');
 			} else if (key == "candidate") {
 				addCandidate(Candidate(attr, bundleMid()));
 			} else if (key == "end-of-candidates") {
@@ -318,7 +318,7 @@ string Description::generateSdp(string_view eol) const {
 	// Session-level attributes
 	sdp << "a=msid-semantic:WMS *" << eol;
 	if (!mIceOptions.empty())
-		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
+		sdp << "a=ice-options:" << utils::implode(mIceOptions, ' ') << eol;
 	if (mFingerprint)
 		sdp << "a=fingerprint:"
 		    << CertificateFingerprint::AlgorithmIdentifier(mFingerprint->algorithm) << " "
@@ -381,7 +381,7 @@ string Description::generateApplicationSdp(string_view eol) const {
 	// Session-level attributes
 	sdp << "a=msid-semantic:WMS *" << eol;
 	if (!mIceOptions.empty())
-		sdp << "a=ice-options:" << utils::implode(mIceOptions, ',') << eol;
+		sdp << "a=ice-options:" << utils::implode(mIceOptions, ' ') << eol;
 
 	for (const auto &attr : mAttributes)
 		sdp << "a=" << attr << eol;


### PR DESCRIPTION
This PR fixes the `ice-options` separator in SDP description, which should be a space (see [RFC8839, section 5.6](https://datatracker.ietf.org/doc/html/rfc8839#name-ice-options-attribute)).

Fixes https://github.com/paullouisageneau/libdatachannel/issues/1623